### PR TITLE
settings panel: log file path, default color checkbox, disable if inline disabled

### DIFF
--- a/src/main/java/com/tabnine/general/StaticConfig.java
+++ b/src/main/java/com/tabnine/general/StaticConfig.java
@@ -3,6 +3,7 @@ package com.tabnine.general;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.openapi.util.SystemInfo;
+import com.tabnine.userSettings.AppSettingsState;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -60,6 +61,11 @@ public class StaticConfig {
     public static final String OPEN_HUB_ACTION = "OpenHub";
 
     public static Optional<String> getLogFilePath() {
+        String logFilePathFromUserSettings = AppSettingsState.getInstance().getLogFilePath();
+        if (!logFilePathFromUserSettings.isEmpty()) {
+            return Optional.of(logFilePathFromUserSettings);
+        }
+
         return Optional.ofNullable(System.getProperty(LOG_FILE_PATH_PROPERTY));
     }
 

--- a/src/main/java/com/tabnine/inline/render/GraphicsUtils.kt
+++ b/src/main/java/com/tabnine/inline/render/GraphicsUtils.kt
@@ -23,7 +23,7 @@ object GraphicsUtils {
 
     val color: Color
         get() {
-            return Color(AppSettingsState.instance.color)
+            return Color(AppSettingsState.instance.inlineHintColor)
         }
 
     val niceContrastColor: Color

--- a/src/main/java/com/tabnine/userSettings/AppSettingsComponent.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsComponent.kt
@@ -1,6 +1,8 @@
 package com.tabnine.userSettings
 
+import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
 import com.intellij.util.ui.UIUtil
 import java.awt.Color
@@ -13,20 +15,34 @@ import javax.swing.JPanel
  */
 class AppSettingsComponent {
     val panel: JPanel
+    private val logFilePathComponent = JBTextField()
     private val colorChooser = JColorChooser()
-
+    private val useDefaultColorCheckbox = JBCheckBox("Use Default Color")
     val preferredFocusedComponent: JComponent
         get() = colorChooser
 
+    var useDefaultColor: Boolean
+        get() = useDefaultColorCheckbox.isSelected
+        set(value) {
+            useDefaultColorCheckbox.isSelected = value
+        }
     var chosenColor: Int
         get() = colorChooser.color.rgb
         set(colorRGB) {
             colorChooser.color = Color(colorRGB)
         }
+    var logFilePath: String
+        get() = logFilePathComponent.text
+        set(value) {
+            logFilePath
+            logFilePathComponent.text = value
+        }
 
     init {
         panel = FormBuilder.createFormBuilder()
+            .addLabeledComponent("Tabnine Log File Path: ", logFilePathComponent, 1, false)
             .addLabeledComponent(JBLabel("Inline Hint Color:", UIUtil.ComponentStyle.LARGE), colorChooser, 1, true)
+            .addComponent(useDefaultColorCheckbox, 1)
             .addComponentFillVertically(JPanel(), 0)
             .panel
     }

--- a/src/main/java/com/tabnine/userSettings/AppSettingsComponent.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsComponent.kt
@@ -5,6 +5,7 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
 import com.intellij.util.ui.UIUtil
+import com.tabnine.capabilities.SuggestionsMode
 import java.awt.Color
 import javax.swing.JColorChooser
 import javax.swing.JComponent
@@ -18,6 +19,8 @@ class AppSettingsComponent {
     private val logFilePathComponent = JBTextField()
     private val colorChooser = JColorChooser()
     private val useDefaultColorCheckbox = JBCheckBox("Use Default Color")
+    private val colorChooserLabel = JBLabel("Inline Hint Color:", UIUtil.ComponentStyle.LARGE)
+
     val preferredFocusedComponent: JComponent
         get() = colorChooser
 
@@ -39,9 +42,15 @@ class AppSettingsComponent {
         }
 
     init {
+        if (SuggestionsMode.getSuggestionMode() != SuggestionsMode.INLINE) {
+            colorChooser.isEnabled = false
+            useDefaultColorCheckbox.isEnabled = false
+            colorChooserLabel.isEnabled = false
+        }
+
         panel = FormBuilder.createFormBuilder()
-            .addLabeledComponent("Tabnine Log File Path: ", logFilePathComponent, 1, false)
-            .addLabeledComponent(JBLabel("Inline Hint Color:", UIUtil.ComponentStyle.LARGE), colorChooser, 1, true)
+            .addLabeledComponent("Log File Path: ", logFilePathComponent, 1, false)
+            .addLabeledComponent(colorChooserLabel, colorChooser, 1, true)
             .addComponent(useDefaultColorCheckbox, 1)
             .addComponentFillVertically(JPanel(), 0)
             .panel

--- a/src/main/java/com/tabnine/userSettings/AppSettingsComponent.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsComponent.kt
@@ -37,7 +37,6 @@ class AppSettingsComponent {
     var logFilePath: String
         get() = logFilePathComponent.text
         set(value) {
-            logFilePath
             logFilePathComponent.text = value
         }
 

--- a/src/main/java/com/tabnine/userSettings/AppSettingsConfigurable.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsConfigurable.kt
@@ -28,17 +28,23 @@ class AppSettingsConfigurable : Configurable {
 
     override fun isModified(): Boolean {
         val settings = instance
-        return settingsComponent!!.chosenColor != settings.color
+        return settingsComponent!!.chosenColor != settings.color ||
+            settingsComponent!!.useDefaultColor != settings.useDefaultColor ||
+            settingsComponent!!.logFilePath != settings.logFilePath
     }
 
     override fun apply() {
         val settings = instance
         settings.color = settingsComponent!!.chosenColor
+        settings.useDefaultColor = settingsComponent!!.useDefaultColor
+        settings.logFilePath = settingsComponent!!.logFilePath
     }
 
     override fun reset() {
         val settings = instance
         settingsComponent!!.chosenColor = settings.color
+        settingsComponent!!.useDefaultColor = settings.useDefaultColor
+        settingsComponent!!.logFilePath = settings.logFilePath
     }
 
     override fun disposeUIResources() {

--- a/src/main/java/com/tabnine/userSettings/AppSettingsConfigurable.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsConfigurable.kt
@@ -28,21 +28,21 @@ class AppSettingsConfigurable : Configurable {
 
     override fun isModified(): Boolean {
         val settings = instance
-        return settingsComponent!!.chosenColor != settings.color ||
+        return settingsComponent!!.chosenColor != settings.inlineHintColor ||
             settingsComponent!!.useDefaultColor != settings.useDefaultColor ||
             settingsComponent!!.logFilePath != settings.logFilePath
     }
 
     override fun apply() {
         val settings = instance
-        settings.color = settingsComponent!!.chosenColor
+        settings.inlineHintColor = settingsComponent!!.chosenColor
         settings.useDefaultColor = settingsComponent!!.useDefaultColor
         settings.logFilePath = settingsComponent!!.logFilePath
     }
 
     override fun reset() {
         val settings = instance
-        settingsComponent!!.chosenColor = settings.color
+        settingsComponent!!.chosenColor = settings.inlineHintColor
         settingsComponent!!.useDefaultColor = settings.useDefaultColor
         settingsComponent!!.logFilePath = settings.logFilePath
     }

--- a/src/main/java/com/tabnine/userSettings/AppSettingsState.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsState.kt
@@ -23,7 +23,7 @@ class AppSettingsState : PersistentStateComponent<AppSettingsState?> {
     var logFilePath: String = ""
     private var colorState = settingsDefaultColor
 
-    var color: Int
+    var inlineHintColor: Int
         get() = if (useDefaultColor) {
             settingsDefaultColor
         } else {

--- a/src/main/java/com/tabnine/userSettings/AppSettingsState.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsState.kt
@@ -8,6 +8,7 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 import com.tabnine.inline.render.GraphicsUtils
 
 val settingsDefaultColor = GraphicsUtils.niceContrastColor.rgb
+
 /**
  * This package (`userSettings`) is heavily influenced by the docs from here:
  * https://plugins.jetbrains.com/docs/intellij/settings-tutorial.html
@@ -30,9 +31,7 @@ class AppSettingsState : PersistentStateComponent<AppSettingsState?> {
             colorState
         }
         set(value) {
-            if (!useDefaultColor) {
-                colorState = value
-            }
+            colorState = value
         }
 
     override fun getState(): AppSettingsState {

--- a/src/main/java/com/tabnine/userSettings/AppSettingsState.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsState.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.components.Storage
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.tabnine.inline.render.GraphicsUtils
 
+val settingsDefaultColor = GraphicsUtils.niceContrastColor.rgb
 /**
  * This package (`userSettings`) is heavily influenced by the docs from here:
  * https://plugins.jetbrains.com/docs/intellij/settings-tutorial.html
@@ -18,7 +19,22 @@ import com.tabnine.inline.render.GraphicsUtils
  */
 @State(name = "org.intellij.sdk.settings.AppSettingsState", storages = [Storage("TabnineSettings.xml")])
 class AppSettingsState : PersistentStateComponent<AppSettingsState?> {
-    var color = GraphicsUtils.niceContrastColor.rgb
+    var useDefaultColor: Boolean = false
+    var logFilePath: String = ""
+    private var colorState = settingsDefaultColor
+
+    var color: Int
+        get() = if (useDefaultColor) {
+            settingsDefaultColor
+        } else {
+            colorState
+        }
+        set(value) {
+            if (!useDefaultColor) {
+                colorState = value
+            }
+        }
+
     override fun getState(): AppSettingsState {
         return this
     }


### PR DESCRIPTION
- **Use default color:** Overrides user's choice with the default one
- **Log File Path**: equivalent to the `idea.properties` one, and its the preferred one (i.e if both are set, the one from the settings panel is taken) 
![image](https://user-images.githubusercontent.com/67855609/150315875-f3f964b6-52bb-4061-86c8-ccf030cf1f4f.png)