### PR TITLE
Send the message id in 'Status Bar Promotion Shown' requests.

### DIFF
--- a/src/main/java/com/tabnine/binary/requests/notifications/BinaryNotification.kt
+++ b/src/main/java/com/tabnine/binary/requests/notifications/BinaryNotification.kt
@@ -7,5 +7,6 @@ data class BinaryNotification(
     var message: String? = null,
     var options: List<NotificationOptions>? = null,
     @SerializedName("notification_type")
-    var notificationType: String?
+    var notificationType: String?,
+    val state: Object?,
 )

--- a/src/main/java/com/tabnine/binary/requests/notifications/shown/NotificationShownRequest.kt
+++ b/src/main/java/com/tabnine/binary/requests/notifications/shown/NotificationShownRequest.kt
@@ -1,10 +1,17 @@
 package com.tabnine.binary.requests.notifications.shown
 
+import com.google.gson.annotations.SerializedName
 import com.tabnine.binary.BinaryRequest
 import com.tabnine.binary.requests.selection.SetStateBinaryResponse
 import com.tabnine.general.StaticConfig
 
-data class NotificationShownRequest(var text: String?) : BinaryRequest<SetStateBinaryResponse> {
+data class NotificationShownRequest(
+    var id: String?,
+    var text: String?,
+    @SerializedName("notification_type")
+    val notificationType: String?,
+    val state: Object?,
+) : BinaryRequest<SetStateBinaryResponse> {
     override fun response(): Class<SetStateBinaryResponse> {
         return SetStateBinaryResponse::class.java
     }

--- a/src/main/java/com/tabnine/binary/requests/statusBar/StatusBarPromotionBinaryResponse.kt
+++ b/src/main/java/com/tabnine/binary/requests/statusBar/StatusBarPromotionBinaryResponse.kt
@@ -7,5 +7,6 @@ data class StatusBarPromotionBinaryResponse(
     var id: String?,
     var message: String?,
     var actions: List<String>?,
-    @SerializedName("notification_type") var notificationType: String?
+    @SerializedName("notification_type") var notificationType: String?,
+    val state: Object?,
 ) : BinaryResponse

--- a/src/main/java/com/tabnine/binary/requests/statusBar/StatusBarPromotionShownRequest.kt
+++ b/src/main/java/com/tabnine/binary/requests/statusBar/StatusBarPromotionShownRequest.kt
@@ -1,10 +1,17 @@
 package com.tabnine.binary.requests.statusBar
 
+import com.google.gson.annotations.SerializedName
 import com.tabnine.binary.BinaryRequest
 import com.tabnine.binary.requests.selection.SetStateBinaryResponse
 import com.tabnine.general.StaticConfig
 
-class StatusBarPromotionShownRequest(private val text: String) : BinaryRequest<SetStateBinaryResponse> {
+class StatusBarPromotionShownRequest(
+    var id: String?,
+    private val text: String,
+    @SerializedName("notification_type")
+    val notificationType: String?,
+    val state: Object?,
+) : BinaryRequest<SetStateBinaryResponse> {
     override fun response(): Class<SetStateBinaryResponse> {
         return SetStateBinaryResponse::class.java
     }

--- a/src/main/java/com/tabnine/general/DependencyContainer.java
+++ b/src/main/java/com/tabnine/general/DependencyContainer.java
@@ -9,6 +9,7 @@ import com.tabnine.binary.fetch.*;
 import com.tabnine.lifecycle.*;
 import com.tabnine.prediction.CompletionFacade;
 import com.tabnine.selections.TabNineLookupListener;
+import com.tabnine.statusBar.StatusBarUpdater;
 import org.jetbrains.annotations.NotNull;
 
 public class DependencyContainer {
@@ -28,7 +29,8 @@ public class DependencyContainer {
     }
 
     public static synchronized TabNineLookupListener instanceOfTabNineLookupListener() {
-        return new TabNineLookupListener(instanceOfBinaryRequestFacade());
+        final BinaryRequestFacade binaryRequestFacade = instanceOfBinaryRequestFacade();
+        return new TabNineLookupListener(binaryRequestFacade, new StatusBarUpdater(binaryRequestFacade));
     }
 
     public static BinaryRequestFacade instanceOfBinaryRequestFacade() {
@@ -54,7 +56,7 @@ public class DependencyContainer {
     }
 
     public static BinaryPromotionStatusBarLifecycle instanceOfBinaryPromotionStatusBar() {
-        return new BinaryPromotionStatusBarLifecycle(instanceOfBinaryRequestFacade());
+        return new BinaryPromotionStatusBarLifecycle(new StatusBarUpdater(instanceOfBinaryRequestFacade()));
     }
 
     public static void setTesting(BinaryRun binaryRunMock, BinaryProcessGatewayProvider binaryProcessGatewayProviderMock) {

--- a/src/main/java/com/tabnine/lifecycle/BinaryNotificationsLifecycle.kt
+++ b/src/main/java/com/tabnine/lifecycle/BinaryNotificationsLifecycle.kt
@@ -53,7 +53,12 @@ class BinaryNotificationsLifecycle(
                         }
 
                         Notifications.Bus.notify(notification)
-                        binaryRequestFacade.executeRequest(NotificationShownRequest(binaryNotification.message))
+                        binaryRequestFacade.executeRequest(
+                            NotificationShownRequest(
+                                binaryNotification.id,
+                                binaryNotification.message, binaryNotification.notificationType, binaryNotification.state
+                            )
+                        )
                         PropertiesComponent.getInstance().setValue(storageKey(binaryNotification.id), true)
                     }
                 }

--- a/src/main/java/com/tabnine/lifecycle/BinaryPromotionStatusBarLifecycle.kt
+++ b/src/main/java/com/tabnine/lifecycle/BinaryPromotionStatusBarLifecycle.kt
@@ -1,15 +1,12 @@
 package com.tabnine.lifecycle
 
-import com.tabnine.binary.BinaryRequestFacade
 import com.tabnine.general.StaticConfig.BINARY_PROMOTION_POLLING_DELAY
 import com.tabnine.general.StaticConfig.BINARY_PROMOTION_POLLING_INTERVAL
 import com.tabnine.statusBar.StatusBarUpdater
 import java.util.Timer
 import kotlin.concurrent.timerTask
 
-class BinaryPromotionStatusBarLifecycle(private val binaryRequestFacade: BinaryRequestFacade) {
-    private val statusBarUpdater = StatusBarUpdater(binaryRequestFacade)
-
+class BinaryPromotionStatusBarLifecycle(private val statusBarUpdater: StatusBarUpdater) {
     fun poll() {
         Timer().schedule(
             timerTask {

--- a/src/main/java/com/tabnine/selections/TabNineLookupListener.java
+++ b/src/main/java/com/tabnine/selections/TabNineLookupListener.java
@@ -25,9 +25,10 @@ public class TabNineLookupListener implements LookupListener {
     private final BinaryRequestFacade binaryRequestFacade;
     private final StatusBarUpdater statusBarUpdater;
 
-    public TabNineLookupListener(BinaryRequestFacade binaryRequestFacade) {
+    public TabNineLookupListener(BinaryRequestFacade binaryRequestFacade,
+                                 StatusBarUpdater statusBarUpdater) {
         this.binaryRequestFacade = binaryRequestFacade;
-        this.statusBarUpdater = new StatusBarUpdater(binaryRequestFacade);
+        this.statusBarUpdater = statusBarUpdater;
     }
 
     @Override

--- a/src/main/java/com/tabnine/selections/TabNineLookupListener.java
+++ b/src/main/java/com/tabnine/selections/TabNineLookupListener.java
@@ -10,6 +10,7 @@ import com.tabnine.binary.requests.selection.SelectionSuggestionRequest;
 import com.tabnine.binary.requests.selection.SetStateBinaryRequest;
 import com.tabnine.general.CompletionOrigin;
 import com.tabnine.prediction.TabNineCompletion;
+import com.tabnine.statusBar.StatusBarUpdater;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
@@ -22,9 +23,11 @@ import static java.util.stream.Collectors.*;
 
 public class TabNineLookupListener implements LookupListener {
     private final BinaryRequestFacade binaryRequestFacade;
+    private final StatusBarUpdater statusBarUpdater;
 
     public TabNineLookupListener(BinaryRequestFacade binaryRequestFacade) {
         this.binaryRequestFacade = binaryRequestFacade;
+        this.statusBarUpdater = new StatusBarUpdater(binaryRequestFacade);
     }
 
     @Override
@@ -67,6 +70,7 @@ public class TabNineLookupListener implements LookupListener {
             addSuggestionsCount(selection, suggestions);
 
             binaryRequestFacade.executeRequest(new SetStateBinaryRequest(selection));
+            this.statusBarUpdater.updateStatusBar();
         }
     }
 

--- a/src/main/java/com/tabnine/statusBar/StatusBarUpdater.kt
+++ b/src/main/java/com/tabnine/statusBar/StatusBarUpdater.kt
@@ -1,0 +1,94 @@
+package com.tabnine.statusBar
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.wm.WindowManager
+import com.tabnine.binary.BinaryRequestFacade
+import com.tabnine.binary.requests.statusBar.StatusBarPromotionBinaryRequest
+import com.tabnine.binary.requests.statusBar.StatusBarPromotionBinaryResponse
+import com.tabnine.binary.requests.statusBar.StatusBarPromotionShownRequest
+import java.util.concurrent.atomic.AtomicBoolean
+
+class StatusBarUpdater(private val binaryRequestFacade: BinaryRequestFacade) {
+
+    private companion object {
+        val synchronizer = AtomicBoolean()
+    }
+
+    fun updateStatusBar() {
+        ApplicationManager.getApplication().executeOnPooledThread { requestStatusBarMessage() }
+    }
+
+    fun requestStatusBarMessage() {
+        try {
+            if (!synchronizer.compareAndSet(false, true)) {
+                return // abort if there's already a request in progress
+            }
+            val statusBarPromotionWidgets = getStatusBarsWidgets()
+            if (statusBarPromotionWidgets.isEmpty()) {
+                return
+            }
+
+            val promotion = binaryRequestFacade.executeRequest(StatusBarPromotionBinaryRequest())
+
+            if (promotion != null) {
+                updateStatusBars(statusBarPromotionWidgets, promotion)
+                binaryRequestFacade.executeRequest(
+                    StatusBarPromotionShownRequest(
+                        promotion.id,
+                        promotion.message ?: "undefined", promotion.notificationType,
+                        promotion.state
+                    )
+                )
+            } else {
+                clear(statusBarPromotionWidgets)
+            }
+        } finally {
+            synchronizer.set(false)
+        }
+    }
+
+    private fun updateStatusBars(
+        statusBarPromotionWidgets: List<StatusBarPromotionWidget.StatusBarPromotionComponent>,
+        statusBarPromotionResponse: StatusBarPromotionBinaryResponse
+    ) {
+        updateStatusBars(
+            statusBarPromotionWidgets, true,
+            statusBarPromotionResponse.message,
+            statusBarPromotionResponse.id, statusBarPromotionResponse.actions,
+            statusBarPromotionResponse.notificationType
+        )
+    }
+
+    private fun clear(statusBarPromotionWidgets: List<StatusBarPromotionWidget.StatusBarPromotionComponent>) {
+        updateStatusBars(
+            statusBarPromotionWidgets, false, null,
+            null, null, null
+        )
+    }
+
+    private fun updateStatusBars(
+        statusBars: List<StatusBarPromotionWidget.StatusBarPromotionComponent>,
+        isVisible: Boolean,
+        text: String?,
+        id: String?,
+        actions: List<String>?,
+        notificationType: String?,
+    ) {
+        for (statusBarPromotionWidget in statusBars) {
+            statusBarPromotionWidget.isVisible = isVisible
+            statusBarPromotionWidget.text = text
+            statusBarPromotionWidget.id = id
+            statusBarPromotionWidget.actions = actions
+            statusBarPromotionWidget.notificationType = notificationType
+        }
+    }
+
+    private fun getStatusBarsWidgets(): List<StatusBarPromotionWidget.StatusBarPromotionComponent> {
+        return ProjectManager.getInstance().openProjects.mapNotNull {
+            val statusBar = WindowManager.getInstance()?.getStatusBar(it)
+            val widget = statusBar?.getWidget(StatusBarPromotionWidget::class.java.name) ?: null
+            (widget as StatusBarPromotionWidget).component as StatusBarPromotionWidget.StatusBarPromotionComponent
+        }
+    }
+}

--- a/src/main/java/com/tabnine/statusBar/StatusBarUpdater.kt
+++ b/src/main/java/com/tabnine/statusBar/StatusBarUpdater.kt
@@ -13,6 +13,7 @@ class StatusBarUpdater(private val binaryRequestFacade: BinaryRequestFacade) {
 
     private companion object {
         val synchronizer = AtomicBoolean()
+        val NO_MESSAGE = "undefined"
     }
 
     fun updateStatusBar() {
@@ -36,7 +37,8 @@ class StatusBarUpdater(private val binaryRequestFacade: BinaryRequestFacade) {
                 binaryRequestFacade.executeRequest(
                     StatusBarPromotionShownRequest(
                         promotion.id,
-                        promotion.message ?: "undefined", promotion.notificationType,
+                        promotion.message ?: NO_MESSAGE,
+                        promotion.notificationType,
                         promotion.state
                     )
                 )
@@ -87,8 +89,8 @@ class StatusBarUpdater(private val binaryRequestFacade: BinaryRequestFacade) {
     private fun getStatusBarsWidgets(): List<StatusBarPromotionWidget.StatusBarPromotionComponent> {
         return ProjectManager.getInstance().openProjects.mapNotNull {
             val statusBar = WindowManager.getInstance()?.getStatusBar(it)
-            val widget = statusBar?.getWidget(StatusBarPromotionWidget::class.java.name) ?: null
-            (widget as StatusBarPromotionWidget).component as StatusBarPromotionWidget.StatusBarPromotionComponent
+            val widget = statusBar?.getWidget(StatusBarPromotionWidget::class.java.name)
+            widget?.let { (widget as StatusBarPromotionWidget).component as StatusBarPromotionWidget.StatusBarPromotionComponent }
         }
     }
 }


### PR DESCRIPTION
Added missing fields to NotificationShownRequest, BinaryNotification, StatusBarPromotionBinaryResponse and StatusBarPromotionShownRequest.
Update status bar on selection (instead of just waiting for the poller).
Display status bar messages in all open project windows (instead of just the first opened one).