### PR TITLE
send snippet shown event

### DIFF
--- a/src/main/java/com/tabnine/binary/requests/autocomplete/ResultEntry.java
+++ b/src/main/java/com/tabnine/binary/requests/autocomplete/ResultEntry.java
@@ -12,5 +12,6 @@ public class ResultEntry {
     public String detail;
     public Boolean deprecated;
     public CompletionKind completion_kind;
+    public Boolean is_cached;
     // TODO other lsp types
 }

--- a/src/main/java/com/tabnine/binary/requests/notifications/shown/SnippetShownRequest.kt
+++ b/src/main/java/com/tabnine/binary/requests/notifications/shown/SnippetShownRequest.kt
@@ -1,0 +1,19 @@
+package com.tabnine.binary.requests.notifications.shown
+
+import com.tabnine.binary.BinaryRequest
+import com.tabnine.binary.requests.selection.SetStateBinaryResponse
+import com.tabnine.general.StaticConfig
+
+class SnippetShownRequest : BinaryRequest<SetStateBinaryResponse> {
+    override fun response(): Class<SetStateBinaryResponse> {
+        return SetStateBinaryResponse::class.java
+    }
+
+    override fun serialize(): Any {
+        return mapOf("SetState" to mapOf("state_type" to mapOf("SnippetShown" to this)))
+    }
+
+    override fun validate(response: SetStateBinaryResponse): Boolean {
+        return StaticConfig.SET_STATE_RESPONSE_RESULT_STRING == response.result
+    }
+}

--- a/src/main/java/com/tabnine/general/StaticConfig.java
+++ b/src/main/java/com/tabnine/general/StaticConfig.java
@@ -20,7 +20,7 @@ public class StaticConfig {
     public static final String TABNINE_PLUGIN_ID_RAW = "com.tabnine.TabNine";
     public static final PluginId TABNINE_PLUGIN_ID = PluginId.getId(TABNINE_PLUGIN_ID_RAW);
     public static final int MAX_COMPLETIONS = 5;
-    public static final String BINARY_PROTOCOL_VERSION = "3.5.34";
+    public static final String BINARY_PROTOCOL_VERSION = "4.0.57";
     public static final int COMPLETION_TIME_THRESHOLD = 1000;
     public static final int NEWLINE_COMPLETION_TIME_THRESHOLD = 3000;
     public static final int ILLEGAL_RESPONSE_THRESHOLD = 5;

--- a/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
+++ b/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
@@ -219,7 +219,7 @@ public class InlineCompletionHandler implements CodeInsightActionHandler {
     }
 
     private void afterCompletionShown(TabNineCompletion completion) {
-        if (completion.completionKind == CompletionKind.Snippet) {
+        if (completion.completionKind == CompletionKind.Snippet && !completion.isCached) {
             try {
                 this.binaryRequestFacade.executeRequest(new SnippetShownRequest());
             } catch (RuntimeException e) {

--- a/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
+++ b/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
@@ -219,6 +219,9 @@ public class InlineCompletionHandler implements CodeInsightActionHandler {
     }
 
     private void afterCompletionShown(TabNineCompletion completion) {
+        // binary is not supporting api version ^4.0.57
+        if (completion.isCached == null) return;
+
         if (completion.completionKind == CompletionKind.Snippet && !completion.isCached) {
             try {
                 this.binaryRequestFacade.executeRequest(new SnippetShownRequest());

--- a/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
+++ b/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
@@ -20,7 +20,10 @@ import com.intellij.util.ObjectUtils;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.messages.MessageBus;
+import com.tabnine.binary.BinaryRequestFacade;
 import com.tabnine.binary.requests.autocomplete.AutocompleteResponse;
+import com.tabnine.binary.requests.notifications.shown.SnippetShownRequest;
+import com.tabnine.general.CompletionKind;
 import com.tabnine.general.DependencyContainer;
 import com.tabnine.intellij.completions.CompletionUtils;
 import com.tabnine.intellij.completions.LimitedSecletionsChangedNotifier;
@@ -28,6 +31,7 @@ import com.tabnine.prediction.CompletionFacade;
 import com.tabnine.prediction.TabNineCompletion;
 import com.tabnine.prediction.TabNinePrefixMatcher;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +46,7 @@ public class InlineCompletionHandler implements CodeInsightActionHandler {
 
     private final CompletionFacade completionFacade =
             DependencyContainer.instanceOfCompletionFacade();
+    private final BinaryRequestFacade binaryRequestFacade = DependencyContainer.instanceOfBinaryRequestFacade();
     private final MessageBus messageBus = ApplicationManager.getApplication().getMessageBus();
     private Future<?> lastPreviewTask = null;
     private final boolean myForward;
@@ -130,6 +135,15 @@ public class InlineCompletionHandler implements CodeInsightActionHandler {
             @NotNull PsiFile file,
             CompletionState completionState,
             int startOffset) {
+        showInlineCompletion(editor, file, completionState, startOffset, null);
+    }
+
+    private void showInlineCompletion(
+            @NotNull Editor editor,
+            @NotNull PsiFile file,
+            CompletionState completionState,
+            int startOffset,
+            @Nullable OnCompletionPreviewUpdatedCallback onCompletionPreviewUpdatedCallback) {
         if (completionState.suggestions == null || completionState.suggestions.isEmpty()) {
             return;
         }
@@ -145,6 +159,9 @@ public class InlineCompletionHandler implements CodeInsightActionHandler {
         CompletionPreview preview = CompletionPreview.findOrCreateCompletionPreview(editor, file);
         completionState.lastDisplayedPreview =
                 preview.updatePreview(completionState.suggestions, nextIndex, startOffset);
+        if (onCompletionPreviewUpdatedCallback != null) {
+            onCompletionPreviewUpdatedCallback.onCompletionPreviewUpdated(completionState.suggestions.get(nextIndex));
+        }
         completionState.lastDisplayedCompletionIndex = nextIndex;
         completionState.lastStartOffset = startOffset;
         completionState.lastModificationStamp = editor.getDocument().getModificationStamp();
@@ -193,11 +210,21 @@ public class InlineCompletionHandler implements CodeInsightActionHandler {
                 }
                 ApplicationManager.getApplication().invokeLater(() -> {
                     completionState.resetStats();
-                    showInlineCompletion(editor, file, completionState, startOffset);
+                    showInlineCompletion(editor, file, completionState, startOffset, this::afterCompletionShown);
                 }, (Condition<Void>) unused -> editor.getDocument().getModificationStamp() != lastModified);
                 return null;
             };
             lastPreviewTask = AppExecutorUtil.getAppExecutorService().submit(runnable);
+        }
+    }
+
+    private void afterCompletionShown(TabNineCompletion completion) {
+        if (completion.completionKind == CompletionKind.Snippet) {
+            try {
+                this.binaryRequestFacade.executeRequest(new SnippetShownRequest());
+            } catch (RuntimeException e) {
+                // swallow - nothing to do with this
+            }
         }
     }
 

--- a/src/main/java/com/tabnine/inline/OnCompletionPreviewUpdatedCallback.kt
+++ b/src/main/java/com/tabnine/inline/OnCompletionPreviewUpdatedCallback.kt
@@ -1,0 +1,7 @@
+package com.tabnine.inline
+
+import com.tabnine.prediction.TabNineCompletion
+
+interface OnCompletionPreviewUpdatedCallback {
+    fun onCompletionPreviewUpdated(completion: TabNineCompletion)
+}

--- a/src/main/java/com/tabnine/intellij/completions/CompletionUtils.java
+++ b/src/main/java/com/tabnine/intellij/completions/CompletionUtils.java
@@ -13,65 +13,66 @@ import static com.tabnine.general.Utils.endsWithADot;
 
 public class CompletionUtils {
 
-  private static String getCursorPrefix(@NotNull Document document, int cursorPosition) {
-    int lineNumber = document.getLineNumber(cursorPosition);
-    int lineStart = document.getLineStartOffset(lineNumber);
+    private static String getCursorPrefix(@NotNull Document document, int cursorPosition) {
+        int lineNumber = document.getLineNumber(cursorPosition);
+        int lineStart = document.getLineStartOffset(lineNumber);
 
-    return document.getText(TextRange.create(lineStart, cursorPosition)).trim();
-  }
-
-  private static String getCursorSuffix(@NotNull Document document, int cursorPosition) {
-    int lineNumber = document.getLineNumber(cursorPosition);
-    int lineEnd = document.getLineEndOffset(lineNumber);
-
-    return document.getText(TextRange.create(cursorPosition, lineEnd)).trim();
-  }
-
-  @NotNull
-  public static TabNineCompletion createTabnineCompletion(
-      @NotNull Document document,
-      String newPrefix,
-      int offset,
-      String oldPrefix,
-      ResultEntry result,
-      int index) {
-    TabNineCompletion completion =
-        new TabNineCompletion(
-            oldPrefix,
-            result.new_prefix,
-            result.old_suffix,
-            result.new_suffix,
-            index,
-            newPrefix,
-            CompletionUtils.getCursorPrefix(document, offset),
-            CompletionUtils.getCursorSuffix(document, offset),
-            result.origin,
-            result.completion_kind);
-
-    completion.detail = result.detail;
-
-    if (result.deprecated != null) {
-      completion.deprecated = result.deprecated;
+        return document.getText(TextRange.create(lineStart, cursorPosition)).trim();
     }
-    return completion;
-  }
 
-  static int completionLimit(
-      CompletionParameters parameters, CompletionResultSet result, boolean isLocked) {
-    return completionLimit(
-        parameters.getEditor().getDocument(),
-        result.getPrefixMatcher().getPrefix(),
-        parameters.getOffset(),
-        isLocked);
-  }
+    private static String getCursorSuffix(@NotNull Document document, int cursorPosition) {
+        int lineNumber = document.getLineNumber(cursorPosition);
+        int lineEnd = document.getLineEndOffset(lineNumber);
 
-  public static int completionLimit(
-      @NotNull Document document, @NotNull String prefix, int offset, boolean isLocked) {
-    if (isLocked) {
-      return 1;
+        return document.getText(TextRange.create(cursorPosition, lineEnd)).trim();
     }
-    boolean preferTabNine = !endsWithADot(document, offset - prefix.length());
 
-    return preferTabNine ? MAX_COMPLETIONS : 1;
-  }
+    @NotNull
+    public static TabNineCompletion createTabnineCompletion(
+            @NotNull Document document,
+            String newPrefix,
+            int offset,
+            String oldPrefix,
+            ResultEntry result,
+            int index) {
+        TabNineCompletion completion =
+                new TabNineCompletion(
+                        oldPrefix,
+                        result.new_prefix,
+                        result.old_suffix,
+                        result.new_suffix,
+                        index,
+                        newPrefix,
+                        CompletionUtils.getCursorPrefix(document, offset),
+                        CompletionUtils.getCursorSuffix(document, offset),
+                        result.origin,
+                        result.completion_kind,
+                        result.is_cached);
+
+        completion.detail = result.detail;
+
+        if (result.deprecated != null) {
+            completion.deprecated = result.deprecated;
+        }
+        return completion;
+    }
+
+    static int completionLimit(
+            CompletionParameters parameters, CompletionResultSet result, boolean isLocked) {
+        return completionLimit(
+                parameters.getEditor().getDocument(),
+                result.getPrefixMatcher().getPrefix(),
+                parameters.getOffset(),
+                isLocked);
+    }
+
+    public static int completionLimit(
+            @NotNull Document document, @NotNull String prefix, int offset, boolean isLocked) {
+        if (isLocked) {
+            return 1;
+        }
+        boolean preferTabNine = !endsWithADot(document, offset - prefix.length());
+
+        return preferTabNine ? MAX_COMPLETIONS : 1;
+    }
 }

--- a/src/main/java/com/tabnine/prediction/TabNineCompletion.java
+++ b/src/main/java/com/tabnine/prediction/TabNineCompletion.java
@@ -20,11 +20,12 @@ public class TabNineCompletion {
     public String cursorSuffix;
     public CompletionOrigin origin;
     public CompletionKind completionKind;
+    public Boolean isCached;
 
     public String detail = null;
     public boolean deprecated = false;
 
-    public TabNineCompletion(String oldPrefix, String newPrefix, String oldSuffix, String newSuffix, int index, String completionPrefix, String cursorPrefix, String cursorSuffix, CompletionOrigin origin, CompletionKind completionKind) {
+    public TabNineCompletion(String oldPrefix, String newPrefix, String oldSuffix, String newSuffix, int index, String completionPrefix, String cursorPrefix, String cursorSuffix, CompletionOrigin origin, CompletionKind completionKind, Boolean isCached) {
         this.oldPrefix = oldPrefix;
         this.newPrefix = newPrefix;
         this.oldSuffix = oldSuffix;
@@ -35,6 +36,7 @@ public class TabNineCompletion {
         this.cursorSuffix = cursorSuffix;
         this.origin = origin;
         this.completionKind = completionKind;
+        this.isCached = isCached;
     }
 
     public CompletionOrigin getOrigin() {


### PR DESCRIPTION
### Update

The below issue has been solved by using the new api version 4.0.57

---

Current behavior is that if you received a snippet, lets say:
```javascript
function average(arr) {
  // 'let sum = 0;...'
```
and you continue typing:
```javascript
function average(arr) {
  let // 'sum = 0;...'
```
it'll count as 2 separate `SnippetShown` events.

i think its ok, since (at least in this plugin) currently the snippet disappears and re-appears after some debouncing. 
@dimacodota wdyt?