### PR TITLE
try to recommend tabnine when certain file extensiosn exist

### DIFF
--- a/src/main/java/com/tabnine/TabnineFileTypeFactory.java
+++ b/src/main/java/com/tabnine/TabnineFileTypeFactory.java
@@ -1,0 +1,23 @@
+package com.tabnine;
+
+import com.intellij.openapi.fileTypes.FileTypeConsumer;
+import com.intellij.openapi.fileTypes.FileTypeFactory;
+import org.jetbrains.annotations.NotNull;
+
+// https://plugins.jetbrains.com/docs/marketplace/intellij-plugin-recommendations.html#file-type
+public class TabnineFileTypeFactory extends FileTypeFactory {
+    @Override
+    public void createFileTypes(@NotNull FileTypeConsumer consumer) {
+        consumer.consume(TabnineIgnoreFileType.INSANCE);
+        consumer.consume(TabnineRootFileType.INSTANCE);
+        consumer.consume(TabnineProjectModelFileType.INSTANCE);
+        consumer.consume(TabnineProjectModelFileType.INSTANCE, "tabnine");
+        consumer.consume(TabnineProjectModelFileType.INSTANCE, ".tabnine");
+        consumer.consume(TabnineProjectModelFileType.INSTANCE, "tabnine.model");
+        consumer.consume(TabnineProjectModelFileType.INSTANCE, ".tabnine.model");
+        consumer.consume(TabnineProjectModelFileType.INSTANCE, "model");
+        consumer.consume(TabnineProjectModelFileType.INSTANCE, ".model");
+
+
+    }
+}

--- a/src/main/java/com/tabnine/TabnineIgnoreFileType.java
+++ b/src/main/java/com/tabnine/TabnineIgnoreFileType.java
@@ -1,0 +1,52 @@
+package com.tabnine;
+
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.tabnine.general.StaticConfig;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class TabnineIgnoreFileType implements FileType {
+    public static TabnineIgnoreFileType INSANCE = new TabnineIgnoreFileType();
+    @NotNull
+    @Override
+    public String getName() {
+        return "Tabnine ignore file";
+    }
+
+    @NotNull
+    @Override
+    public String getDescription() {
+        return "Tabnine ignore file";
+    }
+
+    @NotNull
+    @Override
+    public String getDefaultExtension() {
+        return "tabnineignore";
+    }
+
+    @Nullable
+    @Override
+    public Icon getIcon() {
+        return StaticConfig.ICON;
+    }
+
+    @Override
+    public boolean isBinary() {
+        return false;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public String getCharset(@NotNull VirtualFile file, @NotNull byte[] content) {
+        return null;
+    }
+}

--- a/src/main/java/com/tabnine/TabnineProjectModelFileType.java
+++ b/src/main/java/com/tabnine/TabnineProjectModelFileType.java
@@ -1,0 +1,52 @@
+package com.tabnine;
+
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.tabnine.general.StaticConfig;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class TabnineProjectModelFileType implements FileType {
+    public static TabnineProjectModelFileType INSTANCE = new TabnineProjectModelFileType();
+    @NotNull
+    @Override
+    public String getName() {
+        return "Tabnine project model file";
+    }
+
+    @NotNull
+    @Override
+    public String getDescription() {
+        return "Tabnine project model file";
+    }
+
+    @NotNull
+    @Override
+    public String getDefaultExtension() {
+        return "tabnine.model";
+    }
+
+    @Nullable
+    @Override
+    public Icon getIcon() {
+        return StaticConfig.ICON;
+    }
+
+    @Override
+    public boolean isBinary() {
+        return false;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public String getCharset(@NotNull VirtualFile file, @NotNull byte[] content) {
+        return null;
+    }
+}

--- a/src/main/java/com/tabnine/TabnineRootFileType.java
+++ b/src/main/java/com/tabnine/TabnineRootFileType.java
@@ -1,0 +1,52 @@
+package com.tabnine;
+
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.tabnine.general.StaticConfig;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class TabnineRootFileType implements FileType {
+    public static TabnineRootFileType INSTANCE = new TabnineRootFileType();
+    @NotNull
+    @Override
+    public String getName() {
+        return "Tabnine root file";
+    }
+
+    @NotNull
+    @Override
+    public String getDescription() {
+        return "Tabnine root file";
+    }
+
+    @NotNull
+    @Override
+    public String getDefaultExtension() {
+        return "tabnine_root";
+    }
+
+    @Nullable
+    @Override
+    public Icon getIcon() {
+        return StaticConfig.ICON;
+    }
+
+    @Override
+    public boolean isBinary() {
+        return false;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public String getCharset(@NotNull VirtualFile file, @NotNull byte[] content) {
+        return null;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -71,59 +71,59 @@
 <p>
 <table>
 <tr>
-<td>Java</td>    
-<td>Javascript</td>    
-<td>Python</td>    
+<td>Java</td>
+<td>Javascript</td>
+<td>Python</td>
 </tr>
 <tr>
-<td>extended JS</td>    
-<td>React</td>    
-<td>PHP</td>    
+<td>extended JS</td>
+<td>React</td>
+<td>PHP</td>
 </tr>
 <tr>
-<td>Typescript</td>    
-<td>C Header</td>    
-<td>Bash</td>    
+<td>Typescript</td>
+<td>C Header</td>
+<td>Bash</td>
 </tr>
 <tr>
-<td>ML</td>    
-<td>Swift</td>    
-<td>Ruby</td>    
+<td>ML</td>
+<td>Swift</td>
+<td>Ruby</td>
 </tr>
 <tr>
-<td>Perl</td>    
-<td>Rust</td>    
-<td>SQL</td>    
+<td>Perl</td>
+<td>Rust</td>
+<td>SQL</td>
 </tr>
 <tr>
-<td>Vue</td>    
-<td>F#</td>    
-<td>Scala</td>    
+<td>Vue</td>
+<td>F#</td>
+<td>Scala</td>
 </tr>
 <tr>
-<td>Julia</td>    
-<td>TOML</td>    
-<td>Shell</td>    
+<td>Julia</td>
+<td>TOML</td>
+<td>Shell</td>
 </tr>
 <tr>
-<td>YMAL</td>    
-<td>C / C++ / C#</td>    
-<td>HTML</td>    
+<td>YMAL</td>
+<td>C / C++ / C#</td>
+<td>HTML</td>
 </tr>
 <tr>
-<td>Lua</td>    
-<td>Markdown</td>    
-<td>Haskell</td>    
+<td>Lua</td>
+<td>Markdown</td>
+<td>Haskell</td>
 </tr>
 <tr>
-<td>Go</td>    
-<td>Objective C</td>    
-<td>JSON</td>    
+<td>Go</td>
+<td>Objective C</td>
+<td>JSON</td>
 </tr>
 <tr>
-<td>CSS / SCSS</td>    
-<td>Angular</td>    
-<td>Kotlin</td>    
+<td>CSS / SCSS</td>
+<td>Angular</td>
+<td>Kotlin</td>
 </tr>
 </table>
 </p>
@@ -368,8 +368,9 @@
         <editorActionHandler action="EditorEscape" implementationClass="com.tabnine.inline.EscapeHandler"
                              id="previewEscape" order="before hide-hints"/>
         <editorFactoryDocumentListener implementation="com.tabnine.inline.TabnineDocumentListener" />
+        <fileTypeFactory implementation="com.tabnine.TabnineFileTypeFactory"/>
     </extensions>
-    
+
     <actions>
         <action class="com.tabnine.inline.ShowNextInlineCompletionAction" id="ShowNextInlineCompletionAction"
                 text="Show Next Inline Completion">


### PR DESCRIPTION
Intellij recommend tabnine when:

> The IntelliJ Platform IDEs will recommend a plugin for installation in one of the following cases:
> 
> If a project contains files of types which are unsupported by the running IDE but are supported by a plugin available in the plugin repository.
> 
> If a project was created in n different IDE installation which had the plugin installed, and includes shared settings (modules, facets, artifacts, or run configurations) configured using the plugin.
> 
> 

the instructions are here:
https://plugins.jetbrains.com/docs/marketplace/intellij-plugin-recommendations.html#file-type

(they aren't good)

Tested locally by debugging and witnessing that `.tabnine.model` files have the tabnine icon in the project tree.

> To verify that the file type is registered correctly, you can implement the LanguageFileType.getIcon() method and verify that the correct icon (see Working with Icons and Images) is displayed for files associated with your file type.


We need to release the plugin and test once the static automation tool runs 

https://github.com/JetBrains/intellij-plugin-verifier/tree/master/intellij-feature-extractor/


This is a tool used by the Marketplace to determine a set of supported plugin's features.

> The features are specified using IntelliJ API. In most cases the features are specified as string constants. The tool extracts the constant values from class files using bytecode analysis. There are tricky cases which are hard to analyse without running the plugin's code. In such cases the feature extractor may return incomplete results. The list of extracted plugin features can be seen on this page.


> File extensions
> A plugin author implements abstract class com.intellij.openapi.fileTypes.FileTypeFactory and feeds the com.intellij.openapi.fileTypes.FileTypeConsumer to the only abstract method with supported file extensions.