### PR TITLE
Use info messages background color for 'limit exceeded' inlay hover.

### DIFF
--- a/src/main/java/com/tabnine/intellij/completions/InlayHoverMouseMotionListener.java
+++ b/src/main/java/com/tabnine/intellij/completions/InlayHoverMouseMotionListener.java
@@ -7,10 +7,10 @@ import com.intellij.openapi.editor.Inlay;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
 import com.intellij.openapi.editor.event.EditorMouseEvent;
 import com.intellij.openapi.editor.event.EditorMouseMotionListener;
+import com.intellij.openapi.ui.MessageType;
 import com.intellij.openapi.ui.popup.Balloon;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
 import com.intellij.openapi.util.Disposer;
-import com.intellij.ui.JBColor;
 import com.intellij.ui.awt.RelativePoint;
 import com.intellij.util.DocumentUtil;
 import com.tabnine.binary.BinaryRequestFacade;
@@ -94,7 +94,8 @@ public class InlayHoverMouseMotionListener implements EditorMouseMotionListener 
         return JBPopupFactory.getInstance().createHtmlTextBalloonBuilder(
                 buildHtmlContent(hoverBinaryResponse.getMessage()),
                 null,
-                JBColor.LIGHT_GRAY,
+                null,
+                MessageType.INFO.getPopupBackground(),
                 new HyperlinkListener() {
                     @Override
                     public void hyperlinkUpdate(HyperlinkEvent event) {

--- a/src/main/java/com/tabnine/intellij/completions/LimitExceededLookupElement.java
+++ b/src/main/java/com/tabnine/intellij/completions/LimitExceededLookupElement.java
@@ -72,14 +72,6 @@ public class LimitExceededLookupElement extends InsertNothingLookupElement {
             });
     }
 
-    /*
-    This method is a bit of a mystery. For some reason, reselecting a completion, when
-    the inlay is already displayed (e.g. by pressing ctrl+space) adds another inlay while
-    the previous one is not removed by the document listener. This doesn't happen in debug mode.
-    The following method seems to solve the issue but, in debug mode, when the inlay is added
-    after the last char in the doc, it doesn't (since inlayStartOffset and inlayEndOffset are
-    the same).
-     */
     private boolean isInlayAlreadyDisplayed(Editor editor, int inlayStartOffset, int currentLineNumber) {
         //search for our inlay between the current line end offset and the next line start offset.
         final int inlayEndOffset;


### PR DESCRIPTION
Bug fix: Don't add the 'limit exceeded' inlay if one is already displayed at the current line.