### PR TITLE
Inline tab bug fix

### DIFF
--- a/src/main/java/com/tabnine/inline/AcceptInlineCompletionAction.java
+++ b/src/main/java/com/tabnine/inline/AcceptInlineCompletionAction.java
@@ -5,9 +5,11 @@ import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.actionSystem.EditorAction;
-import com.intellij.openapi.editor.actionSystem.EditorActionHandler;
+import com.intellij.openapi.editor.actionSystem.EditorWriteActionHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 public class AcceptInlineCompletionAction extends EditorAction
     implements HintManagerImpl.ActionToIgnore, InlineCompletionAction {
@@ -18,16 +20,23 @@ public class AcceptInlineCompletionAction extends EditorAction
     super(new AcceptInlineCompletionHandler());
   }
 
-  public static class AcceptInlineCompletionHandler extends EditorActionHandler {
+  public static class AcceptInlineCompletionHandler extends EditorWriteActionHandler {
 
     @Override
-    protected void doExecute(
-        @NotNull Editor editor, @Nullable Caret caret, DataContext dataContext) {
+    public void executeWriteAction(Editor editor, @Nullable Caret caret, DataContext dataContext) {
       CompletionPreview completionPreview = CompletionPreview.findCompletionPreview(editor);
       if (completionPreview == null) {
         return;
       }
       completionPreview.applyPreview();
+    }
+
+    @Override
+    protected boolean isEnabledForCaret(
+        @NotNull Editor editor, @NotNull Caret caret, DataContext dataContext) {
+      CompletionPreview completionPreview = CompletionPreview.findCompletionPreview(editor);
+      return completionPreview != null
+          && Objects.equals(caret.getOffset(), completionPreview.getStartOffset());
     }
   }
 }

--- a/src/main/java/com/tabnine/inline/InlineHints.java
+++ b/src/main/java/com/tabnine/inline/InlineHints.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.keymap.KeymapUtil;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.LightweightHint;
 import com.intellij.ui.SimpleColoredComponent;
 import com.intellij.ui.SimpleColoredText;
@@ -30,15 +31,9 @@ public class InlineHints {
   }
 
   private static void initPreInsertionHint() {
-    String nextShortcut =
-        KeymapUtil.getFirstKeyboardShortcutText(
-            ActionManager.getInstance().getAction(ShowNextInlineCompletionAction.ACTION_ID));
-    String prevShortcut =
-        KeymapUtil.getFirstKeyboardShortcutText(
-            ActionManager.getInstance().getAction(ShowPreviousInlineCompletionAction.ACTION_ID));
-    String acceptShortcut =
-        KeymapUtil.getFirstKeyboardShortcutText(
-            ActionManager.getInstance().getAction(AcceptInlineCompletionAction.ACTION_ID));
+    String nextShortcut = getShortcutText(ShowNextInlineCompletionAction.ACTION_ID);
+    String prevShortcut = getShortcutText(ShowPreviousInlineCompletionAction.ACTION_ID);
+    String acceptShortcut = getShortcutText(AcceptInlineCompletionAction.ACTION_ID);
     String cancelShortcut = KeymapUtil.getKeyText(KeyEvent.VK_ESCAPE);
     String text =
         "Next ("
@@ -54,6 +49,12 @@ public class InlineHints {
       currentText = text;
       preInsertionHintComponent = createInlineHintComponent(text);
     }
+  }
+
+  private static String getShortcutText(String actionId) {
+    String shortcutText =
+        KeymapUtil.getFirstKeyboardShortcutText(ActionManager.getInstance().getAction(actionId));
+    return StringUtil.defaultIfEmpty(shortcutText, "Missing shortcut key");
   }
 
   private static JComponent createInlineHintComponent(String text) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -359,11 +359,7 @@
         <applicationService serviceImplementation="com.tabnine.lifecycle.BinaryStateService"/>
         <applicationService serviceImplementation="com.tabnine.capabilities.CapabilitiesService"/>
         <applicationService serviceImplementation="com.tabnine.lifecycle.LifeCycleHelper"/>
-        <applicationService serviceImplementation="com.tabnine.settings.TabnineSettingsState" />
 
-        <applicationConfigurable parentId="tools" instance="com.tabnine.settings.TabnineSettingsConfigurable"
-                                 id="com.tabnine.settings.TabnineSettingsConfigurable"
-                                 displayName="Tabnine Settings" />
         <actionPromoter implementation="com.tabnine.inline.InlineActionsPromoter" />
         <editorActionHandler action="EditorEscape" implementationClass="com.tabnine.inline.EscapeHandler"
                              id="previewEscape" order="before hide-hints"/>


### PR DESCRIPTION
Fixing the major bug where the inline completion mute by mistake the editor Tab action.
The problem was missing `isEnable` implementation.
Also in this PR:
- Changed the `AcceptInlineCompletionHandler` to be a subclass of `EditorWriteActionHandler` (eliminating the need of `runWriteCommandAction` call when applying the selected inline completion)
- Change the inline text hint to be more friendly (in case no shortcut is set to one of the actions)
- Remove old and irrelevant entries from the `plugin.xml`   