### PR TITLE
More fixes to inline UX

### DIFF
--- a/src/main/java/com/tabnine/inline/CompletionPreview.java
+++ b/src/main/java/com/tabnine/inline/CompletionPreview.java
@@ -203,7 +203,7 @@ public class CompletionPreview implements Disposable, EditorMouseMotionListener 
         return editor.getUserData(INLINE_COMPLETION_PREVIEW);
     }
 
-    static void disposeIfExists(@NotNull Editor editor) {
+    public static void disposeIfExists(@NotNull Editor editor) {
         disposeIfExists(editor, preview -> true);
     }
 

--- a/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
+++ b/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
@@ -37,13 +37,13 @@ import java.util.concurrent.Future;
 public class InlineCompletionHandler implements CodeInsightActionHandler {
     private static final String INLINE_DUMMY_IDENTIFIER = "TabnineInlineDummy";
     private static final Set<Character> CLOSING_CHARACTERS = ContainerUtil.set('\'', '"', '`', ']', '}', ')', '>');
-    public static final int DEBOUNCE_MILLIS = 400;
+    public static final int DEBOUNCE_MILLIS = 350;
 
     private final CompletionFacade completionFacade =
             DependencyContainer.instanceOfCompletionFacade();
     private final MessageBus messageBus = ApplicationManager.getApplication().getMessageBus();
-    private final boolean myForward;
     private Future<?> lastPreviewTask = null;
+    private final boolean myForward;
 
     private static boolean isLocked;
 
@@ -96,11 +96,6 @@ public class InlineCompletionHandler implements CodeInsightActionHandler {
     public void invoke(@NotNull Project project, @NotNull Editor editor, @NotNull PsiFile file) {
         int caretOffset = editor.getCaretModel().getOffset();
         invoke(project, editor, file, caretOffset);
-    }
-
-    public void cancelLastInvocation(Editor editor) {
-        ObjectUtils.doIfNotNull(lastPreviewTask, task -> task.cancel(false));
-        CompletionPreview.disposeIfExists(editor);
     }
 
     private String computeCurrentPrefix(

--- a/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
+++ b/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.wm.IdeFocusManager;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
+import com.intellij.util.Alarm;
 import com.intellij.util.ObjectUtils;
 import com.tabnine.capabilities.SuggestionsMode;
 import org.jetbrains.annotations.NotNull;
@@ -26,11 +27,11 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TabnineDocumentListener implements DocumentListener {
-
+    public static final int MINIMAL_DELAY_MILLIS = 25;
     private final InlineCompletionHandler handler = new InlineCompletionHandler(true);
+    private final Alarm alarm = new Alarm();
 
     private static final java.util.List<String> AUTO_FILLING_PAIRS = Arrays.asList("()", "{}", "[]", "''", "\"\"", "``");
-
     private static final AtomicBoolean isMuted = new AtomicBoolean(false);
 
     @Override
@@ -42,6 +43,18 @@ public class TabnineDocumentListener implements DocumentListener {
                 || event.getNewLength() < 1) {
             return;
         }
+
+        if (ApplicationManager.getApplication().isUnitTestMode()) {
+            documentChangedDebounced(event, eventNewText);
+        } else {
+            alarm.cancelAllRequests();
+            // Give enough time to cancel previous requests in cases where the document listener is called too often
+            // (e.g. on newline+indents, auto-filling pairs etc.).
+            alarm.addRequest(() -> documentChangedDebounced(event, eventNewText), MINIMAL_DELAY_MILLIS);
+        }
+    }
+
+    private void documentChangedDebounced(@NotNull DocumentEvent event, String eventNewText) {
         Document document = event.getDocument();
 
         if (ObjectUtils.doIfCast(document, DocumentEx.class, DocumentEx::isInBulkUpdate)
@@ -66,7 +79,6 @@ public class TabnineDocumentListener implements DocumentListener {
         int endOffset = event.getOffset() + event.getNewLength();
 
         if (newTextIsAutoFilled(eventNewText, document, startOffset, endOffset)) {
-            handler.cancelLastInvocation(editor);
             return;
         }
 

--- a/src/main/java/com/tabnine/selections/AutoImporter.java
+++ b/src/main/java/com/tabnine/selections/AutoImporter.java
@@ -133,10 +133,7 @@ public class AutoImporter implements MarkupModelListener {
                         })
                         .collect(Collectors.toList());
         if (importActions.stream()
-                .filter(f -> {
-                    String actionText = f.getAction().getText();
-                    return actionText.contains(highlightedText);
-                })
+                .filter(f -> f.getAction().getText().contains(highlightedText))
                 .count()
                 > 1) {
             // Skip highlight in case of ambiguity

--- a/src/main/java/com/tabnine/selections/AutoImporter.java
+++ b/src/main/java/com/tabnine/selections/AutoImporter.java
@@ -1,6 +1,5 @@
 package com.tabnine.selections;
 
-import com.intellij.codeInsight.completion.InsertionContext;
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl;
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
@@ -32,197 +31,201 @@ import java.util.stream.Collectors;
 
 public class AutoImporter implements MarkupModelListener {
 
-  private static final int MAX_ATTEMPTS = 2;
-  private static final Key<AutoImporter> TABNINE_AUTO_IMPORTER_KEY =
-      Key.create("TABNINE_AUTO_IMPORTER");
+    private static final int MAX_ATTEMPTS = 2;
+    private static final Key<AutoImporter> TABNINE_AUTO_IMPORTER_KEY =
+            Key.create("TABNINE_AUTO_IMPORTER");
 
-  private int startOffset;
-  private int endOffset;
-  private boolean offsetRangeVisited = false;
-  private final AtomicBoolean codeAnalyzerAutoImportInvoked = new AtomicBoolean(false);
-  @NotNull private final Project project;
-  @NotNull Editor editor;
-  private Disposable myDisposable;
-  private final Map<String, Integer> importCandidates = new HashMap<>();
-  private String lastCandidate;
-  private final Set<String> foundImportsSet = new HashSet<>();
-  private final List<HighlightInfo.IntentionActionDescriptor> importFixes = new ArrayList<>();
+    private int startOffset;
+    private int endOffset;
+    private boolean offsetRangeVisited = false;
+    private final AtomicBoolean codeAnalyzerAutoImportInvoked = new AtomicBoolean(false);
+    @NotNull
+    private final Project project;
+    @NotNull Editor editor;
+    private Disposable myDisposable;
+    private final Map<String, Integer> importCandidates = new HashMap<>();
+    private String lastCandidate;
+    private final Set<String> foundImportsSet = new HashSet<>();
+    private final List<HighlightInfo.IntentionActionDescriptor> importFixes = new ArrayList<>();
 
-  private AutoImporter(@NotNull Editor editor, @NotNull Project project, int startOffset, int endOffset) {
-    this.editor = editor;
-    this.project = project;
-    this.startOffset = startOffset;
-    this.endOffset = endOffset;
-  }
-
-  private void init() {
-    String insertedText = editor.getDocument().getText(new TextRange(startOffset, endOffset));
-    String[] terms = insertedText.split("\\W+");
-    if (terms.length > 0) {
-      for (String term : terms) {
-        importCandidates.put(term, MAX_ATTEMPTS);
-      }
-      lastCandidate = terms[terms.length - 1];
-      myDisposable = Disposer.newDisposable();
-      EditorUtil.disposeWithEditor(editor, myDisposable);
-      ((EditorEx) editor)
-          .getFilteredDocumentMarkupModel()
-          .addMarkupModelListener(myDisposable, this);
+    private AutoImporter(@NotNull Editor editor, @NotNull Project project, int startOffset, int endOffset) {
+        this.editor = editor;
+        this.project = project;
+        this.startOffset = startOffset;
+        this.endOffset = endOffset;
     }
-  }
 
-  public static void registerTabNineAutoImporter(@NotNull Editor editor, @NotNull Project project, int startOffset, int endOffset) {
-    AutoImporter autoImporter = editor.getUserData(TABNINE_AUTO_IMPORTER_KEY);
-    if (autoImporter != null) {
-      autoImporter.cleanup();
-      editor.putUserData(TABNINE_AUTO_IMPORTER_KEY, null);
+    private void init() {
+        String insertedText = editor.getDocument().getText(new TextRange(startOffset, endOffset));
+        String[] terms = insertedText.split("\\W+");
+        if (terms.length > 0) {
+            for (String term : terms) {
+                importCandidates.put(term, MAX_ATTEMPTS);
+            }
+            lastCandidate = terms[terms.length - 1];
+            myDisposable = Disposer.newDisposable();
+            EditorUtil.disposeWithEditor(editor, myDisposable);
+            ((EditorEx) editor)
+                    .getFilteredDocumentMarkupModel()
+                    .addMarkupModelListener(myDisposable, this);
+        }
     }
-    autoImporter = new AutoImporter(editor, project, startOffset, endOffset);
-    editor.putUserData(TABNINE_AUTO_IMPORTER_KEY, autoImporter);
-    autoImporter.init();
-  }
 
-  private boolean isPriorHighlighter(@NotNull RangeHighlighterEx highlighter) {
-    return startOffset > highlighter.getAffectedAreaStartOffset();
-  }
-
-  private boolean isPosteriorHighlighter(@NotNull RangeHighlighterEx highlighter) {
-    return endOffset < highlighter.getAffectedAreaEndOffset();
-  }
-
-  @Nullable
-  private PsiFile getFile(@NotNull RangeHighlighterEx highlighter) {
-    final Document document = highlighter.getDocument();
-    return PsiDocumentManager.getInstance(project).getPsiFile(document);
-  }
-
-  @Nullable
-  private HighlightInfo getHighlightInfo(@NotNull RangeHighlighterEx highlighter) {
-    Object errorTooltip = highlighter.getErrorStripeTooltip();
-    return ObjectUtils.tryCast(errorTooltip, HighlightInfo.class);
-  }
-
-  private void invokeLater(@NotNull Runnable task) {
-    ApplicationManager.getApplication().invokeLater(task);
-  }
-
-  private void autoImportUsingCodeAnalyzer(@NotNull final PsiFile file) {
-    if (codeAnalyzerAutoImportInvoked.get()) {
-      return;
+    public static void registerTabNineAutoImporter(@NotNull Editor editor, @NotNull Project project, int startOffset, int endOffset) {
+        AutoImporter autoImporter = editor.getUserData(TABNINE_AUTO_IMPORTER_KEY);
+        if (autoImporter != null) {
+            autoImporter.cleanup();
+            editor.putUserData(TABNINE_AUTO_IMPORTER_KEY, null);
+        }
+        autoImporter = new AutoImporter(editor, project, startOffset, endOffset);
+        editor.putUserData(TABNINE_AUTO_IMPORTER_KEY, autoImporter);
+        autoImporter.init();
     }
-    final DaemonCodeAnalyzerImpl codeAnalyzer =
-        (DaemonCodeAnalyzerImpl) DaemonCodeAnalyzer.getInstance(project);
-    CommandProcessor.getInstance()
-        .runUndoTransparentAction(() -> invokeLater(() -> {
-          codeAnalyzerAutoImportInvoked.set(true);
-          codeAnalyzer.autoImportReferenceAtCursor(editor, file);
-        }));
-  }
 
-  private void collectImportFixes(
-      @NotNull PsiFile file,
-      @NotNull RangeHighlighterEx highlighter,
-      @NotNull String highlightedText) {
-    List<HighlightInfo.IntentionActionDescriptor> availableFixes =
-        ShowIntentionsPass.getAvailableFixes(editor, file, -1, highlighter.getEndOffset());
-    List<HighlightInfo.IntentionActionDescriptor> importActions =
-        availableFixes.stream()
-            .filter(f -> f.getAction().getText().toLowerCase().contains("import"))
-            .collect(Collectors.toList());
-    if (importActions.stream()
-            .filter(f -> f.getAction().getText().contains(highlightedText))
-            .count()
-        > 1) {
-      // Skip highlight in case of ambiguity
-      return;
+    private boolean isPriorHighlighter(@NotNull RangeHighlighterEx highlighter) {
+        return startOffset > highlighter.getAffectedAreaStartOffset();
     }
-    if (!importActions.isEmpty()) {
-      foundImportsSet.add(highlightedText);
-      importCandidates.remove(highlightedText);
-      importFixes.add(importActions.get(0));
+
+    private boolean isPosteriorHighlighter(@NotNull RangeHighlighterEx highlighter) {
+        return endOffset < highlighter.getAffectedAreaEndOffset();
     }
-  }
 
-  @Override
-  public void afterAdded(@NotNull RangeHighlighterEx highlighter) {
-    try {
-      if (isPriorHighlighter(highlighter)) {
-        // Irrelevant
-        return;
-      }
-      PsiFile file = getFile(highlighter);
-      if (file == null) {
-        return;
-      }
-      if ((isPosteriorHighlighter(highlighter) && offsetRangeVisited) || importCandidates.isEmpty()) {
-        // Moved on to other highlighters - invoke the collected actions (if any)
-        invokeImportActions(file);
-        return;
-      }
-      offsetRangeVisited = true;
-      HighlightInfo highlightInfo = getHighlightInfo(highlighter);
-      if (highlightInfo == null) {
-        return;
-      }
-      String highlightedText = highlightInfo.getText();
-      if (!importCandidates.containsKey(highlightedText)) {
-        // Irrelevant
-        return;
-      }
-      // Try auto import
-      autoImportUsingCodeAnalyzer(file);
-      // Collect import fixes
-      collectImportFixes(file, highlighter, highlightedText);
-      markAsVisited(highlightedText);
-      if (shouldFinishListening(highlightedText)) {
-        // Invoke actions and cleanup
-        invokeImportActions(file);
-      }
-    } catch (Throwable e) {
-      Logger.getInstance(getClass()).warn("Failed to process highlighter: " + highlighter + " for auto-import", e);
+    @Nullable
+    private PsiFile getFile(@NotNull RangeHighlighterEx highlighter) {
+        final Document document = highlighter.getDocument();
+        return PsiDocumentManager.getInstance(project).getPsiFile(document);
     }
-  }
 
-  private boolean shouldFinishListening(@NotNull String term) {
-    return (term.equals(lastCandidate) && foundImportsSet.contains(term))
-        || importCandidates.isEmpty();
-  }
-
-  private void markAsVisited(@NotNull String term) {
-    importCandidates.computeIfPresent(term, (k, v) -> v == 1 ? null : v - 1);
-  }
-
-  private void invokeImportActions(@NotNull PsiFile file) {
-    try {
-      final List<HighlightInfo.IntentionActionDescriptor> importFixActions =
-          new ArrayList<>(importFixes);
-      invokeLater(
-              () -> {
-                importFixActions.forEach(
-                    fix ->
-                        ShowIntentionActionsHandler.chooseActionAndInvoke(
-                            file, editor, fix.getAction(), fix.getAction().getText()));
-              });
-    } catch (Throwable e) {
-      Logger.getInstance(getClass()).warn("Failed to auto import", e);
-    } finally {
-      cleanup();
+    @Nullable
+    private HighlightInfo getHighlightInfo(@NotNull RangeHighlighterEx highlighter) {
+        Object errorTooltip = highlighter.getErrorStripeTooltip();
+        return ObjectUtils.tryCast(errorTooltip, HighlightInfo.class);
     }
-  }
 
-  private void cleanup() {
-    unregisteredAsMarkupModelListener();
-    importCandidates.clear();
-    lastCandidate = null;
-    foundImportsSet.clear();
-    importFixes.clear();
-    offsetRangeVisited = false;
-    codeAnalyzerAutoImportInvoked.set(false);
-  }
-
-  private void unregisteredAsMarkupModelListener() {
-    if (myDisposable != null && !Disposer.isDisposed(myDisposable)) {
-      Disposer.dispose(myDisposable);
+    private void invokeLater(@NotNull Runnable task) {
+        ApplicationManager.getApplication().invokeLater(task);
     }
-  }
+
+    private void autoImportUsingCodeAnalyzer(@NotNull final PsiFile file) {
+        if (codeAnalyzerAutoImportInvoked.get()) {
+            return;
+        }
+        final DaemonCodeAnalyzerImpl codeAnalyzer =
+                (DaemonCodeAnalyzerImpl) DaemonCodeAnalyzer.getInstance(project);
+        CommandProcessor.getInstance()
+                .runUndoTransparentAction(() -> invokeLater(() -> {
+                    codeAnalyzerAutoImportInvoked.set(true);
+                    codeAnalyzer.autoImportReferenceAtCursor(editor, file);
+                }));
+    }
+
+    private void collectImportFixes(
+            @NotNull PsiFile file,
+            @NotNull RangeHighlighterEx highlighter,
+            @NotNull String highlightedText) {
+        List<HighlightInfo.IntentionActionDescriptor> availableFixes =
+                ShowIntentionsPass.getAvailableFixes(editor, file, -1, highlighter.getEndOffset());
+        List<HighlightInfo.IntentionActionDescriptor> importActions =
+                availableFixes.stream()
+                        .filter(f -> {
+                            String actionText = f.getAction().getText().toLowerCase();
+                            return actionText.contains("import") && !actionText.contains("remove");
+                        })
+                        .collect(Collectors.toList());
+        if (importActions.stream()
+                .filter(f -> {
+                    String actionText = f.getAction().getText();
+                    return actionText.contains(highlightedText);
+                })
+                .count()
+                > 1) {
+            // Skip highlight in case of ambiguity
+            return;
+        }
+        if (!importActions.isEmpty()) {
+            foundImportsSet.add(highlightedText);
+            importCandidates.remove(highlightedText);
+            importFixes.add(importActions.get(0));
+        }
+    }
+
+    @Override
+    public void afterAdded(@NotNull RangeHighlighterEx highlighter) {
+        try {
+            if (isPriorHighlighter(highlighter)) {
+                // Irrelevant
+                return;
+            }
+            PsiFile file = getFile(highlighter);
+            if (file == null) {
+                return;
+            }
+            if ((isPosteriorHighlighter(highlighter) && offsetRangeVisited) || importCandidates.isEmpty()) {
+                // Moved on to other highlighters - invoke the collected actions (if any)
+                invokeImportActions(file);
+                return;
+            }
+            offsetRangeVisited = true;
+            HighlightInfo highlightInfo = getHighlightInfo(highlighter);
+            if (highlightInfo == null) {
+                return;
+            }
+            String highlightedText = highlightInfo.getText();
+            if (!importCandidates.containsKey(highlightedText)) {
+                // Irrelevant
+                return;
+            }
+            // Try auto import
+            autoImportUsingCodeAnalyzer(file);
+            // Collect import fixes
+            collectImportFixes(file, highlighter, highlightedText);
+            markAsVisited(highlightedText);
+            if (shouldFinishListening(highlightedText)) {
+                // Invoke actions and cleanup
+                invokeImportActions(file);
+            }
+        } catch (Throwable e) {
+            Logger.getInstance(getClass()).warn("Failed to process highlighter: " + highlighter + " for auto-import", e);
+        }
+    }
+
+    private boolean shouldFinishListening(@NotNull String term) {
+        return (term.equals(lastCandidate) && foundImportsSet.contains(term))
+                || importCandidates.isEmpty();
+    }
+
+    private void markAsVisited(@NotNull String term) {
+        importCandidates.computeIfPresent(term, (k, v) -> v == 1 ? null : v - 1);
+    }
+
+    private void invokeImportActions(@NotNull PsiFile file) {
+        try {
+            final List<HighlightInfo.IntentionActionDescriptor> importFixActions =
+                    new ArrayList<>(importFixes);
+            invokeLater(
+                    () -> importFixActions.forEach(
+                            fix -> ShowIntentionActionsHandler.chooseActionAndInvoke(
+                                    file, editor, fix.getAction(), fix.getAction().getText())));
+        } catch (Throwable e) {
+            Logger.getInstance(getClass()).warn("Failed to auto import", e);
+        } finally {
+            cleanup();
+        }
+    }
+
+    private void cleanup() {
+        unregisteredAsMarkupModelListener();
+        importCandidates.clear();
+        lastCandidate = null;
+        foundImportsSet.clear();
+        importFixes.clear();
+        offsetRangeVisited = false;
+        codeAnalyzerAutoImportInvoked.set(false);
+    }
+
+    private void unregisteredAsMarkupModelListener() {
+        if (myDisposable != null && !Disposer.isDisposed(myDisposable)) {
+            Disposer.dispose(myDisposable);
+        }
+    }
 }

--- a/src/test/java/com/tabnine/plugin/InlineCompletionTests.java
+++ b/src/test/java/com/tabnine/plugin/InlineCompletionTests.java
@@ -1,5 +1,6 @@
 package com.tabnine.plugin;
 
+import com.intellij.util.ObjectUtils;
 import com.tabnine.capabilities.SuggestionsMode;
 import com.tabnine.inline.AcceptInlineCompletionAction;
 import com.tabnine.inline.CompletionPreview;
@@ -103,7 +104,15 @@ public class InlineCompletionTests extends MockedBinaryCompletionTestCase {
     public void dontShowPreviewForAutoFillingChars() throws Exception {
         configureInlineTest(SuggestionsMode.INLINE);
 
-        type("\n[]");
+        type("\n");
+        type("[");
+        // only test the auto-filled char, so dispose the preview before the last character
+        ObjectUtils.doIfNotNull(myFixture.getEditor(), editor -> {
+            CompletionPreview.disposeIfExists(editor);
+            return null;
+        });
+
+        type("]");
         assertNull(
                 "Should not have shown preview",
                 CompletionPreview.getPreviewText(myFixture.getEditor())

--- a/src/test/java/com/tabnine/unitTests/InlineStringProcessorTests.kt
+++ b/src/test/java/com/tabnine/unitTests/InlineStringProcessorTests.kt
@@ -60,4 +60,14 @@ class InlineStringProcessorTests {
             )
         )
     }
+
+    @Test
+    fun testBlockOnlyWithFirstLineEmpty() {
+        assert(
+            determineRendering(listOf("    ", "\nsome text"), "") == RenderingInstructions(
+                FirstLineRendering.None,
+                true
+            )
+        )
+    }
 }


### PR DESCRIPTION
## Fixes
1. Debounce document listener for a short amount of time, to tame calls to the listener.
*Why?*
Mainly for snippets - They appear on empty lines, so if you hit a `\n` and the IDE adds indentation (i.e `\n____`) - It will **sometimes** trigger the listener **twice** - for the newline and for the indentation. This causes snippets to appear with the wrong indentation sometimes, and overall a bad behaior. It's also good for auto-filled chars, like brackets - there's no need to trigger for `(` and `)` separately (not at all actually - this is being handled in a separate condition).
*Double debouncing*
There's another debounce inside `InlineCompletionHandler.java` - So why 2 debouncers?
If you'll have only the outer debouncer you wouldn't issue querties to the binary at all if the call is being debounced, and if you'll have only the inner one you'd issue too many requests.
So the solution is:
- Debounce the outer (listener) function by a short amount of time, to prevent too many calls (like explained above).
- In the inner (handler) function - **always query the binary**, and debounce the update of the UI by a few hundreds of ms (to prevent flickering)
2. Fix auto importer removing the first "import" statement in the file
Apparently, one of the available actions were to "remove unused import" which deleted the import statement entirely - Fixed it by filtering out suggestions to *remove* imports, as its not relevant at all while completing suggestions. The purpose of invoking the auto importer after accepting a suggestion is to import a type that is completed in the suggestion and not imported, not to remove unused imports.