### PR TITLE
Feature/support dot active file

### DIFF
--- a/src/main/java/com/tabnine/binary/fetch/BootstrapperSupport.java
+++ b/src/main/java/com/tabnine/binary/fetch/BootstrapperSupport.java
@@ -31,13 +31,17 @@ public class BootstrapperSupport {
 
     private static Optional<BinaryVersion> locateLocalBootstrapSupportedVersion(LocalBinaryVersions localBinaryVersions) {
         return minimalBootstrappedVersion().flatMap(
-                version ->
-                        localBinaryVersions
+                version -> {
+                    Optional<BinaryVersion> activeVersion = localBinaryVersions.activeVersion();
+                    if (activeVersion.isPresent()) return activeVersion;
+
+                    return localBinaryVersions
                                 .listExisting()
                                 .stream()
                                 .filter(v -> SemVer.parseFromText(v.getVersion()) != null)
                                 .filter(v -> SemVer.parseFromText(v.getVersion()).compareTo(version) >= 0)
-                                .findFirst());
+                                .findFirst();
+                });
     }
 
     private static Optional<BinaryVersion> downloadRemoteVersion(BinaryRemoteSource binaryRemoteSource, BundleDownloader bundleDownloader) {

--- a/src/main/java/com/tabnine/binary/fetch/BootstrapperSupport.java
+++ b/src/main/java/com/tabnine/binary/fetch/BootstrapperSupport.java
@@ -14,7 +14,7 @@ public class BootstrapperSupport {
         return localBootstrapVersion.isPresent() ? localBootstrapVersion : downloadRemoteVersion(binaryRemoteSource, bundleDownloader);
     }
 
-    private static final String BOOTSTRAPPED_VERSION_KEY = "bootstrapped version";
+    public static final String BOOTSTRAPPED_VERSION_KEY = "bootstrapped version";
 
     private static Preferences getPrefs() {
         return Preferences.userNodeForPackage(BootstrapperSupport.class);

--- a/src/main/java/com/tabnine/binary/fetch/LocalBinaryVersions.java
+++ b/src/main/java/com/tabnine/binary/fetch/LocalBinaryVersions.java
@@ -1,13 +1,14 @@
 package com.tabnine.binary.fetch;
 
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.text.SemVer;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static com.tabnine.general.StaticConfig.getBaseDirectory;
@@ -29,5 +30,32 @@ public class LocalBinaryVersions {
                 .map(SemVer::toString)
                 .map(BinaryVersion::new)
                 .filter(version -> binaryValidator.isWorking(version.getVersionFullPath())).collect(toList());
+    }
+
+    public Optional<BinaryVersion> activeVersion() {
+        Path activeFile = getBaseDirectory().resolve(".active");
+
+        if (!activeFile.toFile().exists()) { return Optional.empty(); }
+
+        List<String> lines;
+        try {
+            lines = Files.readAllLines(activeFile);
+        } catch (IOException e) {
+            Logger.getInstance(getClass()).warn("Failed to read .active file", e);
+            lines = new ArrayList<String>();
+        }
+
+        if (lines.size() == 0) { return Optional.empty(); }
+
+        String version = lines.get(0);
+
+        BinaryVersion binaryVersion = new BinaryVersion(version);
+
+        if (!binaryValidator.isWorking(binaryVersion.getVersionFullPath())) {
+            Logger.getInstance(getClass()).warn("Version in .active file is not working");
+            return Optional.empty();
+        }
+
+        return Optional.of(binaryVersion);
     }
 }

--- a/src/main/java/com/tabnine/binary/fetch/LocalBinaryVersions.java
+++ b/src/main/java/com/tabnine/binary/fetch/LocalBinaryVersions.java
@@ -34,17 +34,7 @@ public class LocalBinaryVersions {
     }
 
     public Optional<BinaryVersion> activeVersion() {
-        Path activeFile = getActiveVersionPath();
-
-        if (!activeFile.toFile().exists()) { return Optional.empty(); }
-
-        List<String> lines;
-        try {
-            lines = Files.readAllLines(activeFile);
-        } catch (IOException e) {
-            Logger.getInstance(getClass()).warn("Failed to read .active file", e);
-            lines = new ArrayList<String>();
-        }
+        List<String> lines = readActiveFile();
 
         if (lines.size() == 0) { return Optional.empty(); }
 
@@ -58,5 +48,21 @@ public class LocalBinaryVersions {
         }
 
         return Optional.of(binaryVersion);
+    }
+
+    @NotNull
+    private List<String> readActiveFile() {
+        Path activeFile = getActiveVersionPath();
+
+        List<String> lines = new ArrayList<>();
+        if (activeFile.toFile().exists()) {
+            try {
+                lines = Files.readAllLines(activeFile);
+            } catch (IOException e) {
+                Logger.getInstance(getClass()).warn("Failed to read .active file", e);
+            }
+        }
+
+        return lines;
     }
 }

--- a/src/main/java/com/tabnine/binary/fetch/LocalBinaryVersions.java
+++ b/src/main/java/com/tabnine/binary/fetch/LocalBinaryVersions.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Stream;
 
+import static com.tabnine.general.StaticConfig.getActiveVersionPath;
 import static com.tabnine.general.StaticConfig.getBaseDirectory;
 import static java.util.stream.Collectors.toList;
 
@@ -33,7 +34,7 @@ public class LocalBinaryVersions {
     }
 
     public Optional<BinaryVersion> activeVersion() {
-        Path activeFile = getBaseDirectory().resolve(".active");
+        Path activeFile = getActiveVersionPath();
 
         if (!activeFile.toFile().exists()) { return Optional.empty(); }
 

--- a/src/main/java/com/tabnine/general/StaticConfig.java
+++ b/src/main/java/com/tabnine/general/StaticConfig.java
@@ -115,6 +115,10 @@ public class StaticConfig {
         return Paths.get(System.getProperty(USER_HOME_PATH_PROPERTY), TABNINE_FOLDER_NAME);
     }
 
+    public static Path getActiveVersionPath() {
+        return getBaseDirectory().resolve(".active");
+    }
+
     private static String getExeName() {
         return SystemInfo.isWindows ? "TabNine.exe" : "TabNine";
     }

--- a/src/test/java/com/tabnine/binary/BootstrapperSupportTests.java
+++ b/src/test/java/com/tabnine/binary/BootstrapperSupportTests.java
@@ -45,6 +45,7 @@ public class BootstrapperSupportTests {
         when(bundleDownloader.downloadAndExtractBundle("9.9.9")).thenReturn(Optional.of(new BinaryVersion("9.9.9")));
         assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("9.9.9")));
     }
+
     @Test
     public void testWhenBootstrapperVersionExistsItWillUseIt() throws Exception {
         Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
@@ -54,6 +55,15 @@ public class BootstrapperSupportTests {
         when(localBinaryVersions.listExisting()).thenReturn(binaryVersions);
         assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("8.8.8")));
     }
+
+    @Test
+    public void testWhenActiveVersionExistsItWillUseIt() throws Exception {
+        Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
+        preferences.put("bootstrapped version","8.8.8");
+        when(localBinaryVersions.activeVersion()).thenReturn(Optional.of(new BinaryVersion("7.8.9")));
+        assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("7.8.9")));
+    }
+
     @Test
     public void testWhenGreaterVersionThanPreferedBootstrapperVersionExistsItWillBeUsedInstead() throws Exception {
         Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);

--- a/src/test/java/com/tabnine/binary/BootstrapperSupportTests.java
+++ b/src/test/java/com/tabnine/binary/BootstrapperSupportTests.java
@@ -49,7 +49,7 @@ public class BootstrapperSupportTests {
     @Test
     public void testWhenBootstrapperVersionExistsItWillUseIt() throws Exception {
         Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
-        preferences.put("bootstrapped version","8.8.8");
+        preferences.put(BootstrapperSupport.BOOTSTRAPPED_VERSION_KEY, "8.8.8");
         List<BinaryVersion> binaryVersions = aVersions();
         binaryVersions.add(new BinaryVersion("8.8.8"));
         when(localBinaryVersions.listExisting()).thenReturn(binaryVersions);
@@ -59,7 +59,7 @@ public class BootstrapperSupportTests {
     @Test
     public void testWhenActiveVersionExistsItWillUseIt() throws Exception {
         Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
-        preferences.put("bootstrapped version","8.8.8");
+        preferences.put(BootstrapperSupport.BOOTSTRAPPED_VERSION_KEY,"8.8.8");
         when(localBinaryVersions.activeVersion()).thenReturn(Optional.of(new BinaryVersion("7.8.9")));
         assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("7.8.9")));
     }
@@ -67,7 +67,7 @@ public class BootstrapperSupportTests {
     @Test
     public void testWhenGreaterVersionThanPreferedBootstrapperVersionExistsItWillBeUsedInstead() throws Exception {
         Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
-        preferences.put("bootstrapped version","5.5.5");
+        preferences.put(BootstrapperSupport.BOOTSTRAPPED_VERSION_KEY,"5.5.5");
         List<BinaryVersion> binaryVersions = aVersions();
         binaryVersions.add(new BinaryVersion("55.55.55"));
         when(localBinaryVersions.listExisting()).thenReturn(binaryVersions);
@@ -76,7 +76,7 @@ public class BootstrapperSupportTests {
     @Test
     public void testWhenBootstrappedVersionDidNotExistLocallyTheBootstrapperWillDownloadAgain() throws Exception {
         Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
-        preferences.put("bootstrapped version","6.6.6");
+        preferences.put(BootstrapperSupport.BOOTSTRAPPED_VERSION_KEY,"6.6.6");
         when(localBinaryVersions.listExisting()).thenReturn(aVersions());
         when(binaryRemoteSource.fetchPreferredVersion(StaticConfig.getTabNineBundleVersionUrl())).thenReturn(Optional.of("66.66.66"));
         when(bundleDownloader.downloadAndExtractBundle("66.66.66")).thenReturn(Optional.of(new BinaryVersion("66.66.66")));


### PR DESCRIPTION
The bootstrapper adds a .active file in the ~/.tabnine folder, to signal the plugin which version to run.

This is the plugin side