### PR TITLE
add color picker settings for inline hint

### DIFF
--- a/src/main/java/com/tabnine/inline/render/GraphicsUtils.kt
+++ b/src/main/java/com/tabnine/inline/render/GraphicsUtils.kt
@@ -3,10 +3,10 @@ package com.tabnine.inline.render
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.EditorFontType
 import com.intellij.ui.JBColor
+import com.tabnine.userSettings.AppSettingsState
 import java.awt.Color
 import java.awt.Font
 import java.awt.font.TextAttribute
-import java.util.HashMap
 import kotlin.math.abs
 import kotlin.math.sqrt
 
@@ -20,6 +20,11 @@ object GraphicsUtils {
         attributes[TextAttribute.STRIKETHROUGH] = TextAttribute.STRIKETHROUGH_ON
         return Font(attributes)
     }
+
+    val color: Color
+        get() {
+            return Color(AppSettingsState.instance.color)
+        }
 
     val niceContrastColor: Color
         get() {

--- a/src/main/java/com/tabnine/inline/render/experimental/BlockElementRenderer.kt
+++ b/src/main/java/com/tabnine/inline/render/experimental/BlockElementRenderer.kt
@@ -32,7 +32,7 @@ class BlockElementRenderer(
         targetRegion: Rectangle,
         textAttributes: TextAttributes
     ) {
-        color = color ?: GraphicsUtils.niceContrastColor
+        color = color ?: GraphicsUtils.color
         g.color = color
         g.font = GraphicsUtils.getFont(editor, deprecated)
         blockText.withIndex().forEach { (i, line) ->

--- a/src/main/java/com/tabnine/inline/render/experimental/InlineElementRenderer.kt
+++ b/src/main/java/com/tabnine/inline/render/experimental/InlineElementRenderer.kt
@@ -25,7 +25,7 @@ class InlineElementRenderer(private val editor: Editor, private val suffix: Stri
         textAttributes: TextAttributes
     ) {
         renderingXAnchor = renderingXAnchor ?: targetRegion.x
-        color = color ?: GraphicsUtils.niceContrastColor
+        color = color ?: GraphicsUtils.color
         g.color = color
         g.font = GraphicsUtils.getFont(editor, deprecated)
         g.drawString(suffix, renderingXAnchor!!, targetRegion.y + editor.ascent)

--- a/src/main/java/com/tabnine/userSettings/AppSettingsComponent.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsComponent.kt
@@ -1,0 +1,33 @@
+package com.tabnine.userSettings
+
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.FormBuilder
+import com.intellij.util.ui.UIUtil
+import java.awt.Color
+import javax.swing.JColorChooser
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Supports creating and managing a [JPanel] for the Settings Dialog.
+ */
+class AppSettingsComponent {
+    val panel: JPanel
+    private val colorChooser = JColorChooser()
+
+    val preferredFocusedComponent: JComponent
+        get() = colorChooser
+
+    var chosenColor: Int
+        get() = colorChooser.color.rgb
+        set(colorRGB) {
+            colorChooser.color = Color(colorRGB)
+        }
+
+    init {
+        panel = FormBuilder.createFormBuilder()
+            .addLabeledComponent(JBLabel("Inline Hint Color:", UIUtil.ComponentStyle.LARGE), colorChooser, 1, true)
+            .addComponentFillVertically(JPanel(), 0)
+            .panel
+    }
+}

--- a/src/main/java/com/tabnine/userSettings/AppSettingsConfigurable.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsConfigurable.kt
@@ -1,0 +1,47 @@
+package com.tabnine.userSettings
+
+import com.intellij.openapi.options.Configurable
+import com.tabnine.userSettings.AppSettingsState.Companion.instance
+import org.jetbrains.annotations.Nls
+import javax.swing.JComponent
+
+/**
+ * Provides controller functionality for application settings.
+ */
+class AppSettingsConfigurable : Configurable {
+    private var settingsComponent: AppSettingsComponent? = null
+
+    // A default constructor with no arguments is required because this implementation
+    // is registered as an applicationConfigurable EP
+    override fun getDisplayName(): @Nls(capitalization = Nls.Capitalization.Title) String {
+        return "Tabnine: Settings"
+    }
+
+    override fun getPreferredFocusedComponent(): JComponent {
+        return settingsComponent!!.preferredFocusedComponent
+    }
+
+    override fun createComponent(): JComponent {
+        settingsComponent = AppSettingsComponent()
+        return settingsComponent!!.panel
+    }
+
+    override fun isModified(): Boolean {
+        val settings = instance
+        return settingsComponent!!.chosenColor != settings.color
+    }
+
+    override fun apply() {
+        val settings = instance
+        settings.color = settingsComponent!!.chosenColor
+    }
+
+    override fun reset() {
+        val settings = instance
+        settingsComponent!!.chosenColor = settings.color
+    }
+
+    override fun disposeUIResources() {
+        settingsComponent = null
+    }
+}

--- a/src/main/java/com/tabnine/userSettings/AppSettingsState.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsState.kt
@@ -1,0 +1,35 @@
+package com.tabnine.userSettings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+import com.tabnine.inline.render.GraphicsUtils
+
+/**
+ * This package (`userSettings`) is heavily influenced by the docs from here:
+ * https://plugins.jetbrains.com/docs/intellij/settings-tutorial.html
+ *
+ *
+ * Supports storing the application settings in a persistent way.
+ * The [State] and [Storage] annotations define the name of the data and the file name where
+ * these persistent application settings are stored.
+ */
+@State(name = "org.intellij.sdk.settings.AppSettingsState", storages = [Storage("TabnineSettings.xml")])
+class AppSettingsState : PersistentStateComponent<AppSettingsState?> {
+    var color = GraphicsUtils.niceContrastColor.rgb
+    override fun getState(): AppSettingsState {
+        return this
+    }
+
+    override fun loadState(state: AppSettingsState) {
+        XmlSerializerUtil.copyBean(state, this)
+    }
+
+    companion object {
+        @JvmStatic
+        val instance: AppSettingsState
+            get() = ApplicationManager.getApplication().getService(AppSettingsState::class.java)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -349,6 +349,10 @@
                              id="previewEscape" order="before hide-hints"/>
         <editorFactoryDocumentListener implementation="com.tabnine.inline.TabnineDocumentListener" />
         <fileTypeFactory implementation="com.tabnine.TabnineFileTypeFactory"/>
+        <applicationService serviceImplementation="com.tabnine.userSettings.AppSettingsState"/>
+        <applicationConfigurable parentId="tools" instance="com.tabnine.userSettings.AppSettingsConfigurable"
+                                 id="com.tabnine.userSettings.AppSettingsConfigurable"
+                                 displayName="Tabnine: Settings"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
Added `Tabnine: Settings` section to the settings panel:
![image](https://user-images.githubusercontent.com/67855609/150294612-1e4d6fbe-bd6e-421d-a30f-b909146f5b40.png)

Which controls the color of the inline hint. Don't need to restart after changing color, and the chosen color gets persisted to the disk.

Settings implementation is taken from the docs here: https://plugins.jetbrains.com/docs/intellij/settings-tutorial.html