### PR TITLE
Init users of BinaryRun on appStarting to prevent error: "Should be c…

### DIFF
--- a/src/main/java/com/tabnine/Initializer.java
+++ b/src/main/java/com/tabnine/Initializer.java
@@ -16,9 +16,9 @@ import org.jetbrains.annotations.Nullable;
 import static com.tabnine.general.DependencyContainer.*;
 
 public class Initializer implements ApplicationLoadListener, AppLifecycleListener {
-    private final TabNineDisablePluginListener listener = singletonOfTabNineDisablePluginListener();
-    private final BinaryNotificationsLifecycle binaryNotificationsLifecycle = instanceOfBinaryNotifications();
-    private final BinaryPromotionStatusBarLifecycle binaryPromotionStatusBarLifecycle = instanceOfBinaryPromotionStatusBar();
+    private TabNineDisablePluginListener listener;
+    private BinaryNotificationsLifecycle binaryNotificationsLifecycle;
+    private BinaryPromotionStatusBarLifecycle binaryPromotionStatusBarLifecycle;
 
     @Override
     public void beforeApplicationLoaded(@NotNull Application application, @NotNull String configPath) {
@@ -29,6 +29,9 @@ public class Initializer implements ApplicationLoadListener, AppLifecycleListene
 
     @Override
     public void appStarting(@Nullable Project projectFromCommandLine) {
+        listener = singletonOfTabNineDisablePluginListener();
+        binaryNotificationsLifecycle = instanceOfBinaryNotifications();
+        binaryPromotionStatusBarLifecycle = instanceOfBinaryPromotionStatusBar();
         PluginManagerCore.addDisablePluginListener(listener::onDisable);
         PluginInstaller.addStateListener(instanceOfTabNinePluginStateListener());
         binaryNotificationsLifecycle.poll();


### PR DESCRIPTION
…alled at least in the state CONFIGURATION_STORE_INITIALIZED, the current state is: COMPONENTS_REGISTERED" since BinaryRun calls ApplicationInfo.getInstance().