### PR TITLE
show suggestions only when a single char has been typed

### DIFF
--- a/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
+++ b/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
@@ -41,7 +41,7 @@ public class TabnineDocumentListener implements DocumentListener {
         if (isMuted.get()
                 || SuggestionsMode.getSuggestionMode() != SuggestionsMode.INLINE
                 || eventNewText.equals(CompletionUtil.DUMMY_IDENTIFIER)
-                || event.getNewLength() < 1) {
+                || event.getNewLength() != 1) {
             return;
         }
 

--- a/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
+++ b/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
@@ -41,7 +41,7 @@ public class TabnineDocumentListener implements DocumentListener {
         if (isMuted.get()
                 || SuggestionsMode.getSuggestionMode() != SuggestionsMode.INLINE
                 || eventNewText.equals(CompletionUtil.DUMMY_IDENTIFIER)
-                || event.getNewLength() != 1) {
+                || event.getNewLength() < 1) {
             return;
         }
 
@@ -79,11 +79,17 @@ public class TabnineDocumentListener implements DocumentListener {
         int startOffset = event.getOffset();
         int endOffset = event.getOffset() + event.getNewLength();
 
-        if (newTextIsAutoFilled(eventNewText, document, startOffset, endOffset)) {
+        if (newTextIsAutoFilled(eventNewText, document, startOffset, endOffset)
+                || !newTextIsSingleChange(eventNewText)) {
             return;
         }
 
         handler.invoke(project, editor, file, endOffset);
+    }
+
+    // counts `\n\t` as a single change too.
+    private boolean newTextIsSingleChange(String newText) {
+        return newText.length() == 1 || newText.trim().isEmpty();
     }
 
     private boolean newTextIsAutoFilled(String eventNewText, Document document, int startOffset, int endOffset) {


### PR DESCRIPTION
there was this annoying behavior that when you, for example, `ctrl+v` something into the ide tabnine would hop in and suggest. i disabled it by asserting that the event's new length is exactly 1 - meaning that you typed a single char.