### PR TITLE
use old_prefix instead of deprecated api

### DIFF
--- a/src/main/java/com/tabnine/inline/CompletionPreview.java
+++ b/src/main/java/com/tabnine/inline/CompletionPreview.java
@@ -165,7 +165,7 @@ public class CompletionPreview implements Disposable, EditorMouseMotionListener 
 
         try {
             TabNineCompletion currentCompletion = completions.get(previewIndex);
-            int startOffset = renderedOffset - currentCompletion.completionPrefix.length();
+            int startOffset = renderedOffset - currentCompletion.oldPrefix.length();
             int endOffset = renderedOffset + suffix.length();
             if (currentCompletion.oldSuffix != null && !currentCompletion.oldSuffix.trim().isEmpty()) {
                 int deletingEndOffset = renderedOffset + currentCompletion.oldSuffix.length();

--- a/src/main/java/com/tabnine/inline/CompletionState.java
+++ b/src/main/java/com/tabnine/inline/CompletionState.java
@@ -11,7 +11,6 @@ public class CompletionState {
     private static final Key<CompletionState> INLINE_COMPLETION_STATE =
             Key.create("INLINE_COMPLETION_STATE");
 
-    String prefix;
     int lastDisplayedCompletionIndex;
     boolean preInsertionHintShown;
     int lastStartOffset;

--- a/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
+++ b/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
@@ -84,7 +84,7 @@ public class TabnineDocumentListener implements DocumentListener {
             return;
         }
 
-        handler.invoke(project, editor, file, endOffset);
+        handler.invoke(editor, file, endOffset);
     }
 
     // counts `\n\t` as a single change too.

--- a/src/main/java/com/tabnine/intellij/completions/CompletionUtils.java
+++ b/src/main/java/com/tabnine/intellij/completions/CompletionUtils.java
@@ -30,7 +30,6 @@ public class CompletionUtils {
     @NotNull
     public static TabNineCompletion createTabnineCompletion(
             @NotNull Document document,
-            String newPrefix,
             int offset,
             String oldPrefix,
             ResultEntry result,
@@ -42,7 +41,6 @@ public class CompletionUtils {
                         result.old_suffix,
                         result.new_suffix,
                         index,
-                        newPrefix,
                         CompletionUtils.getCursorPrefix(document, offset),
                         CompletionUtils.getCursorSuffix(document, offset),
                         result.origin,

--- a/src/main/java/com/tabnine/intellij/completions/TabNineCompletionContributor.java
+++ b/src/main/java/com/tabnine/intellij/completions/TabNineCompletionContributor.java
@@ -69,7 +69,7 @@ public class TabNineCompletionContributor extends CompletionContributor {
         final Lookup activeLookup = LookupManager.getActiveLookup(parameters.getEditor());
         for (int index = 0; index < completions.results.length && index < CompletionUtils.completionLimit(parameters, resultSet, completions.is_locked); index++) {
             LookupElement lookupElement = createCompletion(
-                    parameters, resultSet, completions.old_prefix,
+                    parameters, completions.old_prefix,
                     completions.results[index], index, completions.is_locked, activeLookup);
 
             if (resultSet.getPrefixMatcher().prefixMatches(lookupElement)) {
@@ -81,12 +81,11 @@ public class TabNineCompletionContributor extends CompletionContributor {
     }
 
     @NotNull
-    private LookupElement createCompletion(CompletionParameters parameters, CompletionResultSet resultSet,
+    private LookupElement createCompletion(CompletionParameters parameters,
                                                   String oldPrefix, ResultEntry result, int index,
                                            boolean locked, @Nullable Lookup activeLookup) {
         TabNineCompletion completion = CompletionUtils.createTabnineCompletion(
                 parameters.getEditor().getDocument(),
-                resultSet.getPrefixMatcher().getPrefix(),
                 parameters.getOffset(),
                 oldPrefix,
                 result,

--- a/src/main/java/com/tabnine/prediction/TabNineCompletion.java
+++ b/src/main/java/com/tabnine/prediction/TabNineCompletion.java
@@ -15,7 +15,6 @@ public class TabNineCompletion {
     public final String oldSuffix;
     public final String newSuffix;
     public final int index;
-    public String completionPrefix;
     public String cursorPrefix;
     public String cursorSuffix;
     public CompletionOrigin origin;
@@ -25,13 +24,12 @@ public class TabNineCompletion {
     public String detail = null;
     public boolean deprecated = false;
 
-    public TabNineCompletion(String oldPrefix, String newPrefix, String oldSuffix, String newSuffix, int index, String completionPrefix, String cursorPrefix, String cursorSuffix, CompletionOrigin origin, CompletionKind completionKind, Boolean isCached) {
+    public TabNineCompletion(String oldPrefix, String newPrefix, String oldSuffix, String newSuffix, int index, String cursorPrefix, String cursorSuffix, CompletionOrigin origin, CompletionKind completionKind, Boolean isCached) {
         this.oldPrefix = oldPrefix;
         this.newPrefix = newPrefix;
         this.oldSuffix = oldSuffix;
         this.newSuffix = newSuffix;
         this.index = index;
-        this.completionPrefix = completionPrefix;
         this.cursorPrefix = cursorPrefix;
         this.cursorSuffix = cursorSuffix;
         this.origin = origin;
@@ -45,7 +43,7 @@ public class TabNineCompletion {
 
     public String getSuffix() {
         String itemText = this.newPrefix + this.newSuffix;
-        String prefix = this.completionPrefix;
+        String prefix = this.oldPrefix;
         if (prefix.isEmpty()) {
             return itemText;
         }

--- a/src/main/java/com/tabnine/selections/CompletionPreviewListener.java
+++ b/src/main/java/com/tabnine/selections/CompletionPreviewListener.java
@@ -25,9 +25,9 @@ public class CompletionPreviewListener {
         SelectionRequest selection = new SelectionRequest();
 
         selection.language = SelectionUtil.asLanguage(data.file.getName());
-        selection.netLength = completion.newPrefix.replaceFirst("^" + completion.completionPrefix, "").length();
+        selection.netLength = completion.newPrefix.replaceFirst("^" + completion.oldPrefix, "").length();
         selection.linePrefixLength = completion.cursorPrefix.length();
-        selection.lineNetPrefixLength = selection.linePrefixLength - completion.completionPrefix.length();
+        selection.lineNetPrefixLength = selection.linePrefixLength - completion.oldPrefix.length();
         selection.lineSuffixLength = completion.cursorSuffix.length();
         selection.index = data.previewIndex;
         selection.origin = completion.origin;

--- a/src/main/java/com/tabnine/selections/TabNineLookupListener.java
+++ b/src/main/java/com/tabnine/selections/TabNineLookupListener.java
@@ -59,9 +59,9 @@ public class TabNineLookupListener implements LookupListener {
             SelectionRequest selection = new SelectionRequest();
 
             selection.language = SelectionUtil.asLanguage(event.getLookup().getPsiFile().getName());
-            selection.netLength = item.newPrefix.replaceFirst("^" + item.completionPrefix, "").length();
+            selection.netLength = item.newPrefix.replaceFirst("^" + item.oldPrefix, "").length();
             selection.linePrefixLength = item.cursorPrefix.length();
-            selection.lineNetPrefixLength = selection.linePrefixLength - item.completionPrefix.length();
+            selection.lineNetPrefixLength = selection.linePrefixLength - item.oldPrefix.length();
             selection.lineSuffixLength = item.cursorSuffix.length();
             selection.index = ((LookupImpl) event.getLookup()).getSelectedIndex();
             selection.origin = item.origin;


### PR DESCRIPTION
Follow up on https://github.com/codota/tabnine-intellij/pull/278

Instead of the deprecated api `CompletionData.findPrefixStatic`, using `old_prefix` field from the binary (This is also how our vscode plugin handles it).