### PR TITLE
making the plugin compatible with 2019.3 - latest eap

### DIFF
--- a/.github/workflows/compatibility-eap.yml
+++ b/.github/workflows/compatibility-eap.yml
@@ -33,3 +33,13 @@ jobs:
 
       - name: Validate the plugin against latest EAP
         run: ./gradlew runPluginVerifier -PideVersions="" -PlocalPaths="$(pwd)/latest-eap"
+
+      - name: Notify slack fail
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: tab9-build
+          status: FAILED
+          color: danger

--- a/.github/workflows/compatibility-eap.yml
+++ b/.github/workflows/compatibility-eap.yml
@@ -1,0 +1,35 @@
+name: Continues Integration
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *"
+
+jobs:
+  compatibility-eap:
+    name: Ensure plugin compatibility against latest EAP
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Build the plugin
+        run: ./gradlew buildPlugin
+
+      - name: Download latest EAP
+        run: |
+          sudo curl -L "https://download.jetbrains.com/product?code=IC&latest&distribution=linux&type=eap" --output latest-eap.tar.gz
+          mkdir latest-eap && tar -xvf latest-eap.tar.gz -C latest-eap --strip-components 1
+          ls -al latest-eap
+
+      - name: Validate the plugin against latest EAP
+        run: ./gradlew runPluginVerifier -PideVersions="" -PlocalPaths="$(pwd)/latest-eap"

--- a/.github/workflows/compatibility-eap.yml
+++ b/.github/workflows/compatibility-eap.yml
@@ -35,7 +35,7 @@ jobs:
         run: ./gradlew runPluginVerifier -PideVersions="" -PlocalPaths="$(pwd)/latest-eap"
 
       - name: Notify slack fail
-        if: failure()
+#        if: failure()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/compatibility-stable.yml
+++ b/.github/workflows/compatibility-stable.yml
@@ -46,11 +46,17 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
+      - name: Download latest stable
+        run: |
+          sudo curl -L "https://download.jetbrains.com/product?code=IC&latest&distribution=linux" --output latest.tar.gz
+          mkdir latest && tar -xvf latest.tar.gz -C latest --strip-components 1
+          ls -al latest
+
       - name: Build the plugin
         run: ./gradlew buildPlugin
 
       - name: Validate the plugin
-        run: ./gradlew runPluginVerifier
+        run: ./gradlew runPluginVerifier -PlocalPaths="$(pwd)/latest"
 
   security:
     name: Vulnerabilities Scanning

--- a/.github/workflows/compatibility-stable.yml
+++ b/.github/workflows/compatibility-stable.yml
@@ -52,33 +52,6 @@ jobs:
       - name: Validate the plugin
         run: ./gradlew runPluginVerifier
 
-  compatibility-eap:
-    name: Ensure plugin compatibility against latest eap
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-
-      - name: Build the plugin
-        run: ./gradlew buildPlugin
-
-      - name: Download latest EAP
-        run: |
-          sudo curl -L "https://download.jetbrains.com/product?code=IC&latest&distribution=linux&type=eap" --output latest-eap.tar.gz
-          mkdir latest-eap && tar -xvf latest-eap.tar.gz -C latest-eap --strip-components 1
-          ls -al latest-eap
-
-      - name: Validate the plugin against latest EAP
-        run: ./gradlew runPluginVerifier -PideVersions="" -PlocalPaths="$(pwd)/latest-eap"
   security:
     name: Vulnerabilities Scanning
     runs-on: ubuntu-latest

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -31,7 +31,7 @@ jobs:
           path: build/reports
 
   compatibility:
-    name: Ensure plugin compatibility against IDEA Ultimate 2018.2, and 2019.3 for IDEA Community, IDEA Ultimate, PyCharm Community, CLion, and the latest EAP snapshot of IDEA Community.
+    name: Ensure plugin compatibility against IC releases 2019.3 - latest eap
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -50,24 +50,7 @@ jobs:
         run: ./gradlew buildPlugin
 
       - name: Validate the plugin
-        run: ./gradlew buildPlugin
-
-      - name: Verify Plugin on IntelliJ Platforms
-        id: verify
-        uses: ChrisCarini/intellij-platform-plugin-verifier-action@v1.0.3
-        with:
-          ide-versions: |
-            ideaIC:2018.2
-            ideaIC:2020.2.3
-            ideaIU:2019.3
-            pycharmPC:2019.3
-            clion:2019.3
-            ideaIC:LATEST-EAP-SNAPSHOT
-
-      - name: Get log file path and print contents
-        run: |
-          echo "The verifier log file [${{steps.verify.outputs.verification-output-log-filename}}] contents : " ;
-          cat ${{steps.verify.outputs.verification-output-log-filename}}
+        run: ./gradlew runPluginVerifier
 
   security:
     name: Vulnerabilities Scanning

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -30,8 +30,8 @@ jobs:
           name: Reports
           path: build/reports
 
-  compatibility:
-    name: Ensure plugin compatibility against IC releases 2019.3 - latest eap
+  compatibility-stable:
+    name: Ensure plugin compatibility against IC releases 2019.3 - 2021.3
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -52,6 +52,33 @@ jobs:
       - name: Validate the plugin
         run: ./gradlew runPluginVerifier
 
+  compatibility-eap:
+    name: Ensure plugin compatibility against latest eap
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Build the plugin
+        run: ./gradlew buildPlugin
+
+      - name: Download latest EAP
+        run: |
+          sudo curl -L "https://download.jetbrains.com/product?code=IC&latest&distribution=linux&type=eap" --output latest-eap.tar.gz
+          mkdir latest-eap && tar -xvf latest-eap.tar.gz -C latest-eap --strip-components 1
+          ls -al latest-eap
+
+      - name: Validate the plugin against latest EAP
+        run: ./gradlew runPluginVerifier -PideVersions="" -PlocalPaths="$(pwd)/latest-eap"
   security:
     name: Vulnerabilities Scanning
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -91,3 +91,14 @@ tasks {
         dependsOn(ktlintFormat)
     }
 }
+
+static def getIdeVersions(Project project) {
+    def ideVersions = project.hasProperty('ideVersions') ? Arrays.asList(project.ideVersions.split(',')) :
+            ['IC-2021.3.2', 'IC-2021.2.4', 'IC-2021.1.3', 'IC-2020.3.4', 'IC-2020.2.4', 'IC-2020.1.4', 'IC-2019.3.5']
+    System.out.println("Ide Versions to verify: " + ideVersions)
+    return ideVersions
+}
+
+runPluginVerifier {
+    ideVersions = getIdeVersions(project)
+}

--- a/build.gradle
+++ b/build.gradle
@@ -95,9 +95,9 @@ tasks {
 }
 
 static def getIdeVersions(Project project) {
-    def ideVersions = project.hasProperty('ideVersions') ? Arrays.asList(project.ideVersions.split(',')) :
-            ['IC-2021.3.2', 'IC-2021.2.4', 'IC-2021.1.3', 'IC-2020.3.4', 'IC-2020.2.4', 'IC-2020.1.4', 'IC-2019.3.5']
-    System.out.println("Ide Versions to verify: " + ideVersions)
+    def ideVersions = project.hasProperty('ideVersions') ?
+            Arrays.asList(project.ideVersions.split(',')) :
+            ['IC-2019.3.5']
     return ideVersions
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.util.stream.Collectors
+
 plugins {
     id 'java'
     id "org.jetbrains.kotlin.jvm" version "1.4.32"
@@ -101,4 +103,7 @@ static def getIdeVersions(Project project) {
 
 runPluginVerifier {
     ideVersions = getIdeVersions(project)
+    if (project.hasProperty("localPaths")) {
+        localPaths = Arrays.stream(project.localPaths.split(',')).map(File::new).collect(Collectors.toList())
+    }
 }

--- a/src/main/java/com/tabnine/Initializer.java
+++ b/src/main/java/com/tabnine/Initializer.java
@@ -1,37 +1,24 @@
 package com.tabnine;
 
-import com.intellij.ide.AppLifecycleListener;
-import com.intellij.ide.ApplicationLoadListener;
+import com.intellij.ide.ApplicationInitializedListener;
 import com.intellij.ide.plugins.PluginInstaller;
 import com.intellij.ide.plugins.PluginManagerCore;
-import com.intellij.openapi.application.Application;
-import com.intellij.openapi.project.Project;
-import com.intellij.util.messages.MessageBusConnection;
 import com.tabnine.capabilities.CapabilitiesService;
 import com.tabnine.lifecycle.BinaryNotificationsLifecycle;
 import com.tabnine.lifecycle.BinaryPromotionStatusBarLifecycle;
 import com.tabnine.lifecycle.TabNineDisablePluginListener;
 import com.tabnine.lifecycle.TabnineUpdater;
 import com.tabnine.logging.LogInitializerKt;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import static com.tabnine.general.DependencyContainer.*;
 
-public class Initializer implements ApplicationLoadListener, AppLifecycleListener {
+public class Initializer implements ApplicationInitializedListener {
     private TabNineDisablePluginListener listener;
     private BinaryNotificationsLifecycle binaryNotificationsLifecycle;
     private BinaryPromotionStatusBarLifecycle binaryPromotionStatusBarLifecycle;
 
     @Override
-    public void beforeApplicationLoaded(@NotNull Application application, @NotNull String configPath) {
-        final MessageBusConnection connection = application.getMessageBus().connect();
-
-        connection.subscribe(AppLifecycleListener.TOPIC, this);
-    }
-
-    @Override
-    public void appStarting(@Nullable Project projectFromCommandLine) {
+    public void componentsInitialized() {
         LogInitializerKt.init();
         listener = singletonOfTabNineDisablePluginListener();
         binaryNotificationsLifecycle = instanceOfBinaryNotifications();
@@ -42,6 +29,5 @@ public class Initializer implements ApplicationLoadListener, AppLifecycleListene
         binaryPromotionStatusBarLifecycle.poll();
         CapabilitiesService.getInstance().init();
         TabnineUpdater.pollUpdates();
-
     }
 }

--- a/src/main/java/com/tabnine/Initializer.java
+++ b/src/main/java/com/tabnine/Initializer.java
@@ -1,33 +1,51 @@
 package com.tabnine;
 
-import com.intellij.ide.ApplicationInitializedListener;
 import com.intellij.ide.plugins.PluginInstaller;
 import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.openapi.application.PreloadingActivity;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
 import com.tabnine.capabilities.CapabilitiesService;
 import com.tabnine.lifecycle.BinaryNotificationsLifecycle;
 import com.tabnine.lifecycle.BinaryPromotionStatusBarLifecycle;
 import com.tabnine.lifecycle.TabNineDisablePluginListener;
 import com.tabnine.lifecycle.TabnineUpdater;
 import com.tabnine.logging.LogInitializerKt;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.tabnine.general.DependencyContainer.*;
 
-public class Initializer implements ApplicationInitializedListener {
+public class Initializer extends PreloadingActivity implements StartupActivity {
     private TabNineDisablePluginListener listener;
     private BinaryNotificationsLifecycle binaryNotificationsLifecycle;
     private BinaryPromotionStatusBarLifecycle binaryPromotionStatusBarLifecycle;
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
 
     @Override
-    public void componentsInitialized() {
-        LogInitializerKt.init();
-        listener = singletonOfTabNineDisablePluginListener();
-        binaryNotificationsLifecycle = instanceOfBinaryNotifications();
-        binaryPromotionStatusBarLifecycle = instanceOfBinaryPromotionStatusBar();
-        PluginManagerCore.addDisablePluginListener(listener::onDisable);
-        PluginInstaller.addStateListener(instanceOfTabNinePluginStateListener());
-        binaryNotificationsLifecycle.poll();
-        binaryPromotionStatusBarLifecycle.poll();
-        CapabilitiesService.getInstance().init();
-        TabnineUpdater.pollUpdates();
+    public void preload(@NotNull ProgressIndicator indicator) {
+        initialize();
+    }
+
+    @Override
+    public void runActivity(@NotNull Project project) {
+        initialize();
+    }
+
+    private void initialize() {
+        if (!initialized.getAndSet(true)) {
+            LogInitializerKt.init();
+            listener = singletonOfTabNineDisablePluginListener();
+            binaryNotificationsLifecycle = instanceOfBinaryNotifications();
+            binaryPromotionStatusBarLifecycle = instanceOfBinaryPromotionStatusBar();
+            PluginManagerCore.addDisablePluginListener(listener::onDisable);
+            PluginInstaller.addStateListener(instanceOfTabNinePluginStateListener());
+            binaryNotificationsLifecycle.poll();
+            binaryPromotionStatusBarLifecycle.poll();
+            CapabilitiesService.getInstance().init();
+            TabnineUpdater.pollUpdates();
+        }
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -331,11 +331,13 @@
 
     <change-notes>Tabnine is always evolving. Most updates are in the binary sidecar.</change-notes>
 
-    <idea-version since-build="193.*"/>
+    <idea-version since-build="193"/>
     <depends>com.intellij.modules.lang</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <applicationInitializedListener implementation="com.tabnine.Initializer"/>
+<!--        <applicationInitializedListener implementation="com.tabnine.Initializer"/>-->
+        <preloadingActivity implementation="com.tabnine.Initializer"/>
+        <startupActivity implementation="com.tabnine.Initializer"/>
         <statusBarWidgetProvider implementation="com.tabnine.statusBar.StatusBarProvider"/>
         <statusBarWidgetProvider implementation="com.tabnine.statusBar.StatusBarPromotionProvider"/>
         <completion.contributor language="any" implementationClass="com.tabnine.intellij.completions.TabNineCompletionContributor" order="first"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -331,11 +331,11 @@
 
     <change-notes>Tabnine is always evolving. Most updates are in the binary sidecar.</change-notes>
 
-    <idea-version since-build="182.*"/>
+    <idea-version since-build="193.*"/>
     <depends>com.intellij.modules.lang</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <ApplicationLoadListener implementation="com.tabnine.Initializer"/>
+        <applicationInitializedListener implementation="com.tabnine.Initializer"/>
         <statusBarWidgetProvider implementation="com.tabnine.statusBar.StatusBarProvider"/>
         <statusBarWidgetProvider implementation="com.tabnine.statusBar.StatusBarPromotionProvider"/>
         <completion.contributor language="any" implementationClass="com.tabnine.intellij.completions.TabNineCompletionContributor" order="first"/>


### PR DESCRIPTION
1. fixed `Initializer` to use an api that's compatible with 2022.1 (eap)
2. compatibility jobs:
  2.1 on push: check compatibility against 2019.3 and current stable
  2.2 nightly: check compatibility against latest eap