### PR TITLE
add google formatter + ci job to check format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,28 @@ jobs:
       - name: Validate the plugin
         run: ./gradlew runPluginVerifier -PlocalPaths="$(pwd)/latest"
 
+  format:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Check Java Formatting
+        run: ./gradlew verGJF --warning-mode all
+
+      - name: Check Kotlin Formatting
+        run: ./gradlew ktlintCheck
+
   security:
     name: Vulnerabilities Scanning
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'org.jetbrains.intellij' version '1.2.0'
     id 'org.jlleitschuh.gradle.ktlint' version "10.0.0"
     id 'org.jlleitschuh.gradle.ktlint-idea' version "10.0.0"
+    id "com.github.sherter.google-java-format" version "0.9"
 }
 
 group 'com.tabnine'

--- a/channels/alpha/com/tabnine/config/Config.java
+++ b/channels/alpha/com/tabnine/config/Config.java
@@ -1,7 +1,7 @@
 package com.tabnine.config;
 
 public class Config {
-    public final static String CHANNEL = "alpha";
-    public final static Boolean DISPLAY_ORIGIN = true;
-    public final static String LOGGER_HOST = "https://tabnine-logs-gateway.herokuapp.com";
+  public static final String CHANNEL = "alpha";
+  public static final Boolean DISPLAY_ORIGIN = true;
+  public static final String LOGGER_HOST = "https://tabnine-logs-gateway.herokuapp.com";
 }

--- a/channels/beta/com/tabnine/config/Config.java
+++ b/channels/beta/com/tabnine/config/Config.java
@@ -1,7 +1,7 @@
 package com.tabnine.config;
 
 public class Config {
-    public final static String CHANNEL = "beta";
-    public final static Boolean DISPLAY_ORIGIN = false;
-    public final static String LOGGER_HOST = "https://tabnine-logs-gateway.herokuapp.com";
+  public static final String CHANNEL = "beta";
+  public static final Boolean DISPLAY_ORIGIN = false;
+  public static final String LOGGER_HOST = "https://tabnine-logs-gateway.herokuapp.com";
 }

--- a/channels/production/com/tabnine/config/Config.java
+++ b/channels/production/com/tabnine/config/Config.java
@@ -1,7 +1,7 @@
 package com.tabnine.config;
 
 public class Config {
-    public final static String CHANNEL = "production";
-    public final static Boolean DISPLAY_ORIGIN = false;
-    public final static String LOGGER_HOST = "https://tabnine-logs-gateway.herokuapp.com";
+  public static final String CHANNEL = "production";
+  public static final Boolean DISPLAY_ORIGIN = false;
+  public static final String LOGGER_HOST = "https://tabnine-logs-gateway.herokuapp.com";
 }

--- a/src/main/java/com/tabnine/Initializer.java
+++ b/src/main/java/com/tabnine/Initializer.java
@@ -1,5 +1,7 @@
 package com.tabnine;
 
+import static com.tabnine.general.DependencyContainer.*;
+
 import com.intellij.ide.plugins.PluginInstaller;
 import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.application.PreloadingActivity;
@@ -12,40 +14,37 @@ import com.tabnine.lifecycle.BinaryPromotionStatusBarLifecycle;
 import com.tabnine.lifecycle.TabNineDisablePluginListener;
 import com.tabnine.lifecycle.TabnineUpdater;
 import com.tabnine.logging.LogInitializerKt;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static com.tabnine.general.DependencyContainer.*;
-
 public class Initializer extends PreloadingActivity implements StartupActivity {
-    private TabNineDisablePluginListener listener;
-    private BinaryNotificationsLifecycle binaryNotificationsLifecycle;
-    private BinaryPromotionStatusBarLifecycle binaryPromotionStatusBarLifecycle;
-    private final AtomicBoolean initialized = new AtomicBoolean(false);
+  private TabNineDisablePluginListener listener;
+  private BinaryNotificationsLifecycle binaryNotificationsLifecycle;
+  private BinaryPromotionStatusBarLifecycle binaryPromotionStatusBarLifecycle;
+  private final AtomicBoolean initialized = new AtomicBoolean(false);
 
-    @Override
-    public void preload(@NotNull ProgressIndicator indicator) {
-        initialize();
-    }
+  @Override
+  public void preload(@NotNull ProgressIndicator indicator) {
+    initialize();
+  }
 
-    @Override
-    public void runActivity(@NotNull Project project) {
-        initialize();
-    }
+  @Override
+  public void runActivity(@NotNull Project project) {
+    initialize();
+  }
 
-    private void initialize() {
-        if (!initialized.getAndSet(true)) {
-            LogInitializerKt.init();
-            listener = singletonOfTabNineDisablePluginListener();
-            binaryNotificationsLifecycle = instanceOfBinaryNotifications();
-            binaryPromotionStatusBarLifecycle = instanceOfBinaryPromotionStatusBar();
-            PluginManagerCore.addDisablePluginListener(listener::onDisable);
-            PluginInstaller.addStateListener(instanceOfTabNinePluginStateListener());
-            binaryNotificationsLifecycle.poll();
-            binaryPromotionStatusBarLifecycle.poll();
-            CapabilitiesService.getInstance().init();
-            TabnineUpdater.pollUpdates();
-        }
+  private void initialize() {
+    if (!initialized.getAndSet(true)) {
+      LogInitializerKt.init();
+      listener = singletonOfTabNineDisablePluginListener();
+      binaryNotificationsLifecycle = instanceOfBinaryNotifications();
+      binaryPromotionStatusBarLifecycle = instanceOfBinaryPromotionStatusBar();
+      PluginManagerCore.addDisablePluginListener(listener::onDisable);
+      PluginInstaller.addStateListener(instanceOfTabNinePluginStateListener());
+      binaryNotificationsLifecycle.poll();
+      binaryPromotionStatusBarLifecycle.poll();
+      CapabilitiesService.getInstance().init();
+      TabnineUpdater.pollUpdates();
     }
+  }
 }

--- a/src/main/java/com/tabnine/TabnineFileTypeFactory.java
+++ b/src/main/java/com/tabnine/TabnineFileTypeFactory.java
@@ -6,18 +6,16 @@ import org.jetbrains.annotations.NotNull;
 
 // https://plugins.jetbrains.com/docs/marketplace/intellij-plugin-recommendations.html#file-type
 public class TabnineFileTypeFactory extends FileTypeFactory {
-    @Override
-    public void createFileTypes(@NotNull FileTypeConsumer consumer) {
-        consumer.consume(TabnineIgnoreFileType.INSANCE);
-        consumer.consume(TabnineRootFileType.INSTANCE);
-        consumer.consume(TabnineProjectModelFileType.INSTANCE);
-        consumer.consume(TabnineProjectModelFileType.INSTANCE, "tabnine");
-        consumer.consume(TabnineProjectModelFileType.INSTANCE, ".tabnine");
-        consumer.consume(TabnineProjectModelFileType.INSTANCE, "tabnine.model");
-        consumer.consume(TabnineProjectModelFileType.INSTANCE, ".tabnine.model");
-        consumer.consume(TabnineProjectModelFileType.INSTANCE, "model");
-        consumer.consume(TabnineProjectModelFileType.INSTANCE, ".model");
-
-
-    }
+  @Override
+  public void createFileTypes(@NotNull FileTypeConsumer consumer) {
+    consumer.consume(TabnineIgnoreFileType.INSANCE);
+    consumer.consume(TabnineRootFileType.INSTANCE);
+    consumer.consume(TabnineProjectModelFileType.INSTANCE);
+    consumer.consume(TabnineProjectModelFileType.INSTANCE, "tabnine");
+    consumer.consume(TabnineProjectModelFileType.INSTANCE, ".tabnine");
+    consumer.consume(TabnineProjectModelFileType.INSTANCE, "tabnine.model");
+    consumer.consume(TabnineProjectModelFileType.INSTANCE, ".tabnine.model");
+    consumer.consume(TabnineProjectModelFileType.INSTANCE, "model");
+    consumer.consume(TabnineProjectModelFileType.INSTANCE, ".model");
+  }
 }

--- a/src/main/java/com/tabnine/TabnineIgnoreFileType.java
+++ b/src/main/java/com/tabnine/TabnineIgnoreFileType.java
@@ -3,50 +3,50 @@ package com.tabnine;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.tabnine.general.StaticConfig;
+import javax.swing.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
-
 public class TabnineIgnoreFileType implements FileType {
-    public static TabnineIgnoreFileType INSANCE = new TabnineIgnoreFileType();
-    @NotNull
-    @Override
-    public String getName() {
-        return "Tabnine ignore file";
-    }
+  public static TabnineIgnoreFileType INSANCE = new TabnineIgnoreFileType();
 
-    @NotNull
-    @Override
-    public String getDescription() {
-        return "Tabnine ignore file";
-    }
+  @NotNull
+  @Override
+  public String getName() {
+    return "Tabnine ignore file";
+  }
 
-    @NotNull
-    @Override
-    public String getDefaultExtension() {
-        return "tabnineignore";
-    }
+  @NotNull
+  @Override
+  public String getDescription() {
+    return "Tabnine ignore file";
+  }
 
-    @Nullable
-    @Override
-    public Icon getIcon() {
-        return StaticConfig.ICON;
-    }
+  @NotNull
+  @Override
+  public String getDefaultExtension() {
+    return "tabnineignore";
+  }
 
-    @Override
-    public boolean isBinary() {
-        return false;
-    }
+  @Nullable
+  @Override
+  public Icon getIcon() {
+    return StaticConfig.ICON;
+  }
 
-    @Override
-    public boolean isReadOnly() {
-        return false;
-    }
+  @Override
+  public boolean isBinary() {
+    return false;
+  }
 
-    @Nullable
-    @Override
-    public String getCharset(@NotNull VirtualFile file, @NotNull byte[] content) {
-        return null;
-    }
+  @Override
+  public boolean isReadOnly() {
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public String getCharset(@NotNull VirtualFile file, @NotNull byte[] content) {
+    return null;
+  }
 }

--- a/src/main/java/com/tabnine/TabnineProjectModelFileType.java
+++ b/src/main/java/com/tabnine/TabnineProjectModelFileType.java
@@ -3,50 +3,50 @@ package com.tabnine;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.tabnine.general.StaticConfig;
+import javax.swing.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
-
 public class TabnineProjectModelFileType implements FileType {
-    public static TabnineProjectModelFileType INSTANCE = new TabnineProjectModelFileType();
-    @NotNull
-    @Override
-    public String getName() {
-        return "Tabnine project model file";
-    }
+  public static TabnineProjectModelFileType INSTANCE = new TabnineProjectModelFileType();
 
-    @NotNull
-    @Override
-    public String getDescription() {
-        return "Tabnine project model file";
-    }
+  @NotNull
+  @Override
+  public String getName() {
+    return "Tabnine project model file";
+  }
 
-    @NotNull
-    @Override
-    public String getDefaultExtension() {
-        return "tabnine.model";
-    }
+  @NotNull
+  @Override
+  public String getDescription() {
+    return "Tabnine project model file";
+  }
 
-    @Nullable
-    @Override
-    public Icon getIcon() {
-        return StaticConfig.ICON;
-    }
+  @NotNull
+  @Override
+  public String getDefaultExtension() {
+    return "tabnine.model";
+  }
 
-    @Override
-    public boolean isBinary() {
-        return false;
-    }
+  @Nullable
+  @Override
+  public Icon getIcon() {
+    return StaticConfig.ICON;
+  }
 
-    @Override
-    public boolean isReadOnly() {
-        return false;
-    }
+  @Override
+  public boolean isBinary() {
+    return false;
+  }
 
-    @Nullable
-    @Override
-    public String getCharset(@NotNull VirtualFile file, @NotNull byte[] content) {
-        return null;
-    }
+  @Override
+  public boolean isReadOnly() {
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public String getCharset(@NotNull VirtualFile file, @NotNull byte[] content) {
+    return null;
+  }
 }

--- a/src/main/java/com/tabnine/TabnineRootFileType.java
+++ b/src/main/java/com/tabnine/TabnineRootFileType.java
@@ -3,50 +3,50 @@ package com.tabnine;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.tabnine.general.StaticConfig;
+import javax.swing.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
-
 public class TabnineRootFileType implements FileType {
-    public static TabnineRootFileType INSTANCE = new TabnineRootFileType();
-    @NotNull
-    @Override
-    public String getName() {
-        return "Tabnine root file";
-    }
+  public static TabnineRootFileType INSTANCE = new TabnineRootFileType();
 
-    @NotNull
-    @Override
-    public String getDescription() {
-        return "Tabnine root file";
-    }
+  @NotNull
+  @Override
+  public String getName() {
+    return "Tabnine root file";
+  }
 
-    @NotNull
-    @Override
-    public String getDefaultExtension() {
-        return "tabnine_root";
-    }
+  @NotNull
+  @Override
+  public String getDescription() {
+    return "Tabnine root file";
+  }
 
-    @Nullable
-    @Override
-    public Icon getIcon() {
-        return StaticConfig.ICON;
-    }
+  @NotNull
+  @Override
+  public String getDefaultExtension() {
+    return "tabnine_root";
+  }
 
-    @Override
-    public boolean isBinary() {
-        return false;
-    }
+  @Nullable
+  @Override
+  public Icon getIcon() {
+    return StaticConfig.ICON;
+  }
 
-    @Override
-    public boolean isReadOnly() {
-        return false;
-    }
+  @Override
+  public boolean isBinary() {
+    return false;
+  }
 
-    @Nullable
-    @Override
-    public String getCharset(@NotNull VirtualFile file, @NotNull byte[] content) {
-        return null;
-    }
+  @Override
+  public boolean isReadOnly() {
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public String getCharset(@NotNull VirtualFile file, @NotNull byte[] content) {
+    return null;
+  }
 }

--- a/src/main/java/com/tabnine/binary/BinaryProcessGatewayProvider.java
+++ b/src/main/java/com/tabnine/binary/BinaryProcessGatewayProvider.java
@@ -1,7 +1,7 @@
 package com.tabnine.binary;
 
 public class BinaryProcessGatewayProvider {
-    public BinaryProcessGateway generateBinaryProcessGateway() {
-        return new BinaryProcessGateway();
-    }
+  public BinaryProcessGateway generateBinaryProcessGateway() {
+    return new BinaryProcessGateway();
+  }
 }

--- a/src/main/java/com/tabnine/binary/BinaryProcessRequester.java
+++ b/src/main/java/com/tabnine/binary/BinaryProcessRequester.java
@@ -4,10 +4,8 @@ import com.tabnine.binary.exceptions.TabNineDeadException;
 import org.jetbrains.annotations.Nullable;
 
 public interface BinaryProcessRequester {
-    @Nullable
-    <R extends BinaryResponse> R request(BinaryRequest<R> request) throws TabNineDeadException;
+  @Nullable
+  <R extends BinaryResponse> R request(BinaryRequest<R> request) throws TabNineDeadException;
 
-    void destroy();
+  void destroy();
 }
-
-

--- a/src/main/java/com/tabnine/binary/BinaryProcessRequesterImpl.java
+++ b/src/main/java/com/tabnine/binary/BinaryProcessRequesterImpl.java
@@ -1,82 +1,84 @@
 package com.tabnine.binary;
 
-import com.intellij.openapi.diagnostic.Logger;
-import com.tabnine.binary.exceptions.TabNineDeadException;
-import com.tabnine.binary.exceptions.TabNineInvalidResponseException;
-
-import org.jetbrains.annotations.Nullable;
-import java.io.IOException;
-
 import static com.tabnine.general.StaticConfig.ILLEGAL_RESPONSE_THRESHOLD;
 import static com.tabnine.general.StaticConfig.wrapWithBinaryRequest;
 
+import com.intellij.openapi.diagnostic.Logger;
+import com.tabnine.binary.exceptions.TabNineDeadException;
+import com.tabnine.binary.exceptions.TabNineInvalidResponseException;
+import java.io.IOException;
+import org.jetbrains.annotations.Nullable;
+
 public class BinaryProcessRequesterImpl implements BinaryProcessRequester {
-    private int illegalResponsesGiven = 0;
+  private int illegalResponsesGiven = 0;
 
-    private final ParsedBinaryIO parsedBinaryIO;
+  private final ParsedBinaryIO parsedBinaryIO;
 
-    public BinaryProcessRequesterImpl(ParsedBinaryIO parsedBinaryIO) {
-        this.parsedBinaryIO = parsedBinaryIO;
+  public BinaryProcessRequesterImpl(ParsedBinaryIO parsedBinaryIO) {
+    this.parsedBinaryIO = parsedBinaryIO;
+  }
+
+  /**
+   * Request a prediction from TabNine's binary.
+   *
+   * @param request
+   * @return an AutocompleteResponse
+   * @throws TabNineDeadException if process's dead.
+   * @throws TabNineDeadException if process's BufferedReader has reached its end (also mean
+   *     dead...).
+   * @throws TabNineDeadException if there was an IOException communicating to the process.
+   * @throws TabNineDeadException if the result from the process was invalid multiple times.
+   */
+  @Override
+  @Nullable
+  public synchronized <R extends BinaryResponse> R request(BinaryRequest<R> request)
+      throws TabNineDeadException {
+    if (parsedBinaryIO.isDead()) {
+      throw new TabNineDeadException("Binary is dead");
     }
 
-    /**
-     * Request a prediction from TabNine's binary.
-     *
-     * @param request
-     * @return an AutocompleteResponse
-     * @throws TabNineDeadException if process's dead.
-     * @throws TabNineDeadException if process's BufferedReader has reached its end (also mean dead...).
-     * @throws TabNineDeadException if there was an IOException communicating to the process.
-     * @throws TabNineDeadException if the result from the process was invalid multiple times.
-     */
-    @Override
-    @Nullable
-    public synchronized <R extends BinaryResponse> R request(BinaryRequest<R> request) throws TabNineDeadException {
-        if (parsedBinaryIO.isDead()) {
-            throw new TabNineDeadException("Binary is dead");
-        }
+    try {
+      parsedBinaryIO.writeRequest(wrapWithBinaryRequest(request.serialize()));
 
-        try {
-            parsedBinaryIO.writeRequest(wrapWithBinaryRequest(request.serialize()));
+      return readResult(request);
+    } catch (IOException e) {
+      Logger.getInstance(getClass()).warn("Exception communicating with the binary", e);
 
-            return readResult(request);
-        } catch (IOException e) {
-            Logger.getInstance(getClass()).warn("Exception communicating with the binary", e);
-
-            throw new TabNineDeadException(e);
-        }
+      throw new TabNineDeadException(e);
     }
+  }
 
-    @Override
-    public void destroy() {
-        parsedBinaryIO.destroy();
+  @Override
+  public void destroy() {
+    parsedBinaryIO.destroy();
+  }
+
+  @Nullable
+  private <R extends BinaryResponse> R readResult(BinaryRequest<R> request)
+      throws IOException, TabNineDeadException {
+    try {
+      R response = parsedBinaryIO.readResponse(request.response());
+
+      if (!request.validate(response)) {
+        throw new TabNineInvalidResponseException();
+      }
+
+      this.illegalResponsesGiven = 0;
+
+      return response;
+    } catch (TabNineInvalidResponseException exception) {
+      if (request.shouldBeAllowed(exception)) {
+        return null;
+      }
+
+      if (++illegalResponsesGiven > ILLEGAL_RESPONSE_THRESHOLD) {
+        illegalResponsesGiven = 0;
+        throw new TabNineDeadException("Too many illegal responses given");
+      } else {
+        Logger.getInstance(getClass()).warn(exception);
+
+        return null;
+      }
     }
-
-    @Nullable
-    private <R extends BinaryResponse> R readResult(BinaryRequest<R> request) throws IOException, TabNineDeadException {
-        try {
-            R response = parsedBinaryIO.readResponse(request.response());
-
-            if (!request.validate(response)) {
-                throw new TabNineInvalidResponseException();
-            }
-
-            this.illegalResponsesGiven = 0;
-
-            return response;
-        } catch (TabNineInvalidResponseException exception) {
-            if (request.shouldBeAllowed(exception)) {
-                return null;
-            }
-
-            if (++illegalResponsesGiven > ILLEGAL_RESPONSE_THRESHOLD) {
-                illegalResponsesGiven = 0;
-                throw new TabNineDeadException("Too many illegal responses given");
-            } else {
-                Logger.getInstance(getClass()).warn(exception);
-
-                return null;
-            }
-        }
-    }
+  }
 }

--- a/src/main/java/com/tabnine/binary/BinaryProcessRequesterPoller.java
+++ b/src/main/java/com/tabnine/binary/BinaryProcessRequesterPoller.java
@@ -2,7 +2,6 @@ package com.tabnine.binary;
 
 import com.tabnine.binary.exceptions.TabNineDeadException;
 
-
 public interface BinaryProcessRequesterPoller {
-    void pollUntilReady(BinaryProcessGateway binaryProcessGateway) throws TabNineDeadException;
+  void pollUntilReady(BinaryProcessGateway binaryProcessGateway) throws TabNineDeadException;
 }

--- a/src/main/java/com/tabnine/binary/BinaryProcessRequesterPollerCappedImpl.java
+++ b/src/main/java/com/tabnine/binary/BinaryProcessRequesterPollerCappedImpl.java
@@ -1,76 +1,79 @@
 package com.tabnine.binary;
 
+import static com.intellij.util.concurrency.AppExecutorUtil.getAppExecutorService;
+import static com.tabnine.general.StaticConfig.wrapWithBinaryRequest;
+
 import com.google.gson.GsonBuilder;
 import com.intellij.openapi.diagnostic.Logger;
 import com.tabnine.binary.exceptions.TabNineDeadException;
 import com.tabnine.binary.requests.config.StateRequest;
 import com.tabnine.binary.requests.config.StateResponse;
-
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import static com.intellij.util.concurrency.AppExecutorUtil.getAppExecutorService;
-import static com.tabnine.general.StaticConfig.wrapWithBinaryRequest;
+public class BinaryProcessRequesterPollerCappedImpl implements BinaryProcessRequesterPoller {
 
-public class BinaryProcessRequesterPollerCappedImpl implements BinaryProcessRequesterPoller  {
+  // number of times it will poll until ready
+  public int pollAttempts;
+  // sleep time between poll attempts to binary
+  public int pollSleepIntervalMillis;
 
-    // number of times it will poll until ready
-    public int pollAttempts;
-    // sleep time between poll attempts to binary
-    public int pollSleepIntervalMillis;
+  public int requestTimeoutMillis;
 
-    public int requestTimeoutMillis;
+  public BinaryProcessRequesterPollerCappedImpl(
+      int pollAttempts, int pollSleepIntervalMillis, int requestTimeoutMillis) {
+    this.pollAttempts = pollAttempts;
+    this.pollSleepIntervalMillis = pollSleepIntervalMillis;
+    this.requestTimeoutMillis = requestTimeoutMillis;
+  }
 
-    public BinaryProcessRequesterPollerCappedImpl(int pollAttempts, int pollSleepIntervalMillis, int requestTimeoutMillis) {
-        this.pollAttempts = pollAttempts;
-        this.pollSleepIntervalMillis = pollSleepIntervalMillis;
-        this.requestTimeoutMillis = requestTimeoutMillis;
+  @Override
+  public void pollUntilReady(BinaryProcessGateway binaryProcessGateway)
+      throws TabNineDeadException {
+    if (this.pollAttempts <= 0) {
+      return;
     }
 
+    ParsedBinaryIO parsedBinaryIO =
+        new ParsedBinaryIO(new GsonBuilder().create(), binaryProcessGateway);
+    int remaining = this.pollAttempts;
+    long startTime = System.currentTimeMillis();
+    while (remaining > 0) {
+      remaining--;
+      StateRequest stateRequest = new StateRequest();
+      try {
 
-    @Override
-    public void pollUntilReady(BinaryProcessGateway binaryProcessGateway) throws TabNineDeadException {
-        if (this.pollAttempts <= 0) {
-            return;
+        StateResponse stateResponse =
+            getAppExecutorService()
+                .submit(() -> makeStateRequest(parsedBinaryIO, stateRequest))
+                .get(this.requestTimeoutMillis, TimeUnit.MILLISECONDS);
+        if (stateResponse != null) {
+          long end = System.currentTimeMillis();
+          Logger.getInstance(getClass()).info("polling took " + (end - startTime) + "ms");
+          return;
         }
+      } catch (Exception e) {
+        // debug log this since it can re-try and don't want to send to sentry
+        Logger.getInstance(getClass()).debug("polling failed with error");
+        System.out.println(e);
+      }
+      try {
+        Thread.sleep(pollSleepIntervalMillis);
+      } catch (InterruptedException e) {
 
-        ParsedBinaryIO parsedBinaryIO = new ParsedBinaryIO(new GsonBuilder().create(), binaryProcessGateway);
-        int remaining = this.pollAttempts;
-        long startTime = System.currentTimeMillis();
-        while (remaining > 0) {
-            remaining--;
-            StateRequest stateRequest = new StateRequest();
-            try {
-
-                StateResponse stateResponse = getAppExecutorService()
-                        .submit(() -> makeStateRequest(parsedBinaryIO, stateRequest))
-                        .get(this.requestTimeoutMillis, TimeUnit.MILLISECONDS);
-                if (stateResponse != null) {
-                    long end = System.currentTimeMillis();
-                    Logger.getInstance(getClass()).info("polling took " + (end - startTime) + "ms");
-                    return;
-                }
-            } catch (Exception e) {
-                // debug log this since it can re-try and don't want to send to sentry
-                Logger.getInstance(getClass()).debug("polling failed with error");
-                System.out.println(e);
-            }
-            try {
-                Thread.sleep(pollSleepIntervalMillis);
-            } catch (InterruptedException e) {
-
-            }
-        }
-
-        TabNineDeadException exception = new TabNineDeadException("binary polling failed");
-        // this will be sent to sentry
-        Logger.getInstance(getClass()).warn("binary polling failed", exception);
-        throw  exception;
+      }
     }
 
-    private StateResponse makeStateRequest(ParsedBinaryIO parsedBinaryIO, StateRequest stateRequest) throws IOException, com.tabnine.binary.exceptions.TabNineDeadException, com.tabnine.binary.exceptions.TabNineInvalidResponseException {
-        parsedBinaryIO.writeRequest(wrapWithBinaryRequest(stateRequest.serialize()));
-        return parsedBinaryIO.readResponse(stateRequest.response());
-    }
+    TabNineDeadException exception = new TabNineDeadException("binary polling failed");
+    // this will be sent to sentry
+    Logger.getInstance(getClass()).warn("binary polling failed", exception);
+    throw exception;
+  }
+
+  private StateResponse makeStateRequest(ParsedBinaryIO parsedBinaryIO, StateRequest stateRequest)
+      throws IOException, com.tabnine.binary.exceptions.TabNineDeadException,
+          com.tabnine.binary.exceptions.TabNineInvalidResponseException {
+    parsedBinaryIO.writeRequest(wrapWithBinaryRequest(stateRequest.serialize()));
+    return parsedBinaryIO.readResponse(stateRequest.response());
+  }
 }

--- a/src/main/java/com/tabnine/binary/BinaryProcessRequesterProvider.java
+++ b/src/main/java/com/tabnine/binary/BinaryProcessRequesterProvider.java
@@ -1,123 +1,139 @@
 package com.tabnine.binary;
 
+import static com.tabnine.general.StaticConfig.*;
+import static java.util.Collections.singletonMap;
+
 import com.google.gson.GsonBuilder;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.tabnine.binary.exceptions.BinaryCannotRecoverException;
 import com.tabnine.binary.exceptions.NoValidBinaryToRunException;
 import com.tabnine.binary.exceptions.TabNineDeadException;
-
 import java.io.IOException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeoutException;
-
-import static com.tabnine.general.StaticConfig.*;
-import static java.util.Collections.singletonMap;
 
 public class BinaryProcessRequesterProvider {
-    private final BinaryRun binaryRun;
-    private final BinaryProcessGatewayProvider binaryProcessGatewayProvider;
+  private final BinaryRun binaryRun;
+  private final BinaryProcessGatewayProvider binaryProcessGatewayProvider;
 
-    private int consecutiveRestarts = 0;
-    private int consecutiveTimeouts = 0;
-    private BinaryProcessRequesterPoller poller;
-    private BinaryProcessRequester binaryProcessRequester;
-    private Future<?> binaryInit;
+  private int consecutiveRestarts = 0;
+  private int consecutiveTimeouts = 0;
+  private BinaryProcessRequesterPoller poller;
+  private BinaryProcessRequester binaryProcessRequester;
+  private Future<?> binaryInit;
 
-    private BinaryProcessRequesterProvider(BinaryRun binaryRun, BinaryProcessGatewayProvider binaryProcessGatewayProvider, BinaryProcessRequesterPoller poller) {
-        this.binaryRun = binaryRun;
-        this.binaryProcessGatewayProvider = binaryProcessGatewayProvider;
-        this.poller = poller;
+  private BinaryProcessRequesterProvider(
+      BinaryRun binaryRun,
+      BinaryProcessGatewayProvider binaryProcessGatewayProvider,
+      BinaryProcessRequesterPoller poller) {
+    this.binaryRun = binaryRun;
+    this.binaryProcessGatewayProvider = binaryProcessGatewayProvider;
+    this.poller = poller;
+  }
+
+  public static BinaryProcessRequesterProvider create(
+      BinaryRun binaryRun,
+      BinaryProcessGatewayProvider binaryProcessGatewayProvider,
+      BinaryProcessRequesterPoller poller) {
+    BinaryProcessRequesterProvider binaryProcessRequesterProvider =
+        new BinaryProcessRequesterProvider(binaryRun, binaryProcessGatewayProvider, poller);
+
+    binaryProcessRequesterProvider.createNew();
+
+    return binaryProcessRequesterProvider;
+  }
+
+  public BinaryProcessRequester get() {
+    if (isStarting()) {
+      Logger.getInstance(getClass())
+          .info("Can't get completions because Tabnine process is not started yet.");
+
+      return VoidBinaryProcessRequester.instance();
     }
 
-    public static BinaryProcessRequesterProvider create(BinaryRun binaryRun,
-                                                        BinaryProcessGatewayProvider binaryProcessGatewayProvider,
-                                                        BinaryProcessRequesterPoller poller) {
-        BinaryProcessRequesterProvider binaryProcessRequesterProvider = new BinaryProcessRequesterProvider(binaryRun, binaryProcessGatewayProvider, poller);
+    return binaryProcessRequester;
+  }
 
-        binaryProcessRequesterProvider.createNew();
+  public void onSuccessfulRequest() {
+    consecutiveTimeouts = 0;
+    consecutiveRestarts = 0;
+  }
 
-        return binaryProcessRequesterProvider;
+  public void onDead(Throwable e) {
+    consecutiveTimeouts = 0;
+    Logger.getInstance(getClass()).warn("Tabnine is in invalid state, it is being restarted.", e);
+
+    if (++consecutiveRestarts > CONSECUTIVE_RESTART_THRESHOLD) {
+      // NOTICE: In the production version of IntelliJ, logging an error kills the plugin. So this
+      // is similar to exit(1);
+      Logger.getInstance(getClass())
+          .error(
+              "Tabnine is not able to function properly. Contact support@tabnine.com",
+              new BinaryCannotRecoverException());
+    } else {
+      createNew();
     }
+  }
 
-    public BinaryProcessRequester get() {
-        if(isStarting()) {
-            Logger.getInstance(getClass()).info("Can't get completions because Tabnine process is not started yet.");
+  public void onTimeout() {
+    Logger.getInstance(getClass()).info("TabNine's response timed out.");
 
-            return VoidBinaryProcessRequester.instance();
-        }
-
-        return binaryProcessRequester;
+    if (++consecutiveTimeouts >= CONSECUTIVE_TIMEOUTS_THRESHOLD) {
+      Logger.getInstance(getClass())
+          .warn(
+              "Requests to TabNine's binary are consistently taking too long. Restarting the binary.");
+      createNew();
     }
+  }
 
-    public void onSuccessfulRequest() {
-        consecutiveTimeouts = 0;
-        consecutiveRestarts = 0;
+  private boolean isStarting() {
+    return this.binaryInit == null || !this.binaryInit.isDone();
+  }
+
+  private void createNew() {
+    if (binaryProcessRequester != null) {
+      binaryProcessRequester.destroy();
     }
+    BinaryProcessGateway binaryProcessGateway =
+        binaryProcessGatewayProvider.generateBinaryProcessGateway();
 
-    public void onDead(Throwable e) {
-        consecutiveTimeouts = 0;
-        Logger.getInstance(getClass()).warn("Tabnine is in invalid state, it is being restarted.", e);
+    initProcess(binaryProcessGateway);
 
-        if (++consecutiveRestarts > CONSECUTIVE_RESTART_THRESHOLD) {
-            // NOTICE: In the production version of IntelliJ, logging an error kills the plugin. So this is similar to exit(1);
-            Logger.getInstance(getClass()).error("Tabnine is not able to function properly. Contact support@tabnine.com", new BinaryCannotRecoverException());
-        } else {
-            createNew();
-        }
-    }
+    this.binaryProcessRequester =
+        new BinaryProcessRequesterImpl(
+            new ParsedBinaryIO(new GsonBuilder().create(), binaryProcessGateway));
+  }
 
-    public void onTimeout() {
-        Logger.getInstance(getClass()).info("TabNine's response timed out.");
-
-        if (++consecutiveTimeouts >= CONSECUTIVE_TIMEOUTS_THRESHOLD) {
-            Logger.getInstance(getClass()).warn("Requests to TabNine's binary are consistently taking too long. Restarting the binary.");
-            createNew();
-        }
-    }
-
-    private boolean isStarting() {
-        return this.binaryInit == null || !this.binaryInit.isDone();
-    }
-
-    private void createNew() {
-        if(binaryProcessRequester != null) {
-            binaryProcessRequester.destroy();
-        }
-        BinaryProcessGateway binaryProcessGateway = binaryProcessGatewayProvider.generateBinaryProcessGateway();
-
-
-        initProcess(binaryProcessGateway);
-
-        this.binaryProcessRequester = new BinaryProcessRequesterImpl(new ParsedBinaryIO(new GsonBuilder().create(), binaryProcessGateway));
-
-
-    }
-
-    private void initProcess(BinaryProcessGateway binaryProcessGateway) {
-        binaryInit = AppExecutorUtil.getAppExecutorService().submit(() -> {
-            for (int attempt = 0; shouldTryStartingBinary(attempt); attempt++) {
-                try {
-                    binaryProcessGateway.init(binaryRun.generateRunCommand(singletonMap("ide-restart-counter", consecutiveRestarts)));
-
-                    break;
-                } catch (IOException | NoValidBinaryToRunException e) {
-                    Logger.getInstance(getClass()).warn("Error restarting TabNine. Will try again.", e);
-
+  private void initProcess(BinaryProcessGateway binaryProcessGateway) {
+    binaryInit =
+        AppExecutorUtil.getAppExecutorService()
+            .submit(
+                () -> {
+                  for (int attempt = 0; shouldTryStartingBinary(attempt); attempt++) {
                     try {
+                      binaryProcessGateway.init(
+                          binaryRun.generateRunCommand(
+                              singletonMap("ide-restart-counter", consecutiveRestarts)));
+
+                      break;
+                    } catch (IOException | NoValidBinaryToRunException e) {
+                      Logger.getInstance(getClass())
+                          .warn("Error restarting TabNine. Will try again.", e);
+
+                      try {
                         sleepUponFailure(attempt);
-                    } catch (InterruptedException e2) {
-                        Logger.getInstance(getClass()).warn("TabNine was interrupted between restart attempts.", e);
+                      } catch (InterruptedException e2) {
+                        Logger.getInstance(getClass())
+                            .warn("TabNine was interrupted between restart attempts.", e);
+                      }
                     }
-                }
-            }
-            try {
-                poller.pollUntilReady(binaryProcessGateway);
-            } catch (TabNineDeadException e) {
-                Logger.getInstance(getClass()).warn("timed out polling binary for ready status", e);
-            }
-        });
-    }
-
+                  }
+                  try {
+                    poller.pollUntilReady(binaryProcessGateway);
+                  } catch (TabNineDeadException e) {
+                    Logger.getInstance(getClass())
+                        .warn("timed out polling binary for ready status", e);
+                  }
+                });
+  }
 }
-

--- a/src/main/java/com/tabnine/binary/BinaryRequest.java
+++ b/src/main/java/com/tabnine/binary/BinaryRequest.java
@@ -4,14 +4,15 @@ import com.tabnine.binary.exceptions.TabNineInvalidResponseException;
 import org.jetbrains.annotations.NotNull;
 
 public interface BinaryRequest<R extends BinaryResponse> {
-    Class<R> response();
-    Object serialize();
+  Class<R> response();
 
-    default boolean validate(@NotNull R response) {
-        return true;
-    }
-    
-    default boolean shouldBeAllowed(@NotNull TabNineInvalidResponseException e) {
-        return false;
-    }
+  Object serialize();
+
+  default boolean validate(@NotNull R response) {
+    return true;
+  }
+
+  default boolean shouldBeAllowed(@NotNull TabNineInvalidResponseException e) {
+    return false;
+  }
 }

--- a/src/main/java/com/tabnine/binary/BinaryRequestFacade.java
+++ b/src/main/java/com/tabnine/binary/BinaryRequestFacade.java
@@ -1,55 +1,56 @@
 package com.tabnine.binary;
 
+import static com.intellij.util.concurrency.AppExecutorUtil.getAppExecutorService;
+import static com.tabnine.general.StaticConfig.COMPLETION_TIME_THRESHOLD;
+
 import com.intellij.openapi.diagnostic.Logger;
 import com.tabnine.binary.exceptions.TabNineDeadException;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import static com.intellij.util.concurrency.AppExecutorUtil.getAppExecutorService;
-import static com.tabnine.general.StaticConfig.COMPLETION_TIME_THRESHOLD;
+import org.jetbrains.annotations.Nullable;
 
 public class BinaryRequestFacade {
-    private final BinaryProcessRequesterProvider binaryProcessRequesterProvider;
+  private final BinaryProcessRequesterProvider binaryProcessRequesterProvider;
 
-    public BinaryRequestFacade(BinaryProcessRequesterProvider binaryProcessRequesterProvider) {
-        this.binaryProcessRequesterProvider = binaryProcessRequesterProvider;
+  public BinaryRequestFacade(BinaryProcessRequesterProvider binaryProcessRequesterProvider) {
+    this.binaryProcessRequesterProvider = binaryProcessRequesterProvider;
+  }
+
+  public <R extends BinaryResponse> R executeRequest(BinaryRequest<R> req) {
+    return executeRequest(req, COMPLETION_TIME_THRESHOLD);
+  }
+
+  @Nullable
+  public <R extends BinaryResponse> R executeRequest(BinaryRequest<R> req, int timeoutMillis) {
+    BinaryProcessRequester binaryProcessRequester = binaryProcessRequesterProvider.get();
+
+    try {
+      R result =
+          getAppExecutorService()
+              .submit(() -> binaryProcessRequester.request(req))
+              .get(timeoutMillis, TimeUnit.MILLISECONDS);
+
+      if (result != null) {
+        binaryProcessRequesterProvider.onSuccessfulRequest();
+      }
+
+      return result;
+    } catch (TimeoutException e) {
+      binaryProcessRequesterProvider.onTimeout();
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof TabNineDeadException) {
+        binaryProcessRequesterProvider.onDead(e.getCause());
+      }
+
+      Logger.getInstance(getClass()).warn("Tabnine's threw an unknown error during request.", e);
+    } catch (CancellationException e) {
+      // This is ok. Nothing needs to be done.
+    } catch (Exception e) {
+      Logger.getInstance(getClass()).warn("Tabnine's threw an unknown error.", e);
     }
 
-    public <R extends BinaryResponse> R executeRequest(BinaryRequest<R> req) {
-        return executeRequest(req, COMPLETION_TIME_THRESHOLD);
-    }
-
-    @Nullable
-    public <R extends BinaryResponse> R executeRequest(BinaryRequest<R> req, int timeoutMillis) {
-        BinaryProcessRequester binaryProcessRequester = binaryProcessRequesterProvider.get();
-
-        try {
-            R result = getAppExecutorService().submit(() -> binaryProcessRequester.request(req))
-                    .get(timeoutMillis, TimeUnit.MILLISECONDS);
-
-            if(result != null) {
-                binaryProcessRequesterProvider.onSuccessfulRequest();
-            }
-
-            return result;
-        } catch (TimeoutException e) {
-            binaryProcessRequesterProvider.onTimeout();
-        } catch (ExecutionException e) {
-            if (e.getCause() instanceof TabNineDeadException) {
-                binaryProcessRequesterProvider.onDead(e.getCause());
-            }
-
-            Logger.getInstance(getClass()).warn("Tabnine's threw an unknown error during request.", e);
-        } catch (CancellationException e) {
-            // This is ok. Nothing needs to be done.
-        } catch (Exception e) {
-            Logger.getInstance(getClass()).warn("Tabnine's threw an unknown error.", e);
-        }
-
-        return null;
-    }
+    return null;
+  }
 }

--- a/src/main/java/com/tabnine/binary/BinaryResponse.java
+++ b/src/main/java/com/tabnine/binary/BinaryResponse.java
@@ -1,4 +1,3 @@
 package com.tabnine.binary;
 
-public interface BinaryResponse {
-}
+public interface BinaryResponse {}

--- a/src/main/java/com/tabnine/binary/BinaryRun.java
+++ b/src/main/java/com/tabnine/binary/BinaryRun.java
@@ -1,21 +1,5 @@
 package com.tabnine.binary;
 
-import com.intellij.openapi.application.ApplicationInfo;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.util.PlatformUtils;
-import com.tabnine.binary.exceptions.NoValidBinaryToRunException;
-import com.tabnine.binary.exceptions.TabNineDeadException;
-import com.tabnine.binary.fetch.BinaryVersionFetcher;
-import com.tabnine.config.Config;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import com.intellij.openapi.application.PermanentInstallationID;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import static com.tabnine.general.StaticConfig.UNINSTALLING_FLAG;
 import static com.tabnine.general.StaticConfig.getLogFilePath;
 import static com.tabnine.general.Utils.cmdSanitize;
@@ -23,72 +7,94 @@ import static com.tabnine.general.Utils.getTabNinePluginVersion;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.PermanentInstallationID;
+import com.intellij.util.PlatformUtils;
+import com.tabnine.binary.exceptions.NoValidBinaryToRunException;
+import com.tabnine.binary.exceptions.TabNineDeadException;
+import com.tabnine.binary.fetch.BinaryVersionFetcher;
+import com.tabnine.config.Config;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 public class BinaryRun {
-    private final BinaryVersionFetcher binaryFetcher;
+  private final BinaryVersionFetcher binaryFetcher;
 
-    public BinaryRun(BinaryVersionFetcher binaryFetcher) {
-        this.binaryFetcher = binaryFetcher;
+  public BinaryRun(BinaryVersionFetcher binaryFetcher) {
+    this.binaryFetcher = binaryFetcher;
+  }
+
+  @NotNull
+  public List<String> generateRunCommand(@Nullable Map<String, Object> additionalMetadata)
+      throws NoValidBinaryToRunException {
+    List<String> command = new ArrayList<>(singletonList(binaryFetcher.fetchBinary()));
+
+    command.addAll(getBinaryConstantParameters(additionalMetadata));
+
+    return command;
+  }
+
+  public Process reportUninstall(@Nullable Map<String, Object> additionalMetadata)
+      throws NoValidBinaryToRunException, TabNineDeadException {
+    String fullLocation = binaryFetcher.fetchBinary();
+    List<String> command = new ArrayList<>(asList(fullLocation, UNINSTALLING_FLAG));
+
+    command.addAll(getBinaryConstantParameters(additionalMetadata));
+
+    try {
+      return new ProcessBuilder(command).start();
+    } catch (IOException e) {
+      throw new TabNineDeadException(e, fullLocation);
     }
+  }
 
-    @NotNull
-    public List<String> generateRunCommand(@Nullable Map<String, Object> additionalMetadata) throws NoValidBinaryToRunException {
-        List<String> command = new ArrayList<>(singletonList(binaryFetcher.fetchBinary()));
+  private ArrayList<String> getBinaryConstantParameters(
+      @Nullable Map<String, Object> additionalMetadata) {
+    ArrayList<String> constantParameters = new ArrayList<>();
 
-        command.addAll(getBinaryConstantParameters(additionalMetadata));
+    if (ApplicationManager.getApplication() != null
+        && !ApplicationManager.getApplication().isUnitTestMode()) {
+      List<String> metadata =
+          new ArrayList<>(
+              asList(
+                  "--client-metadata",
+                  "pluginVersion=" + cmdSanitize(getTabNinePluginVersion()),
+                  "clientIsUltimate=" + PlatformUtils.isIdeaUltimate(),
+                  "clientChannel=" + Config.CHANNEL,
+                  "pluginUserId=" + PermanentInstallationID.get()));
+      final ApplicationInfo applicationInfo = ApplicationInfo.getInstance();
 
-        return command;
-    }
+      if (applicationInfo != null) {
+        constantParameters.add("--client");
+        constantParameters.add(cmdSanitize(applicationInfo.getVersionName()));
+        constantParameters.add("--no-lsp");
+        constantParameters.add("true");
 
-    public Process reportUninstall(@Nullable Map<String, Object> additionalMetadata) throws NoValidBinaryToRunException, TabNineDeadException {
-        String fullLocation = binaryFetcher.fetchBinary();
-        List<String> command = new ArrayList<>(asList(fullLocation, UNINSTALLING_FLAG));
+        metadata.add("clientVersion=" + cmdSanitize(applicationInfo.getFullVersion()));
+        metadata.add("clientApiVersion=" + cmdSanitize(applicationInfo.getApiVersion()));
+      }
 
-        command.addAll(getBinaryConstantParameters(additionalMetadata));
+      if (additionalMetadata != null) {
+        additionalMetadata.forEach(
+            (key, value) ->
+                metadata.add(String.format("%s=%s", key, cmdSanitize(value.toString()))));
+      }
 
-        try {
-            return new ProcessBuilder(command).start();
-        } catch (IOException e) {
-            throw new TabNineDeadException(e, fullLocation);
-        }
-    }
-
-    private ArrayList<String> getBinaryConstantParameters(@Nullable Map<String, Object> additionalMetadata) {
-        ArrayList<String> constantParameters = new ArrayList<>();
-
-        if (ApplicationManager.getApplication() != null && !ApplicationManager.getApplication().isUnitTestMode()) {
-            List<String> metadata = new ArrayList<>(asList(
-                    "--client-metadata",
-                    "pluginVersion=" + cmdSanitize(getTabNinePluginVersion()),
-                    "clientIsUltimate=" + PlatformUtils.isIdeaUltimate(),
-                    "clientChannel=" + Config.CHANNEL,
-                    "pluginUserId=" + PermanentInstallationID.get()
-            ));
-            final ApplicationInfo applicationInfo = ApplicationInfo.getInstance();
-
-            if (applicationInfo != null) {
-                constantParameters.add("--client");
-                constantParameters.add(cmdSanitize(applicationInfo.getVersionName()));
-                constantParameters.add("--no-lsp");
-                constantParameters.add("true");
-
-                metadata.add("clientVersion=" + cmdSanitize(applicationInfo.getFullVersion()));
-                metadata.add("clientApiVersion=" + cmdSanitize(applicationInfo.getApiVersion()));
-            }
-
-            if (additionalMetadata != null) {
-                additionalMetadata.forEach((key, value) ->
-                        metadata.add(String.format("%s=%s", key, cmdSanitize(value.toString()))));
-            }
-
-            getLogFilePath().ifPresent(v -> {
+      getLogFilePath()
+          .ifPresent(
+              v -> {
                 constantParameters.add("--log-file-path");
                 constantParameters.add(v);
-            });
+              });
 
-            constantParameters.addAll(metadata);
-        }
-
-        return constantParameters;
+      constantParameters.addAll(metadata);
     }
 
+    return constantParameters;
+  }
 }

--- a/src/main/java/com/tabnine/binary/ParsedBinaryIO.java
+++ b/src/main/java/com/tabnine/binary/ParsedBinaryIO.java
@@ -1,46 +1,48 @@
 package com.tabnine.binary;
 
+import static java.lang.String.format;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.tabnine.binary.exceptions.TabNineDeadException;
 import com.tabnine.binary.exceptions.TabNineInvalidResponseException;
-import org.jetbrains.annotations.NotNull;
-
 import java.io.IOException;
 import java.util.Optional;
-
-import static java.lang.String.format;
+import org.jetbrains.annotations.NotNull;
 
 public class ParsedBinaryIO {
-    private final Gson gson;
-    private final BinaryProcessGateway binaryProcessGateway;
+  private final Gson gson;
+  private final BinaryProcessGateway binaryProcessGateway;
 
-    public ParsedBinaryIO(Gson gson, BinaryProcessGateway binaryProcessGateway) {
-        this.gson = gson;
-        this.binaryProcessGateway = binaryProcessGateway;
+  public ParsedBinaryIO(Gson gson, BinaryProcessGateway binaryProcessGateway) {
+    this.gson = gson;
+    this.binaryProcessGateway = binaryProcessGateway;
+  }
+
+  @NotNull
+  public <R> R readResponse(Class<R> responseClass)
+      throws IOException, TabNineDeadException, TabNineInvalidResponseException {
+    String rawResponse = binaryProcessGateway.readRawResponse();
+
+    try {
+      return Optional.ofNullable(gson.fromJson(rawResponse, responseClass))
+          .orElseThrow(
+              () -> new TabNineInvalidResponseException("Binary returned null as a response"));
+    } catch (TabNineInvalidResponseException | JsonSyntaxException e) {
+      throw new TabNineInvalidResponseException(
+          format("Binary returned illegal response: %s", rawResponse), e, rawResponse);
     }
+  }
 
-    @NotNull
-    public <R> R readResponse(Class<R> responseClass) throws IOException, TabNineDeadException, TabNineInvalidResponseException {
-        String rawResponse = binaryProcessGateway.readRawResponse();
+  public void writeRequest(Object request) throws IOException {
+    binaryProcessGateway.writeRequest(gson.toJson(request) + "\n");
+  }
 
-        try {
-            return Optional.ofNullable(gson.fromJson(rawResponse, responseClass))
-                    .orElseThrow(() -> new TabNineInvalidResponseException("Binary returned null as a response"));
-        } catch (TabNineInvalidResponseException | JsonSyntaxException e) {
-            throw new TabNineInvalidResponseException(format("Binary returned illegal response: %s", rawResponse), e, rawResponse);
-        }
-    }
+  public boolean isDead() {
+    return binaryProcessGateway.isDead();
+  }
 
-    public void writeRequest(Object request) throws IOException {
-        binaryProcessGateway.writeRequest(gson.toJson(request) + "\n");
-    }
-
-    public boolean isDead() {
-        return binaryProcessGateway.isDead();
-    }
-
-    public void destroy() {
-        binaryProcessGateway.destroy();
-    }
+  public void destroy() {
+    binaryProcessGateway.destroy();
+  }
 }

--- a/src/main/java/com/tabnine/binary/SideEffectExecutor.java
+++ b/src/main/java/com/tabnine/binary/SideEffectExecutor.java
@@ -1,10 +1,9 @@
 package com.tabnine.binary;
 
 import com.tabnine.binary.exceptions.NoValidBinaryToRunException;
-
 import java.io.IOException;
 
 @FunctionalInterface
 public interface SideEffectExecutor {
-    void execute() throws IOException, NoValidBinaryToRunException;
+  void execute() throws IOException, NoValidBinaryToRunException;
 }

--- a/src/main/java/com/tabnine/binary/VoidBinaryProcessRequester.java
+++ b/src/main/java/com/tabnine/binary/VoidBinaryProcessRequester.java
@@ -4,19 +4,19 @@ import com.tabnine.binary.exceptions.TabNineDeadException;
 import org.jetbrains.annotations.Nullable;
 
 public class VoidBinaryProcessRequester implements BinaryProcessRequester {
-    private static final BinaryProcessRequester INSTANCE = new VoidBinaryProcessRequester();
+  private static final BinaryProcessRequester INSTANCE = new VoidBinaryProcessRequester();
 
-    public static BinaryProcessRequester instance() {
-        return INSTANCE;
-    }
+  public static BinaryProcessRequester instance() {
+    return INSTANCE;
+  }
 
-    @Nullable
-    @Override
-    public <R extends BinaryResponse> R request(BinaryRequest<R> request) throws TabNineDeadException {
-        return null;
-    }
+  @Nullable
+  @Override
+  public <R extends BinaryResponse> R request(BinaryRequest<R> request)
+      throws TabNineDeadException {
+    return null;
+  }
 
-    @Override
-    public void destroy() {
-    }
+  @Override
+  public void destroy() {}
 }

--- a/src/main/java/com/tabnine/binary/exceptions/BinaryCannotRecoverException.java
+++ b/src/main/java/com/tabnine/binary/exceptions/BinaryCannotRecoverException.java
@@ -1,7 +1,7 @@
 package com.tabnine.binary.exceptions;
 
 public class BinaryCannotRecoverException extends RuntimeException {
-    public BinaryCannotRecoverException() {
-        super();
-    }
+  public BinaryCannotRecoverException() {
+    super();
+  }
 }

--- a/src/main/java/com/tabnine/binary/exceptions/FailedToDownloadException.java
+++ b/src/main/java/com/tabnine/binary/exceptions/FailedToDownloadException.java
@@ -1,11 +1,11 @@
 package com.tabnine.binary.exceptions;
 
 public class FailedToDownloadException extends Exception {
-    public FailedToDownloadException(Throwable e) {
-        super(e);
-    }
+  public FailedToDownloadException(Throwable e) {
+    super(e);
+  }
 
-    public FailedToDownloadException(String s) {
-        super(s);
-    }
+  public FailedToDownloadException(String s) {
+    super(s);
+  }
 }

--- a/src/main/java/com/tabnine/binary/exceptions/InvalidVersionPathException.kt
+++ b/src/main/java/com/tabnine/binary/exceptions/InvalidVersionPathException.kt
@@ -1,0 +1,3 @@
+package com.tabnine.binary.exceptions
+
+class InvalidVersionPathException(version: String) : RuntimeException("Given version path is invalid: '$version'")

--- a/src/main/java/com/tabnine/binary/exceptions/NoValidBinaryToRunException.java
+++ b/src/main/java/com/tabnine/binary/exceptions/NoValidBinaryToRunException.java
@@ -1,4 +1,3 @@
 package com.tabnine.binary.exceptions;
 
-public class NoValidBinaryToRunException extends Exception {
-}
+public class NoValidBinaryToRunException extends Exception {}

--- a/src/main/java/com/tabnine/binary/exceptions/TabNineDeadException.java
+++ b/src/main/java/com/tabnine/binary/exceptions/TabNineDeadException.java
@@ -1,26 +1,26 @@
 package com.tabnine.binary.exceptions;
 
 public class TabNineDeadException extends Exception {
-    private String location = null;
+  private String location = null;
 
-    public TabNineDeadException() {
-        super();
-    }
+  public TabNineDeadException() {
+    super();
+  }
 
-    public TabNineDeadException(Exception e) {
-        super(e);
-    }
+  public TabNineDeadException(Exception e) {
+    super(e);
+  }
 
-    public TabNineDeadException(String message) {
-        super(message);
-    }
+  public TabNineDeadException(String message) {
+    super(message);
+  }
 
-    public TabNineDeadException(Exception e, String location) {
-        super(e);
-        this.location = location;
-    }
+  public TabNineDeadException(Exception e, String location) {
+    super(e);
+    this.location = location;
+  }
 
-    public String getLocation() {
-        return location;
-    }
+  public String getLocation() {
+    return location;
+  }
 }

--- a/src/main/java/com/tabnine/binary/exceptions/TabNineInvalidResponseException.java
+++ b/src/main/java/com/tabnine/binary/exceptions/TabNineInvalidResponseException.java
@@ -3,25 +3,24 @@ package com.tabnine.binary.exceptions;
 import java.util.Optional;
 
 public class TabNineInvalidResponseException extends Exception {
-    private final Optional<String> rawResponse;
+  private final Optional<String> rawResponse;
 
-    public TabNineInvalidResponseException() {
-        super();
-        this.rawResponse = Optional.empty();
-    }
+  public TabNineInvalidResponseException() {
+    super();
+    this.rawResponse = Optional.empty();
+  }
 
-    public TabNineInvalidResponseException(String s) {
-        super(s);
-        this.rawResponse = Optional.empty();
+  public TabNineInvalidResponseException(String s) {
+    super(s);
+    this.rawResponse = Optional.empty();
+  }
 
-    }
+  public TabNineInvalidResponseException(String format, Exception e, String rawResponse) {
+    super(format, e);
+    this.rawResponse = Optional.ofNullable(rawResponse);
+  }
 
-    public TabNineInvalidResponseException(String format, Exception e, String rawResponse) {
-        super(format, e);
-        this.rawResponse = Optional.ofNullable(rawResponse);
-    }
-
-    public Optional<String> getRawResponse() {
-        return rawResponse;
-    }
+  public Optional<String> getRawResponse() {
+    return rawResponse;
+  }
 }

--- a/src/main/java/com/tabnine/binary/fetch/BinaryDownloader.java
+++ b/src/main/java/com/tabnine/binary/fetch/BinaryDownloader.java
@@ -1,24 +1,24 @@
 package com.tabnine.binary.fetch;
 
-import java.util.Optional;
-
 import static com.tabnine.general.StaticConfig.*;
 
+import java.util.Optional;
+
 public class BinaryDownloader {
-    private final TempBinaryValidator tempBinaryValidator;
-    private final GeneralDownloader downloader;
-    public BinaryDownloader(TempBinaryValidator tempBinaryValidator, GeneralDownloader downloader) {
-        this.tempBinaryValidator = tempBinaryValidator;
-        this.downloader = downloader;
-    }
+  private final TempBinaryValidator tempBinaryValidator;
+  private final GeneralDownloader downloader;
 
-    public Optional<BinaryVersion> downloadBinary(String version) {
-        String urlString = String.join("/", getServerUrl(), version, TARGET_NAME, EXECUTABLE_NAME);
-        String destination = versionFullPath(version);
-        if (this.downloader.download(urlString, destination, tempBinaryValidator)) {
-             return Optional.of(new BinaryVersion(destination, version));
-        }
-        return Optional.empty();
-    }
+  public BinaryDownloader(TempBinaryValidator tempBinaryValidator, GeneralDownloader downloader) {
+    this.tempBinaryValidator = tempBinaryValidator;
+    this.downloader = downloader;
+  }
 
+  public Optional<BinaryVersion> downloadBinary(String version) {
+    String urlString = String.join("/", getServerUrl(), version, TARGET_NAME, EXECUTABLE_NAME);
+    String destination = versionFullPath(version);
+    if (this.downloader.download(urlString, destination, tempBinaryValidator)) {
+      return Optional.of(new BinaryVersion(destination, version));
+    }
+    return Optional.empty();
+  }
 }

--- a/src/main/java/com/tabnine/binary/fetch/BinaryRemoteSource.java
+++ b/src/main/java/com/tabnine/binary/fetch/BinaryRemoteSource.java
@@ -1,53 +1,56 @@
 package com.tabnine.binary.fetch;
 
+import static com.tabnine.general.StaticConfig.getTabNineBetaVersionUrl;
+import static com.tabnine.general.Utils.readContent;
+
 import com.intellij.openapi.diagnostic.Logger;
 import com.tabnine.general.StaticConfig;
-import org.jetbrains.annotations.NotNull;
-
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.List;
 import java.util.Optional;
-
-import static com.tabnine.general.StaticConfig.getTabNineBetaVersionUrl;
-import static com.tabnine.general.Utils.readContent;
+import org.jetbrains.annotations.NotNull;
 
 public class BinaryRemoteSource {
-    @NotNull
-    public Optional<String> fetchPreferredVersion() {
-        return fetchPreferredVersion(StaticConfig.getTabNineVersionUrl());
+  @NotNull
+  public Optional<String> fetchPreferredVersion() {
+    return fetchPreferredVersion(StaticConfig.getTabNineVersionUrl());
+  }
+
+  public Optional<String> fetchPreferredVersion(String url) {
+    try {
+      return Optional.of(remoteVersionRequest(url));
+    } catch (IOException e) {
+      Logger.getInstance(getClass())
+          .warn("Request of current version failed. Falling back to latest local version.", e);
+      return Optional.empty();
+    }
+  }
+
+  @NotNull
+  public Optional<BinaryVersion> existingLocalBetaVersion(List<BinaryVersion> localVersions) {
+    try {
+      String remoteBetaVersion = remoteVersionRequest(getTabNineBetaVersionUrl());
+
+      return localVersions.stream()
+          .filter(version -> remoteBetaVersion.equals(version.getVersion()))
+          .findAny();
+    } catch (IOException e) {
+      Logger.getInstance(getClass())
+          .warn("Request of current version failed. Falling back to latest local version.", e);
     }
 
-    public Optional<String> fetchPreferredVersion(String url) {
-        try {
-            return Optional.of(remoteVersionRequest(url));
-        } catch (IOException e) {
-            Logger.getInstance(getClass()).warn("Request of current version failed. Falling back to latest local version.", e);
-            return Optional.empty();
-        }
-    }
+    return Optional.empty();
+  }
 
-    @NotNull
-    public Optional<BinaryVersion> existingLocalBetaVersion(List<BinaryVersion> localVersions) {
-        try {
-            String remoteBetaVersion = remoteVersionRequest(getTabNineBetaVersionUrl());
+  @NotNull
+  private String remoteVersionRequest(String url) throws IOException {
+    URLConnection connection = new URL(url).openConnection();
 
-            return localVersions.stream().filter(version -> remoteBetaVersion.equals(version.getVersion())).findAny();
-        } catch (IOException e) {
-            Logger.getInstance(getClass()).warn("Request of current version failed. Falling back to latest local version.", e);
-        }
+    connection.setConnectTimeout(StaticConfig.REMOTE_CONNECTION_TIMEOUT);
+    connection.setReadTimeout(StaticConfig.REMOTE_CONNECTION_TIMEOUT);
 
-        return Optional.empty();
-    }
-
-    @NotNull
-    private String remoteVersionRequest(String url) throws IOException {
-        URLConnection connection = new URL(url).openConnection();
-
-        connection.setConnectTimeout(StaticConfig.REMOTE_CONNECTION_TIMEOUT);
-        connection.setReadTimeout(StaticConfig.REMOTE_CONNECTION_TIMEOUT);
-
-        return readContent(connection.getInputStream());
-    }
+    return readContent(connection.getInputStream());
+  }
 }

--- a/src/main/java/com/tabnine/binary/fetch/BinaryValidator.java
+++ b/src/main/java/com/tabnine/binary/fetch/BinaryValidator.java
@@ -1,34 +1,40 @@
 package com.tabnine.binary.fetch;
 
-import com.intellij.openapi.diagnostic.Logger;
+import static java.lang.String.format;
 
+import com.intellij.openapi.diagnostic.Logger;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 
-import static java.lang.String.format;
-
 public class BinaryValidator {
-    public boolean isWorking(String binaryFullPath) {
-        File binaryFile = new File(binaryFullPath);
+  public boolean isWorking(String binaryFullPath) {
+    File binaryFile = new File(binaryFullPath);
 
-        // we test only absolute paths because otherwise we would have to search $PATH
-        // which java has no built in support for
-        if (binaryFile.isAbsolute() && !binaryFile.exists()) {
-            return false;
-        }
-
-        ProcessBuilder binary = new ProcessBuilder(binaryFullPath, "--print-version");
-
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(binary.start().getInputStream(), StandardCharsets.UTF_8))) {
-            if (reader.readLine() != null) {
-                return true;
-            }
-        } catch (Exception e) {
-            Logger.getInstance(getClass()).warn(format("Tabnine binary at `%s` was queried for it's version and failed to respond.", binaryFullPath), e);
-        }
-
-        return false;
+    // we test only absolute paths because otherwise we would have to search $PATH
+    // which java has no built in support for
+    if (binaryFile.isAbsolute() && !binaryFile.exists()) {
+      return false;
     }
+
+    ProcessBuilder binary = new ProcessBuilder(binaryFullPath, "--print-version");
+
+    try (BufferedReader reader =
+        new BufferedReader(
+            new InputStreamReader(binary.start().getInputStream(), StandardCharsets.UTF_8))) {
+      if (reader.readLine() != null) {
+        return true;
+      }
+    } catch (Exception e) {
+      Logger.getInstance(getClass())
+          .warn(
+              format(
+                  "Tabnine binary at `%s` was queried for it's version and failed to respond.",
+                  binaryFullPath),
+              e);
+    }
+
+    return false;
+  }
 }

--- a/src/main/java/com/tabnine/binary/fetch/BinaryVersion.java
+++ b/src/main/java/com/tabnine/binary/fetch/BinaryVersion.java
@@ -1,51 +1,53 @@
 package com.tabnine.binary.fetch;
 
-import java.util.Objects;
-
 import static com.tabnine.general.StaticConfig.versionFullPath;
 
+import java.util.Objects;
+
 public class BinaryVersion {
-    private final String versionFullPath;
-    private final String version;
+  private final String versionFullPath;
+  private final String version;
 
-    public BinaryVersion(String versionFullPath, String version) {
-        this.versionFullPath = versionFullPath;
-        this.version = version;
-    }
+  public BinaryVersion(String versionFullPath, String version) {
+    this.versionFullPath = versionFullPath;
+    this.version = version;
+  }
 
-    public BinaryVersion(String version) {
-        this(versionFullPath(version), version);
-    }
+  public BinaryVersion(String version) {
+    this(versionFullPath(version), version);
+  }
 
-    public String getVersionFullPath() {
-        return versionFullPath;
-    }
+  public String getVersionFullPath() {
+    return versionFullPath;
+  }
 
-    public String getVersion() {
-        return version;
-    }
+  public String getVersion() {
+    return version;
+  }
 
-    @Override
-    public String toString() {
-        return "BinaryVersions{" +
-                "versionFullPath='" + versionFullPath + '\'' +
-                ", version='" + version + '\'' +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "BinaryVersions{"
+        + "versionFullPath='"
+        + versionFullPath
+        + '\''
+        + ", version='"
+        + version
+        + '\''
+        + '}';
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        BinaryVersion that = (BinaryVersion) o;
-        return Objects.equals(versionFullPath, that.versionFullPath) &&
-                Objects.equals(version, that.version);
-    }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    BinaryVersion that = (BinaryVersion) o;
+    return Objects.equals(versionFullPath, that.versionFullPath)
+        && Objects.equals(version, that.version);
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(versionFullPath, version);
-    }
-
-
+  @Override
+  public int hashCode() {
+    return Objects.hash(versionFullPath, version);
+  }
 }

--- a/src/main/java/com/tabnine/binary/fetch/BinaryVersionFetcher.java
+++ b/src/main/java/com/tabnine/binary/fetch/BinaryVersionFetcher.java
@@ -1,67 +1,88 @@
 package com.tabnine.binary.fetch;
 
+import static java.lang.String.format;
+
 import com.intellij.openapi.diagnostic.Logger;
 import com.tabnine.binary.exceptions.NoValidBinaryToRunException;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static java.lang.String.format;
-
 public class BinaryVersionFetcher {
-    private LocalBinaryVersions localBinaryVersions;
-    private BinaryRemoteSource binaryRemoteSource;
-    private BinaryDownloader binaryDownloader;
-    private BundleDownloader bundleDownloader;
+  private LocalBinaryVersions localBinaryVersions;
+  private BinaryRemoteSource binaryRemoteSource;
+  private BinaryDownloader binaryDownloader;
+  private BundleDownloader bundleDownloader;
 
-    public BinaryVersionFetcher(LocalBinaryVersions localBinaryVersions, BinaryRemoteSource binaryRemoteSource, BinaryDownloader binaryDownloader, BundleDownloader bundleDownloader) {
-        this.localBinaryVersions = localBinaryVersions;
-        this.binaryRemoteSource = binaryRemoteSource;
-        this.binaryDownloader = binaryDownloader;
-        this.bundleDownloader = bundleDownloader;
+  public BinaryVersionFetcher(
+      LocalBinaryVersions localBinaryVersions,
+      BinaryRemoteSource binaryRemoteSource,
+      BinaryDownloader binaryDownloader,
+      BundleDownloader bundleDownloader) {
+    this.localBinaryVersions = localBinaryVersions;
+    this.binaryRemoteSource = binaryRemoteSource;
+    this.binaryDownloader = binaryDownloader;
+    this.bundleDownloader = bundleDownloader;
+  }
+
+  /**
+   * Fetchs TabNine's preferred version from remote server, downloads it if it is not available, and
+   * returns the path to run it.
+   *
+   * @return path of the binary to run
+   * @throws SecurityException, NoExistingBinaryException if something went wrong
+   */
+  public String fetchBinary() throws NoValidBinaryToRunException {
+    Optional<BinaryVersion> bootstrappedVersion =
+        BootstrapperSupport.bootstrapVersion(
+            localBinaryVersions, binaryRemoteSource, bundleDownloader);
+    if (bootstrappedVersion.isPresent()) {
+      Logger.getInstance(getClass())
+          .info(format("found local bootstrapped version %s", bootstrappedVersion.get()));
+      return bootstrappedVersion.get().getVersionFullPath();
+    }
+    Logger.getInstance(getClass())
+        .warn("couldn't get bootstrapped version. fallback to legacy code!");
+    List<BinaryVersion> versions = localBinaryVersions.listExisting();
+
+    Optional<BinaryVersion> preferredBetaVersion =
+        binaryRemoteSource.existingLocalBetaVersion(versions);
+
+    if (preferredBetaVersion.isPresent()) {
+      Logger.getInstance(getClass())
+          .info(
+              format(
+                  "Binary latest beta version %s was found locally, so it is being preferred.",
+                  preferredBetaVersion.get().getVersion()));
+
+      return preferredBetaVersion.get().getVersionFullPath();
     }
 
-    /**
-     * Fetchs TabNine's preferred version from remote server, downloads it if it is not available, and returns the path to run it.
-     *
-     * @return path of the binary to run
-     * @throws SecurityException, NoExistingBinaryException if something went wrong
-     */
-    public String fetchBinary() throws NoValidBinaryToRunException {
-        Optional<BinaryVersion> bootstrappedVersion = BootstrapperSupport.bootstrapVersion(localBinaryVersions, binaryRemoteSource, bundleDownloader);
-        if (bootstrappedVersion.isPresent()) {
-            Logger.getInstance(getClass()).info(format("found local bootstrapped version %s", bootstrappedVersion.get()));
-            return bootstrappedVersion.get().getVersionFullPath();
-        }
-        Logger.getInstance(getClass()).warn("couldn't get bootstrapped version. fallback to legacy code!");
-        List<BinaryVersion> versions = localBinaryVersions.listExisting();
+    return binaryRemoteSource
+        .fetchPreferredVersion()
+        .map(getLocalOrDownload(versions))
+        .orElseGet(versions.stream()::findFirst)
+        .map(BinaryVersion::getVersionFullPath)
+        .orElseThrow(NoValidBinaryToRunException::new);
+  }
 
-        Optional<BinaryVersion> preferredBetaVersion = binaryRemoteSource.existingLocalBetaVersion(versions);
+  private Function<String, Optional<BinaryVersion>> getLocalOrDownload(
+      List<BinaryVersion> versions) {
+    return preferred -> {
+      Optional<BinaryVersion> localVersion =
+          versions.stream().filter(version -> preferred.equals(version.getVersion())).findAny();
 
-        if (preferredBetaVersion.isPresent()) {
-            Logger.getInstance(getClass()).info(format("Binary latest beta version %s was found locally, so it is being preferred.", preferredBetaVersion.get().getVersion()));
+      if (localVersion.isPresent()) {
+        return localVersion;
+      }
 
-            return preferredBetaVersion.get().getVersionFullPath();
-        }
+      Logger.getInstance(getClass())
+          .info(
+              format(
+                  "Current binary version %s not found locally, it is being downloaded.",
+                  preferred));
 
-        return binaryRemoteSource.fetchPreferredVersion().map(getLocalOrDownload(versions))
-                .orElseGet(versions.stream()::findFirst)
-                .map(BinaryVersion::getVersionFullPath)
-                .orElseThrow(NoValidBinaryToRunException::new);
-    }
-
-    private Function<String, Optional<BinaryVersion>> getLocalOrDownload(List<BinaryVersion> versions) {
-        return preferred -> {
-            Optional<BinaryVersion> localVersion = versions.stream().filter(version -> preferred.equals(version.getVersion())).findAny();
-
-            if (localVersion.isPresent()) {
-                return localVersion;
-            }
-
-            Logger.getInstance(getClass()).info(format("Current binary version %s not found locally, it is being downloaded.", preferred));
-
-            return binaryDownloader.downloadBinary(preferred);
-        };
-    }
+      return binaryDownloader.downloadBinary(preferred);
+    };
+  }
 }

--- a/src/main/java/com/tabnine/binary/fetch/BootstrapperSupport.java
+++ b/src/main/java/com/tabnine/binary/fetch/BootstrapperSupport.java
@@ -2,50 +2,59 @@ package com.tabnine.binary.fetch;
 
 import com.intellij.util.text.SemVer;
 import com.tabnine.general.StaticConfig;
-
 import java.util.Optional;
 import java.util.prefs.Preferences;
 
 // bootstrapper support class
 // once out of beta/alpha all of this code can replace the existing fetchBinary()
 public class BootstrapperSupport {
-    static Optional<BinaryVersion> bootstrapVersion(LocalBinaryVersions localBinaryVersions, BinaryRemoteSource binaryRemoteSource, BundleDownloader bundleDownloader) {
-        Optional<BinaryVersion> localBootstrapVersion = locateLocalBootstrapSupportedVersion(localBinaryVersions);
-        return localBootstrapVersion.isPresent() ? localBootstrapVersion : downloadRemoteVersion(binaryRemoteSource, bundleDownloader);
-    }
+  static Optional<BinaryVersion> bootstrapVersion(
+      LocalBinaryVersions localBinaryVersions,
+      BinaryRemoteSource binaryRemoteSource,
+      BundleDownloader bundleDownloader) {
+    Optional<BinaryVersion> localBootstrapVersion =
+        locateLocalBootstrapSupportedVersion(localBinaryVersions);
+    return localBootstrapVersion.isPresent()
+        ? localBootstrapVersion
+        : downloadRemoteVersion(binaryRemoteSource, bundleDownloader);
+  }
 
-    public static final String BOOTSTRAPPED_VERSION_KEY = "bootstrapped version";
+  public static final String BOOTSTRAPPED_VERSION_KEY = "bootstrapped version";
 
-    private static Preferences getPrefs() {
-        return Preferences.userNodeForPackage(BootstrapperSupport.class);
-    }
+  private static Preferences getPrefs() {
+    return Preferences.userNodeForPackage(BootstrapperSupport.class);
+  }
 
-    private static BinaryVersion savePreferredBootstrapVersion(BinaryVersion version) {
-        getPrefs().put(BOOTSTRAPPED_VERSION_KEY, version.getVersion());
-        return version;
-    }
+  private static BinaryVersion savePreferredBootstrapVersion(BinaryVersion version) {
+    getPrefs().put(BOOTSTRAPPED_VERSION_KEY, version.getVersion());
+    return version;
+  }
 
-    private static Optional<SemVer> minimalBootstrappedVersion() {
-        return Optional.ofNullable(getPrefs().get(BOOTSTRAPPED_VERSION_KEY, null)).map(SemVer::parseFromText);
-    }
+  private static Optional<SemVer> minimalBootstrappedVersion() {
+    return Optional.ofNullable(getPrefs().get(BOOTSTRAPPED_VERSION_KEY, null))
+        .map(SemVer::parseFromText);
+  }
 
-    private static Optional<BinaryVersion> locateLocalBootstrapSupportedVersion(LocalBinaryVersions localBinaryVersions) {
-        return minimalBootstrappedVersion().flatMap(
-                version -> {
-                    Optional<BinaryVersion> activeVersion = localBinaryVersions.activeVersion();
-                    if (activeVersion.isPresent()) return activeVersion;
+  private static Optional<BinaryVersion> locateLocalBootstrapSupportedVersion(
+      LocalBinaryVersions localBinaryVersions) {
+    return minimalBootstrappedVersion()
+        .flatMap(
+            version -> {
+              Optional<BinaryVersion> activeVersion = localBinaryVersions.activeVersion();
+              if (activeVersion.isPresent()) return activeVersion;
 
-                    return localBinaryVersions
-                                .listExisting()
-                                .stream()
-                                .filter(v -> SemVer.parseFromText(v.getVersion()) != null)
-                                .filter(v -> SemVer.parseFromText(v.getVersion()).compareTo(version) >= 0)
-                                .findFirst();
-                });
-    }
+              return localBinaryVersions.listExisting().stream()
+                  .filter(v -> SemVer.parseFromText(v.getVersion()) != null)
+                  .filter(v -> SemVer.parseFromText(v.getVersion()).compareTo(version) >= 0)
+                  .findFirst();
+            });
+  }
 
-    private static Optional<BinaryVersion> downloadRemoteVersion(BinaryRemoteSource binaryRemoteSource, BundleDownloader bundleDownloader) {
-        return binaryRemoteSource.fetchPreferredVersion(StaticConfig.getTabNineBundleVersionUrl())
-                .flatMap(bundleDownloader::downloadAndExtractBundle).map(BootstrapperSupport::savePreferredBootstrapVersion);
-    }
+  private static Optional<BinaryVersion> downloadRemoteVersion(
+      BinaryRemoteSource binaryRemoteSource, BundleDownloader bundleDownloader) {
+    return binaryRemoteSource
+        .fetchPreferredVersion(StaticConfig.getTabNineBundleVersionUrl())
+        .flatMap(bundleDownloader::downloadAndExtractBundle)
+        .map(BootstrapperSupport::savePreferredBootstrapVersion);
+  }
 }

--- a/src/main/java/com/tabnine/binary/fetch/BundleDownloader.java
+++ b/src/main/java/com/tabnine/binary/fetch/BundleDownloader.java
@@ -1,7 +1,8 @@
 package com.tabnine.binary.fetch;
 
-import com.intellij.openapi.diagnostic.Logger;
+import static com.tabnine.general.StaticConfig.*;
 
+import com.intellij.openapi.diagnostic.Logger;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -10,62 +11,61 @@ import java.util.Optional;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import static com.tabnine.general.StaticConfig.*;
+public class BundleDownloader {
 
-public class BundleDownloader  {
+  private final TempBundleValidator validator;
+  private final GeneralDownloader downloader;
 
-    private final TempBundleValidator validator;
-    private final GeneralDownloader downloader;
-    public BundleDownloader(TempBundleValidator validator, GeneralDownloader downloader) {
-        this.validator = validator;
-        this.downloader = downloader;
+  public BundleDownloader(TempBundleValidator validator, GeneralDownloader downloader) {
+    this.validator = validator;
+    this.downloader = downloader;
+  }
+
+  public Optional<BinaryVersion> downloadAndExtractBundle(String version) {
+    String urlString = String.join("/", getBundleServerUrl(), version, TARGET_NAME, "TabNine.zip");
+    String destination = bundleFullPath(version);
+    if (this.downloader.download(urlString, destination, validator)) {
+      try {
+        unzipFile(destination);
+        java.nio.file.Paths.get(destination).toFile().delete();
+        return Optional.of(new BinaryVersion(versionFullPath(version), version));
+      } catch (IOException e) {
+        Logger.getInstance(getClass()).warn("error unzipping file", e);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private void unzipFile(String fileZip) throws IOException {
+    File destDir = new File(fileZip).getParentFile();
+    byte[] buffer = new byte[1024];
+    ZipInputStream zis = new ZipInputStream(new FileInputStream(fileZip));
+    ZipEntry zipEntry = zis.getNextEntry();
+    while (zipEntry != null) {
+      File newFile = newFile(destDir, zipEntry);
+      FileOutputStream fos = new FileOutputStream(newFile);
+      int len;
+      while ((len = zis.read(buffer)) > 0) {
+        fos.write(buffer, 0, len);
+      }
+      fos.close();
+      zipEntry = zis.getNextEntry();
+      newFile.setExecutable(true);
+    }
+    zis.closeEntry();
+    zis.close();
+  }
+
+  private File newFile(File destinationDir, ZipEntry zipEntry) throws IOException {
+    File destFile = new File(destinationDir, zipEntry.getName());
+
+    String destDirPath = destinationDir.getCanonicalPath();
+    String destFilePath = destFile.getCanonicalPath();
+
+    if (!destFilePath.startsWith(destDirPath + File.separator)) {
+      throw new IOException("Entry is outside of the target dir: " + zipEntry.getName());
     }
 
-    public Optional<BinaryVersion> downloadAndExtractBundle(String version) {
-        String urlString = String.join("/", getBundleServerUrl(), version, TARGET_NAME, "TabNine.zip");
-        String destination = bundleFullPath(version);
-        if (this.downloader.download(urlString, destination, validator)) {
-            try {
-                unzipFile(destination);
-                java.nio.file.Paths.get(destination).toFile().delete();
-                return Optional.of(new BinaryVersion(versionFullPath(version), version));
-            } catch (IOException e) {
-                Logger.getInstance(getClass()).warn("error unzipping file", e);
-            }
-        }
-        return Optional.empty();
-    }
-
-    private void unzipFile(String fileZip) throws IOException {
-        File destDir = new File(fileZip).getParentFile();
-        byte[] buffer = new byte[1024];
-        ZipInputStream zis = new ZipInputStream(new FileInputStream(fileZip));
-        ZipEntry zipEntry = zis.getNextEntry();
-        while (zipEntry != null) {
-            File newFile = newFile(destDir, zipEntry);
-            FileOutputStream fos = new FileOutputStream(newFile);
-            int len;
-            while ((len = zis.read(buffer)) > 0) {
-                fos.write(buffer, 0, len);
-            }
-            fos.close();
-            zipEntry = zis.getNextEntry();
-            newFile.setExecutable(true);
-        }
-        zis.closeEntry();
-        zis.close();
-    }
-
-    private File newFile(File destinationDir, ZipEntry zipEntry) throws IOException {
-        File destFile = new File(destinationDir, zipEntry.getName());
-
-        String destDirPath = destinationDir.getCanonicalPath();
-        String destFilePath = destFile.getCanonicalPath();
-
-        if (!destFilePath.startsWith(destDirPath + File.separator)) {
-            throw new IOException("Entry is outside of the target dir: " + zipEntry.getName());
-        }
-
-        return destFile;
-    }
+    return destFile;
+  }
 }

--- a/src/main/java/com/tabnine/binary/fetch/DownloadValidator.java
+++ b/src/main/java/com/tabnine/binary/fetch/DownloadValidator.java
@@ -1,9 +1,8 @@
 package com.tabnine.binary.fetch;
 
 import com.tabnine.binary.exceptions.FailedToDownloadException;
-
 import java.nio.file.Path;
 
 public interface DownloadValidator {
-    void validateAndRename(Path tempDestination, Path destination) throws FailedToDownloadException;
+  void validateAndRename(Path tempDestination, Path destination) throws FailedToDownloadException;
 }

--- a/src/main/java/com/tabnine/binary/fetch/GeneralDownloader.java
+++ b/src/main/java/com/tabnine/binary/fetch/GeneralDownloader.java
@@ -1,8 +1,11 @@
 package com.tabnine.binary.fetch;
 
+import static com.tabnine.general.StaticConfig.BINARY_READ_TIMEOUT;
+import static com.tabnine.general.StaticConfig.REMOTE_CONNECTION_TIMEOUT;
+import static java.lang.String.format;
+
 import com.intellij.openapi.diagnostic.Logger;
 import com.tabnine.binary.exceptions.FailedToDownloadException;
-
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -12,37 +15,34 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.UUID;
 
-import static com.tabnine.general.StaticConfig.BINARY_READ_TIMEOUT;
-import static com.tabnine.general.StaticConfig.REMOTE_CONNECTION_TIMEOUT;
-import static java.lang.String.format;
-
 public class GeneralDownloader {
-    boolean download(String urlString, String destination, DownloadValidator validator) {
-        Path tempDestination = Paths.get(format("%s.download.%s", destination, UUID.randomUUID()));
+  boolean download(String urlString, String destination, DownloadValidator validator) {
+    Path tempDestination = Paths.get(format("%s.download.%s", destination, UUID.randomUUID()));
 
-        try {
-            if (!tempDestination.getParent().toFile().exists()) {
-                if (!tempDestination.getParent().toFile().mkdirs()) {
-                    Logger.getInstance(GeneralDownloader.class).warn(format("Could not create the required directories for %s", tempDestination));
-                    return false;
-                }
-            }
-            URLConnection connection = new URL(urlString).openConnection();
-            connection.setConnectTimeout(REMOTE_CONNECTION_TIMEOUT);
-            connection.setReadTimeout(BINARY_READ_TIMEOUT);
-            Files.copy(connection.getInputStream(), tempDestination, StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException e) {
-            Logger.getInstance(GeneralDownloader.class).warn(e);
-            return false;
+    try {
+      if (!tempDestination.getParent().toFile().exists()) {
+        if (!tempDestination.getParent().toFile().mkdirs()) {
+          Logger.getInstance(GeneralDownloader.class)
+              .warn(format("Could not create the required directories for %s", tempDestination));
+          return false;
         }
-        try {
-            validator.validateAndRename(tempDestination, Paths.get(destination));
-        } catch (FailedToDownloadException e) {
-            Logger.getInstance(GeneralDownloader.class).warn(e);
-            tempDestination.toFile().delete();
-            return false;
-        }
-
-        return true;
+      }
+      URLConnection connection = new URL(urlString).openConnection();
+      connection.setConnectTimeout(REMOTE_CONNECTION_TIMEOUT);
+      connection.setReadTimeout(BINARY_READ_TIMEOUT);
+      Files.copy(connection.getInputStream(), tempDestination, StandardCopyOption.REPLACE_EXISTING);
+    } catch (IOException e) {
+      Logger.getInstance(GeneralDownloader.class).warn(e);
+      return false;
     }
+    try {
+      validator.validateAndRename(tempDestination, Paths.get(destination));
+    } catch (FailedToDownloadException e) {
+      Logger.getInstance(GeneralDownloader.class).warn(e);
+      tempDestination.toFile().delete();
+      return false;
+    }
+
+    return true;
+  }
 }

--- a/src/main/java/com/tabnine/binary/fetch/LocalBinaryVersions.java
+++ b/src/main/java/com/tabnine/binary/fetch/LocalBinaryVersions.java
@@ -1,71 +1,78 @@
 package com.tabnine.binary.fetch;
 
+import static com.tabnine.general.StaticConfig.getActiveVersionPath;
+import static com.tabnine.general.StaticConfig.getBaseDirectory;
+import static java.util.stream.Collectors.toList;
+
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.text.SemVer;
-import org.jetbrains.annotations.NotNull;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Stream;
-
-import static com.tabnine.general.StaticConfig.getActiveVersionPath;
-import static com.tabnine.general.StaticConfig.getBaseDirectory;
-import static java.util.stream.Collectors.toList;
+import org.jetbrains.annotations.NotNull;
 
 public class LocalBinaryVersions {
-    public static final String BAD_VERSION = "4.0.47";
-    private BinaryValidator binaryValidator;
+  public static final String BAD_VERSION = "4.0.47";
+  private BinaryValidator binaryValidator;
 
-    public LocalBinaryVersions(BinaryValidator binaryValidator) {
-        this.binaryValidator = binaryValidator;
+  public LocalBinaryVersions(BinaryValidator binaryValidator) {
+    this.binaryValidator = binaryValidator;
+  }
+
+  @NotNull
+  public List<BinaryVersion> listExisting() {
+    File[] versionsFolders =
+        Optional.ofNullable(getBaseDirectory().toFile().listFiles()).orElse(new File[0]);
+
+    return Stream.of(versionsFolders)
+        .map(File::getName)
+        .map(SemVer::parseFromText)
+        .filter(Objects::nonNull)
+        .sorted(Comparator.reverseOrder())
+        .map(SemVer::toString)
+        .map(BinaryVersion::new)
+        .filter(
+            version ->
+                !version.getVersion().equals(BAD_VERSION)
+                    && binaryValidator.isWorking(version.getVersionFullPath()))
+        .collect(toList());
+  }
+
+  public Optional<BinaryVersion> activeVersion() {
+    List<String> lines = readActiveFile();
+
+    if (lines.size() == 0) return Optional.empty();
+
+    String version = lines.get(0);
+
+    if (version.equals(BAD_VERSION)) return Optional.empty();
+
+    BinaryVersion binaryVersion = new BinaryVersion(version);
+
+    if (!binaryValidator.isWorking(binaryVersion.getVersionFullPath())) {
+      Logger.getInstance(getClass()).warn("Version in .active file is not working");
+      return Optional.empty();
     }
 
-    @NotNull
-    public List<BinaryVersion> listExisting() {
-        File[] versionsFolders = Optional.ofNullable(getBaseDirectory().toFile().listFiles()).orElse(new File[0]);
+    return Optional.of(binaryVersion);
+  }
 
-        return Stream.of(versionsFolders).map(File::getName).map(SemVer::parseFromText).filter(Objects::nonNull)
-                .sorted(Comparator.reverseOrder())
-                .map(SemVer::toString)
-                .map(BinaryVersion::new)
-                .filter(version -> !version.getVersion().equals(BAD_VERSION) && binaryValidator.isWorking(version.getVersionFullPath())).collect(toList());
+  @NotNull
+  private List<String> readActiveFile() {
+    Path activeFile = getActiveVersionPath();
+
+    List<String> lines = new ArrayList<>();
+    if (activeFile.toFile().exists()) {
+      try {
+        lines = Files.readAllLines(activeFile);
+      } catch (IOException e) {
+        Logger.getInstance(getClass()).warn("Failed to read .active file", e);
+      }
     }
 
-    public Optional<BinaryVersion> activeVersion() {
-        List<String> lines = readActiveFile();
-
-        if (lines.size() == 0) return Optional.empty();
-
-        String version = lines.get(0);
-
-        if (version.equals(BAD_VERSION)) return Optional.empty();
-
-        BinaryVersion binaryVersion = new BinaryVersion(version);
-
-        if (!binaryValidator.isWorking(binaryVersion.getVersionFullPath())) {
-            Logger.getInstance(getClass()).warn("Version in .active file is not working");
-            return Optional.empty();
-        }
-
-        return Optional.of(binaryVersion);
-    }
-
-    @NotNull
-    private List<String> readActiveFile() {
-        Path activeFile = getActiveVersionPath();
-
-        List<String> lines = new ArrayList<>();
-        if (activeFile.toFile().exists()) {
-            try {
-                lines = Files.readAllLines(activeFile);
-            } catch (IOException e) {
-                Logger.getInstance(getClass()).warn("Failed to read .active file", e);
-            }
-        }
-
-        return lines;
-    }
+    return lines;
+  }
 }

--- a/src/main/java/com/tabnine/binary/fetch/TempBinaryValidator.java
+++ b/src/main/java/com/tabnine/binary/fetch/TempBinaryValidator.java
@@ -1,38 +1,42 @@
 package com.tabnine.binary.fetch;
 
-import com.tabnine.binary.exceptions.FailedToDownloadException;
-
-import java.nio.file.Path;
-
 import static com.tabnine.general.StaticConfig.BINARY_MINIMUM_REASONABLE_SIZE;
 import static java.lang.String.format;
 
+import com.tabnine.binary.exceptions.FailedToDownloadException;
+import java.nio.file.Path;
+
 public class TempBinaryValidator implements DownloadValidator {
-    private final BinaryValidator binaryValidator;
+  private final BinaryValidator binaryValidator;
 
-    public TempBinaryValidator(BinaryValidator binaryValidator) {
-        this.binaryValidator = binaryValidator;
+  public TempBinaryValidator(BinaryValidator binaryValidator) {
+    this.binaryValidator = binaryValidator;
+  }
+
+  public void validateAndRename(Path tempDestination, Path destination)
+      throws FailedToDownloadException {
+    if (!tempDestination.toFile().exists()) {
+      throw new FailedToDownloadException(
+          "Temp file was not found at " + tempDestination.toString());
     }
 
-    public void validateAndRename(Path tempDestination, Path destination) throws FailedToDownloadException {
-        if (!tempDestination.toFile().exists()) {
-            throw new FailedToDownloadException("Temp file was not found at " + tempDestination.toString());
-        }
-
-        if (tempDestination.toFile().length() < BINARY_MINIMUM_REASONABLE_SIZE) {
-            throw new FailedToDownloadException("Binary content from server was corrupt");
-        }
-
-        if (!tempDestination.toFile().setExecutable(true)) {
-            throw new FailedToDownloadException("Couldn't set execute permission on " + tempDestination);
-        }
-
-        if (!binaryValidator.isWorking(tempDestination.toString())) {
-            throw new FailedToDownloadException(format("Could run to validate at: %s", tempDestination));
-        }
-
-        if (!tempDestination.toFile().renameTo(destination.toFile()) || !destination.toFile().exists()) {
-            throw new FailedToDownloadException("Although downloaded successfully and without errors, Tabnine's binary does not exists in the detination folder: " + destination.toString());
-        }
+    if (tempDestination.toFile().length() < BINARY_MINIMUM_REASONABLE_SIZE) {
+      throw new FailedToDownloadException("Binary content from server was corrupt");
     }
+
+    if (!tempDestination.toFile().setExecutable(true)) {
+      throw new FailedToDownloadException("Couldn't set execute permission on " + tempDestination);
+    }
+
+    if (!binaryValidator.isWorking(tempDestination.toString())) {
+      throw new FailedToDownloadException(format("Could run to validate at: %s", tempDestination));
+    }
+
+    if (!tempDestination.toFile().renameTo(destination.toFile())
+        || !destination.toFile().exists()) {
+      throw new FailedToDownloadException(
+          "Although downloaded successfully and without errors, Tabnine's binary does not exists in the detination folder: "
+              + destination.toString());
+    }
+  }
 }

--- a/src/main/java/com/tabnine/binary/fetch/TempBundleValidator.java
+++ b/src/main/java/com/tabnine/binary/fetch/TempBundleValidator.java
@@ -1,18 +1,22 @@
 package com.tabnine.binary.fetch;
 
 import com.tabnine.binary.exceptions.FailedToDownloadException;
-
 import java.nio.file.Path;
 
 public class TempBundleValidator implements DownloadValidator {
-    @Override
-    public void validateAndRename(Path tempDestination, Path destination) throws FailedToDownloadException {
-        if (!tempDestination.toFile().exists()) {
-            throw new FailedToDownloadException("Temp file was not found at " + tempDestination.toString());
-        }
-
-        if (!tempDestination.toFile().renameTo(destination.toFile()) || !destination.toFile().exists()) {
-            throw new FailedToDownloadException("Although downloaded successfully and without errors, TabNine's binary does not exists in the detination folder: " + destination.toString());
-        }
+  @Override
+  public void validateAndRename(Path tempDestination, Path destination)
+      throws FailedToDownloadException {
+    if (!tempDestination.toFile().exists()) {
+      throw new FailedToDownloadException(
+          "Temp file was not found at " + tempDestination.toString());
     }
+
+    if (!tempDestination.toFile().renameTo(destination.toFile())
+        || !destination.toFile().exists()) {
+      throw new FailedToDownloadException(
+          "Although downloaded successfully and without errors, TabNine's binary does not exists in the detination folder: "
+              + destination.toString());
+    }
+  }
 }

--- a/src/main/java/com/tabnine/binary/requests/autocomplete/AutocompleteRequest.java
+++ b/src/main/java/com/tabnine/binary/requests/autocomplete/AutocompleteRequest.java
@@ -1,34 +1,38 @@
 package com.tabnine.binary.requests.autocomplete;
 
+import static java.util.Collections.singletonMap;
+
 import com.google.gson.annotations.SerializedName;
 import com.tabnine.binary.BinaryRequest;
 
-import static java.util.Collections.singletonMap;
-
 public class AutocompleteRequest implements BinaryRequest<AutocompleteResponse> {
-    public String before;
-    public String after;
-    public String filename;
-    @SerializedName(value = "region_includes_beginning")
-    public boolean regionIncludesBeginning;
-    @SerializedName(value = "region_includes_end")
-    public boolean regionIncludesEnd;
-    @SerializedName(value = "max_num_results")
-    public int maxResults;
-    public int offset;
-    public int line;
-    public int character;
+  public String before;
+  public String after;
+  public String filename;
 
-    public Class<AutocompleteResponse> response() {
-        return AutocompleteResponse.class;
-    }
+  @SerializedName(value = "region_includes_beginning")
+  public boolean regionIncludesBeginning;
 
-    @Override
-    public Object serialize() {
-        return singletonMap("Autocomplete", this);
-    }
+  @SerializedName(value = "region_includes_end")
+  public boolean regionIncludesEnd;
 
-    public boolean validate(AutocompleteResponse response) {
-        return this.before.endsWith(response.old_prefix);
-    }
+  @SerializedName(value = "max_num_results")
+  public int maxResults;
+
+  public int offset;
+  public int line;
+  public int character;
+
+  public Class<AutocompleteResponse> response() {
+    return AutocompleteResponse.class;
+  }
+
+  @Override
+  public Object serialize() {
+    return singletonMap("Autocomplete", this);
+  }
+
+  public boolean validate(AutocompleteResponse response) {
+    return this.before.endsWith(response.old_prefix);
+  }
 }

--- a/src/main/java/com/tabnine/binary/requests/autocomplete/AutocompleteResponse.java
+++ b/src/main/java/com/tabnine/binary/requests/autocomplete/AutocompleteResponse.java
@@ -3,8 +3,8 @@ package com.tabnine.binary.requests.autocomplete;
 import com.tabnine.binary.BinaryResponse;
 
 public class AutocompleteResponse implements BinaryResponse {
-    public String old_prefix;
-    public ResultEntry[] results;
-    public String[] user_message;
-    public boolean is_locked;
+  public String old_prefix;
+  public ResultEntry[] results;
+  public String[] user_message;
+  public boolean is_locked;
 }

--- a/src/main/java/com/tabnine/binary/requests/autocomplete/ResultEntry.java
+++ b/src/main/java/com/tabnine/binary/requests/autocomplete/ResultEntry.java
@@ -4,14 +4,14 @@ import com.tabnine.general.CompletionKind;
 import com.tabnine.general.CompletionOrigin;
 
 public class ResultEntry {
-    public String new_prefix;
-    public String old_suffix;
-    public String new_suffix;
+  public String new_prefix;
+  public String old_suffix;
+  public String new_suffix;
 
-    public CompletionOrigin origin;
-    public String detail;
-    public Boolean deprecated;
-    public CompletionKind completion_kind;
-    public Boolean is_cached;
-    // TODO other lsp types
+  public CompletionOrigin origin;
+  public String detail;
+  public Boolean deprecated;
+  public CompletionKind completion_kind;
+  public Boolean is_cached;
+  // TODO other lsp types
 }

--- a/src/main/java/com/tabnine/binary/requests/config/ConfigRequest.java
+++ b/src/main/java/com/tabnine/binary/requests/config/ConfigRequest.java
@@ -1,29 +1,29 @@
 package com.tabnine.binary.requests.config;
 
+import static java.util.Collections.singletonMap;
+
 import com.tabnine.binary.BinaryRequest;
 import com.tabnine.binary.exceptions.TabNineInvalidResponseException;
 import org.jetbrains.annotations.NotNull;
 
-import static java.util.Collections.singletonMap;
-
 public class ConfigRequest implements BinaryRequest<ConfigResponse> {
-    @Override
-    public Class<ConfigResponse> response() {
-        return ConfigResponse.class;
-    }
+  @Override
+  public Class<ConfigResponse> response() {
+    return ConfigResponse.class;
+  }
 
-    @Override
-    public Object serialize() {
-        return singletonMap("Configuration", new Object());
-    }
+  @Override
+  public Object serialize() {
+    return singletonMap("Configuration", new Object());
+  }
 
-    @Override
-    public boolean validate(@NotNull ConfigResponse response) {
-        return true;
-    }
+  @Override
+  public boolean validate(@NotNull ConfigResponse response) {
+    return true;
+  }
 
-    @Override
-    public boolean shouldBeAllowed(@NotNull TabNineInvalidResponseException e) {
-        return true;
-    }
+  @Override
+  public boolean shouldBeAllowed(@NotNull TabNineInvalidResponseException e) {
+    return true;
+  }
 }

--- a/src/main/java/com/tabnine/binary/requests/config/ConfigResponse.java
+++ b/src/main/java/com/tabnine/binary/requests/config/ConfigResponse.java
@@ -2,5 +2,4 @@ package com.tabnine.binary.requests.config;
 
 import com.tabnine.binary.BinaryResponse;
 
-public class ConfigResponse implements BinaryResponse {
-}
+public class ConfigResponse implements BinaryResponse {}

--- a/src/main/java/com/tabnine/binary/requests/selection/SelectionRequest.java
+++ b/src/main/java/com/tabnine/binary/requests/selection/SelectionRequest.java
@@ -3,42 +3,48 @@ package com.tabnine.binary.requests.selection;
 import com.google.gson.annotations.SerializedName;
 import com.tabnine.general.CompletionKind;
 import com.tabnine.general.CompletionOrigin;
-
 import java.util.List;
 
 public class SelectionRequest {
-    // the file extension: rs | js etc.
-    public String language;
-    // suggestion total length ('namespace'.length)
-    public Integer length;
-    public CompletionOrigin origin;
-    // length - what's already written ('space'.length)
-    @SerializedName(value = "net_length")
-    public Integer netLength;
-    // the percentage showed with the suggestion
-    public String strength;
-    // index of the selected suggestion (1)
-    public Integer index;
-    // text written before the suggestion start ('String name'.length)
-    @SerializedName(value = "line_prefix_length")
-    public Integer linePrefixLength;
-    // line_prefix_length - the part of the text that's in the suggestion ('String '.length)
-    @SerializedName(value = "line_net_prefix_length")
-    public Integer lineNetPrefixLength;
-    // text written the place at which the suggestion showed (' = "L'.length)
-    @SerializedName(value = "line_suffix_length")
-    public Integer lineSuffixLength;
-    @SerializedName(value = "num_of_suggestions")
-    public Integer suggestionsCount;
-    @SerializedName(value = "num_of_vanilla_suggestions")
-    public Integer vanillaSuggestionsCount;
-    @SerializedName(value = "num_of_deep_local_suggestions")
-    public Integer deepLocalSuggestionsCount;
-    @SerializedName(value = "num_of_deep_cloud_suggestions")
-    public Integer deepCloudSuggestionsCount;
-    @SerializedName(value = "num_of_lsp_suggestions")
-    public Integer lspSuggestionsCount;
-    public List<SelectionSuggestionRequest> suggestions;
-    @SerializedName(value = "completion_kind")
-    public CompletionKind completionKind;
+  // the file extension: rs | js etc.
+  public String language;
+  // suggestion total length ('namespace'.length)
+  public Integer length;
+  public CompletionOrigin origin;
+  // length - what's already written ('space'.length)
+  @SerializedName(value = "net_length")
+  public Integer netLength;
+  // the percentage showed with the suggestion
+  public String strength;
+  // index of the selected suggestion (1)
+  public Integer index;
+  // text written before the suggestion start ('String name'.length)
+  @SerializedName(value = "line_prefix_length")
+  public Integer linePrefixLength;
+  // line_prefix_length - the part of the text that's in the suggestion ('String '.length)
+  @SerializedName(value = "line_net_prefix_length")
+  public Integer lineNetPrefixLength;
+  // text written the place at which the suggestion showed (' = "L'.length)
+  @SerializedName(value = "line_suffix_length")
+  public Integer lineSuffixLength;
+
+  @SerializedName(value = "num_of_suggestions")
+  public Integer suggestionsCount;
+
+  @SerializedName(value = "num_of_vanilla_suggestions")
+  public Integer vanillaSuggestionsCount;
+
+  @SerializedName(value = "num_of_deep_local_suggestions")
+  public Integer deepLocalSuggestionsCount;
+
+  @SerializedName(value = "num_of_deep_cloud_suggestions")
+  public Integer deepCloudSuggestionsCount;
+
+  @SerializedName(value = "num_of_lsp_suggestions")
+  public Integer lspSuggestionsCount;
+
+  public List<SelectionSuggestionRequest> suggestions;
+
+  @SerializedName(value = "completion_kind")
+  public CompletionKind completionKind;
 }

--- a/src/main/java/com/tabnine/binary/requests/selection/SelectionSuggestionRequest.java
+++ b/src/main/java/com/tabnine/binary/requests/selection/SelectionSuggestionRequest.java
@@ -1,16 +1,15 @@
 package com.tabnine.binary.requests.selection;
 
 public class SelectionSuggestionRequest {
-    Integer length;
-    String strength;
-    String origin;
+  Integer length;
+  String strength;
+  String origin;
 
-    public SelectionSuggestionRequest() {
-    }
+  public SelectionSuggestionRequest() {}
 
-    public SelectionSuggestionRequest(Integer length, String strength, String origin) {
-        this.length = length;
-        this.strength = strength;
-        this.origin = origin;
-    }
+  public SelectionSuggestionRequest(Integer length, String strength, String origin) {
+    this.length = length;
+    this.strength = strength;
+    this.origin = origin;
+  }
 }

--- a/src/main/java/com/tabnine/binary/requests/selection/SetStateBinaryRequest.java
+++ b/src/main/java/com/tabnine/binary/requests/selection/SetStateBinaryRequest.java
@@ -1,30 +1,31 @@
 package com.tabnine.binary.requests.selection;
 
-import com.tabnine.binary.BinaryRequest;
-import org.jetbrains.annotations.NotNull;
-
 import static com.tabnine.general.StaticConfig.SET_STATE_RESPONSE_RESULT_STRING;
 import static java.util.Collections.singletonMap;
 
+import com.tabnine.binary.BinaryRequest;
+import org.jetbrains.annotations.NotNull;
+
 public class SetStateBinaryRequest implements BinaryRequest<SetStateBinaryResponse> {
-    private final SelectionRequest selectionRequest;
+  private final SelectionRequest selectionRequest;
 
-    public SetStateBinaryRequest(SelectionRequest selectionRequest) {
-        this.selectionRequest = selectionRequest;
-    }
+  public SetStateBinaryRequest(SelectionRequest selectionRequest) {
+    this.selectionRequest = selectionRequest;
+  }
 
-    @Override
-    public Class<SetStateBinaryResponse> response() {
-        return SetStateBinaryResponse.class;
-    }
+  @Override
+  public Class<SetStateBinaryResponse> response() {
+    return SetStateBinaryResponse.class;
+  }
 
-    @Override
-    public Object serialize() {
-        return singletonMap("SetState", singletonMap("state_type", singletonMap("Selection", selectionRequest)));
-    }
+  @Override
+  public Object serialize() {
+    return singletonMap(
+        "SetState", singletonMap("state_type", singletonMap("Selection", selectionRequest)));
+  }
 
-    @Override
-    public boolean validate(@NotNull SetStateBinaryResponse response) {
-        return SET_STATE_RESPONSE_RESULT_STRING.equals(response.getResult());
-    }
+  @Override
+  public boolean validate(@NotNull SetStateBinaryResponse response) {
+    return SET_STATE_RESPONSE_RESULT_STRING.equals(response.getResult());
+  }
 }

--- a/src/main/java/com/tabnine/binary/requests/selection/SetStateBinaryResponse.java
+++ b/src/main/java/com/tabnine/binary/requests/selection/SetStateBinaryResponse.java
@@ -3,13 +3,13 @@ package com.tabnine.binary.requests.selection;
 import com.tabnine.binary.BinaryResponse;
 
 public class SetStateBinaryResponse implements BinaryResponse {
-    private String result;
+  private String result;
 
-    public String getResult() {
-        return result;
-    }
+  public String getResult() {
+    return result;
+  }
 
-    public void setResult(String result) {
-        this.result = result;
-    }
+  public void setResult(String result) {
+    this.result = result;
+  }
 }

--- a/src/main/java/com/tabnine/binary/requests/statusBar/ConfigOpenedFromStatusBarRequest.java
+++ b/src/main/java/com/tabnine/binary/requests/statusBar/ConfigOpenedFromStatusBarRequest.java
@@ -1,25 +1,27 @@
 package com.tabnine.binary.requests.statusBar;
 
+import static com.tabnine.general.StaticConfig.SET_STATE_RESPONSE_RESULT_STRING;
+import static java.util.Collections.singletonMap;
+
 import com.tabnine.binary.BinaryRequest;
 import com.tabnine.binary.requests.selection.SetStateBinaryResponse;
 import org.jetbrains.annotations.NotNull;
 
-import static com.tabnine.general.StaticConfig.SET_STATE_RESPONSE_RESULT_STRING;
-import static java.util.Collections.singletonMap;
-
 public class ConfigOpenedFromStatusBarRequest implements BinaryRequest<SetStateBinaryResponse> {
-    @Override
-    public Class<SetStateBinaryResponse> response() {
-        return SetStateBinaryResponse.class;
-    }
+  @Override
+  public Class<SetStateBinaryResponse> response() {
+    return SetStateBinaryResponse.class;
+  }
 
-    @Override
-    public Object serialize() {
-        return singletonMap("SetState", singletonMap("state_type", singletonMap("State", singletonMap("state_type", "status"))));
-    }
+  @Override
+  public Object serialize() {
+    return singletonMap(
+        "SetState",
+        singletonMap("state_type", singletonMap("State", singletonMap("state_type", "status"))));
+  }
 
-    @Override
-    public boolean validate(@NotNull SetStateBinaryResponse response) {
-        return SET_STATE_RESPONSE_RESULT_STRING.equals(response.getResult());
-    }
+  @Override
+  public boolean validate(@NotNull SetStateBinaryResponse response) {
+    return SET_STATE_RESPONSE_RESULT_STRING.equals(response.getResult());
+  }
 }

--- a/src/main/java/com/tabnine/binary/requests/uninstall/UninstallRequest.java
+++ b/src/main/java/com/tabnine/binary/requests/uninstall/UninstallRequest.java
@@ -1,32 +1,32 @@
 package com.tabnine.binary.requests.uninstall;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+
 import com.tabnine.binary.BinaryRequest;
 import com.tabnine.binary.exceptions.TabNineInvalidResponseException;
 import org.jetbrains.annotations.NotNull;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
-
 public class UninstallRequest implements BinaryRequest<UninstallResponse> {
-    public static final String BACKWARD_COMPATIABLE_RESPONSE = "null";
+  public static final String BACKWARD_COMPATIABLE_RESPONSE = "null";
 
-    @Override
-    public Class<UninstallResponse> response() {
-        return UninstallResponse.class;
-    }
+  @Override
+  public Class<UninstallResponse> response() {
+    return UninstallResponse.class;
+  }
 
-    @Override
-    public Object serialize() {
-        return singletonMap("Uninstalling", emptyMap());
-    }
+  @Override
+  public Object serialize() {
+    return singletonMap("Uninstalling", emptyMap());
+  }
 
-    @Override
-    public boolean validate(@NotNull UninstallResponse response) {
-        return true;
-    }
+  @Override
+  public boolean validate(@NotNull UninstallResponse response) {
+    return true;
+  }
 
-    @Override
-    public boolean shouldBeAllowed(@NotNull TabNineInvalidResponseException e) {
-        return e.getRawResponse().filter(BACKWARD_COMPATIABLE_RESPONSE::equals).isPresent();
-    }
+  @Override
+  public boolean shouldBeAllowed(@NotNull TabNineInvalidResponseException e) {
+    return e.getRawResponse().filter(BACKWARD_COMPATIABLE_RESPONSE::equals).isPresent();
+  }
 }

--- a/src/main/java/com/tabnine/binary/requests/uninstall/UninstallResponse.java
+++ b/src/main/java/com/tabnine/binary/requests/uninstall/UninstallResponse.java
@@ -2,5 +2,4 @@ package com.tabnine.binary.requests.uninstall;
 
 import com.tabnine.binary.BinaryResponse;
 
-public class UninstallResponse implements BinaryResponse {
-}
+public class UninstallResponse implements BinaryResponse {}

--- a/src/main/java/com/tabnine/capabilities/CapabilitiesService.java
+++ b/src/main/java/com/tabnine/capabilities/CapabilitiesService.java
@@ -6,7 +6,6 @@ import com.tabnine.binary.BinaryRequestFacade;
 import com.tabnine.binary.requests.capabilities.CapabilitiesRequest;
 import com.tabnine.binary.requests.capabilities.CapabilitiesResponse;
 import com.tabnine.general.DependencyContainer;
-
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;

--- a/src/main/java/com/tabnine/capabilities/Capability.java
+++ b/src/main/java/com/tabnine/capabilities/Capability.java
@@ -3,8 +3,8 @@ package com.tabnine.capabilities;
 import com.google.gson.annotations.SerializedName;
 
 public enum Capability {
-    @SerializedName("inline_suggestions_mode")
-    INLINE_SUGGESTIONS,
-    @SerializedName("alpha")
-    ALPHA,
+  @SerializedName("inline_suggestions_mode")
+  INLINE_SUGGESTIONS,
+  @SerializedName("alpha")
+  ALPHA,
 }

--- a/src/main/java/com/tabnine/capabilities/SuggestionsMode.java
+++ b/src/main/java/com/tabnine/capabilities/SuggestionsMode.java
@@ -8,7 +8,9 @@ public enum SuggestionsMode {
   ;
 
   public static SuggestionsMode getSuggestionMode() {
-    boolean jbPreviewOn = Registry.is("ide.lookup.preview.insertion"); // If true, jetbrains build in preview feature is on
+    boolean jbPreviewOn =
+        Registry.is(
+            "ide.lookup.preview.insertion"); // If true, jetbrains build in preview feature is on
     if (CapabilitiesService.getInstance().isCapabilityEnabled(Capability.INLINE_SUGGESTIONS)
         && !jbPreviewOn) {
       return INLINE;

--- a/src/main/java/com/tabnine/general/CompletionKind.java
+++ b/src/main/java/com/tabnine/general/CompletionKind.java
@@ -1,7 +1,7 @@
 package com.tabnine.general;
 
 public enum CompletionKind {
-    Classic,
-    Line,
-    Snippet
+  Classic,
+  Line,
+  Snippet
 }

--- a/src/main/java/com/tabnine/general/CompletionOrigin.java
+++ b/src/main/java/com/tabnine/general/CompletionOrigin.java
@@ -1,11 +1,11 @@
 package com.tabnine.general;
 
 public enum CompletionOrigin {
-    LOCAL,
-    CLOUD,
-    VANILLA,
-    VANILLA_KEYWORD,
-    LSP,
-    SNIPPET,
-    UNKNOWN;
+  LOCAL,
+  CLOUD,
+  VANILLA,
+  VANILLA_KEYWORD,
+  LSP,
+  SNIPPET,
+  UNKNOWN;
 }

--- a/src/main/java/com/tabnine/general/DependencyContainer.java
+++ b/src/main/java/com/tabnine/general/DependencyContainer.java
@@ -11,141 +11,160 @@ import com.tabnine.statusBar.StatusBarUpdater;
 import org.jetbrains.annotations.NotNull;
 
 public class DependencyContainer {
-    private static TabNineDisablePluginListener DISABLE_PLUGIN_LISTENER_INSTANCE = null;
-    private static BinaryProcessRequesterProvider BINARY_PROCESS_REQUESTER_PROVIDER_INSTANCE = null;
+  private static TabNineDisablePluginListener DISABLE_PLUGIN_LISTENER_INSTANCE = null;
+  private static BinaryProcessRequesterProvider BINARY_PROCESS_REQUESTER_PROVIDER_INSTANCE = null;
 
-    // For Integration Tests
-    private static BinaryRun binaryRunMock = null;
-    private static BinaryProcessGatewayProvider binaryProcessGatewayProviderMock = null;
-    private static BinaryProcessRequesterPoller poller = null;
-    public static TabNineDisablePluginListener singletonOfTabNineDisablePluginListener() {
-        if (DISABLE_PLUGIN_LISTENER_INSTANCE == null) {
-            DISABLE_PLUGIN_LISTENER_INSTANCE = new TabNineDisablePluginListener(instanceOfUninstallReporter(), instanceOfBinaryRequestFacade());
-        }
+  // For Integration Tests
+  private static BinaryRun binaryRunMock = null;
+  private static BinaryProcessGatewayProvider binaryProcessGatewayProviderMock = null;
+  private static BinaryProcessRequesterPoller poller = null;
 
-        return DISABLE_PLUGIN_LISTENER_INSTANCE;
+  public static TabNineDisablePluginListener singletonOfTabNineDisablePluginListener() {
+    if (DISABLE_PLUGIN_LISTENER_INSTANCE == null) {
+      DISABLE_PLUGIN_LISTENER_INSTANCE =
+          new TabNineDisablePluginListener(
+              instanceOfUninstallReporter(), instanceOfBinaryRequestFacade());
     }
 
-    public static synchronized TabNineLookupListener instanceOfTabNineLookupListener() {
-        final BinaryRequestFacade binaryRequestFacade = instanceOfBinaryRequestFacade();
-        return new TabNineLookupListener(binaryRequestFacade, new StatusBarUpdater(binaryRequestFacade));
+    return DISABLE_PLUGIN_LISTENER_INSTANCE;
+  }
+
+  public static synchronized TabNineLookupListener instanceOfTabNineLookupListener() {
+    final BinaryRequestFacade binaryRequestFacade = instanceOfBinaryRequestFacade();
+    return new TabNineLookupListener(
+        binaryRequestFacade, new StatusBarUpdater(binaryRequestFacade));
+  }
+
+  public static CompletionPreviewListener instanceOfCompletionPreviewListener() {
+    final BinaryRequestFacade binaryRequestFacade = instanceOfBinaryRequestFacade();
+    return new CompletionPreviewListener(
+        binaryRequestFacade, new StatusBarUpdater(binaryRequestFacade));
+  }
+
+  public static BinaryRequestFacade instanceOfBinaryRequestFacade() {
+    return new BinaryRequestFacade(singletonOfBinaryProcessRequesterProvider());
+  }
+
+  @NotNull
+  public static CompletionFacade instanceOfCompletionFacade() {
+    return new CompletionFacade(instanceOfBinaryRequestFacade());
+  }
+
+  @NotNull
+  public static PluginStateListener instanceOfTabNinePluginStateListener() {
+    return new TabNinePluginStateListener(
+        instanceOfUninstallReporter(), instanceOfBinaryRequestFacade());
+  }
+
+  public static BinaryNotificationsLifecycle instanceOfBinaryNotifications() {
+    return new BinaryNotificationsLifecycle(
+        instanceOfBinaryRequestFacade(), instanceOfGlobalActionVisitor());
+  }
+
+  public static BinaryInstantiatedActions instanceOfGlobalActionVisitor() {
+    return new BinaryInstantiatedActions(instanceOfBinaryRequestFacade());
+  }
+
+  public static BinaryPromotionStatusBarLifecycle instanceOfBinaryPromotionStatusBar() {
+    return new BinaryPromotionStatusBarLifecycle(
+        new StatusBarUpdater(instanceOfBinaryRequestFacade()));
+  }
+
+  public static void setTesting(
+      BinaryRun binaryRunMock,
+      BinaryProcessGatewayProvider binaryProcessGatewayProviderMock,
+      BinaryProcessRequesterPoller poller) {
+    DependencyContainer.binaryRunMock = binaryRunMock;
+    DependencyContainer.binaryProcessGatewayProviderMock = binaryProcessGatewayProviderMock;
+    DependencyContainer.poller = poller;
+  }
+
+  private static BinaryProcessRequesterProvider singletonOfBinaryProcessRequesterProvider() {
+    if (BINARY_PROCESS_REQUESTER_PROVIDER_INSTANCE == null) {
+      BINARY_PROCESS_REQUESTER_PROVIDER_INSTANCE =
+          BinaryProcessRequesterProvider.create(
+              instanceOfBinaryRun(),
+              instanceOfBinaryProcessGatewayProvider(),
+              instanceOfRequestPoller());
     }
 
-    public static CompletionPreviewListener instanceOfCompletionPreviewListener() {
-        final BinaryRequestFacade binaryRequestFacade = instanceOfBinaryRequestFacade();
-        return new CompletionPreviewListener(binaryRequestFacade, new StatusBarUpdater(binaryRequestFacade));
+    return BINARY_PROCESS_REQUESTER_PROVIDER_INSTANCE;
+  }
+
+  private static BinaryProcessGatewayProvider instanceOfBinaryProcessGatewayProvider() {
+    if (binaryProcessGatewayProviderMock != null) {
+      return binaryProcessGatewayProviderMock;
     }
 
-    public static BinaryRequestFacade instanceOfBinaryRequestFacade() {
-        return new BinaryRequestFacade(singletonOfBinaryProcessRequesterProvider());
+    return new BinaryProcessGatewayProvider();
+  }
+
+  private static BinaryProcessRequesterPoller instanceOfRequestPoller() {
+    if (poller != null) {
+      return poller;
+    }
+    return new BinaryProcessRequesterPollerCappedImpl(10, 100, 1000);
+  }
+
+  private static UninstallReporter instanceOfUninstallReporter() {
+    return new UninstallReporter(instanceOfBinaryRun());
+  }
+
+  @NotNull
+  private static BinaryRun instanceOfBinaryRun() {
+    if (binaryRunMock != null) {
+      return binaryRunMock;
     }
 
-    @NotNull
-    public static CompletionFacade instanceOfCompletionFacade() {
-        return new CompletionFacade(instanceOfBinaryRequestFacade());
-    }
+    return new BinaryRun(instanceOfBinaryFetcher());
+  }
 
-    @NotNull
-    public static PluginStateListener instanceOfTabNinePluginStateListener() {
-        return new TabNinePluginStateListener(instanceOfUninstallReporter(), instanceOfBinaryRequestFacade());
-    }
+  @NotNull
+  private static BinaryVersionFetcher instanceOfBinaryFetcher() {
+    return new BinaryVersionFetcher(
+        instanceOfLocalBinaryVersions(),
+        instanceOfBinaryRemoteSource(),
+        instanceOfBinaryDownloader(),
+        instanceOfBundleDownloader());
+  }
 
-    public static BinaryNotificationsLifecycle instanceOfBinaryNotifications() {
-        return new BinaryNotificationsLifecycle(instanceOfBinaryRequestFacade(), instanceOfGlobalActionVisitor());
-    }
+  @NotNull
+  private static BinaryDownloader instanceOfBinaryDownloader() {
+    return new BinaryDownloader(instanceOfBinaryPropositionValidator(), instanceOfDownloader());
+  }
 
-    public static BinaryInstantiatedActions instanceOfGlobalActionVisitor() {
-        return new BinaryInstantiatedActions(instanceOfBinaryRequestFacade());
-    }
+  @NotNull
+  private static BundleDownloader instanceOfBundleDownloader() {
+    return new BundleDownloader(instanceOfBundlePropositionValidator(), instanceOfDownloader());
+  }
 
-    public static BinaryPromotionStatusBarLifecycle instanceOfBinaryPromotionStatusBar() {
-        return new BinaryPromotionStatusBarLifecycle(new StatusBarUpdater(instanceOfBinaryRequestFacade()));
-    }
+  @NotNull
+  private static GeneralDownloader instanceOfDownloader() {
+    return new GeneralDownloader();
+  }
 
-    public static void setTesting(BinaryRun binaryRunMock, BinaryProcessGatewayProvider binaryProcessGatewayProviderMock, BinaryProcessRequesterPoller poller) {
-        DependencyContainer.binaryRunMock = binaryRunMock;
-        DependencyContainer.binaryProcessGatewayProviderMock = binaryProcessGatewayProviderMock;
-        DependencyContainer.poller = poller;
-    }
+  @NotNull
+  private static TempBinaryValidator instanceOfBinaryPropositionValidator() {
+    return new TempBinaryValidator(instanceOfBinaryValidator());
+  }
 
-    private static BinaryProcessRequesterProvider singletonOfBinaryProcessRequesterProvider() {
-        if (BINARY_PROCESS_REQUESTER_PROVIDER_INSTANCE == null) {
-            BINARY_PROCESS_REQUESTER_PROVIDER_INSTANCE = BinaryProcessRequesterProvider.create(instanceOfBinaryRun(), instanceOfBinaryProcessGatewayProvider(), instanceOfRequestPoller());
-        }
+  @NotNull
+  private static TempBundleValidator instanceOfBundlePropositionValidator() {
+    return new TempBundleValidator();
+  }
 
-        return BINARY_PROCESS_REQUESTER_PROVIDER_INSTANCE;
-    }
+  @NotNull
+  private static BinaryRemoteSource instanceOfBinaryRemoteSource() {
+    return new BinaryRemoteSource();
+  }
 
-    private static BinaryProcessGatewayProvider instanceOfBinaryProcessGatewayProvider() {
-        if(binaryProcessGatewayProviderMock != null) {
-            return binaryProcessGatewayProviderMock;
-        }
+  @NotNull
+  private static LocalBinaryVersions instanceOfLocalBinaryVersions() {
+    return new LocalBinaryVersions(instanceOfBinaryValidator());
+  }
 
-        return new BinaryProcessGatewayProvider();
-    }
-
-    private static BinaryProcessRequesterPoller instanceOfRequestPoller() {
-        if (poller != null) {
-            return poller;
-        }
-        return new BinaryProcessRequesterPollerCappedImpl(10, 100, 1000);
-    }
-
-    private static UninstallReporter instanceOfUninstallReporter() {
-        return new UninstallReporter(instanceOfBinaryRun());
-    }
-
-    @NotNull
-    private static BinaryRun instanceOfBinaryRun() {
-        if(binaryRunMock != null) {
-            return binaryRunMock;
-        }
-
-        return new BinaryRun(instanceOfBinaryFetcher());
-    }
-
-    @NotNull
-    private static BinaryVersionFetcher instanceOfBinaryFetcher() {
-        return new BinaryVersionFetcher(instanceOfLocalBinaryVersions(), instanceOfBinaryRemoteSource(), instanceOfBinaryDownloader(), instanceOfBundleDownloader());
-    }
-
-    @NotNull
-    private static BinaryDownloader instanceOfBinaryDownloader() {
-        return new BinaryDownloader(instanceOfBinaryPropositionValidator(), instanceOfDownloader());
-    }
-
-    @NotNull
-    private static BundleDownloader instanceOfBundleDownloader() {
-        return new BundleDownloader(instanceOfBundlePropositionValidator(), instanceOfDownloader());
-    }
-
-    @NotNull
-    private static GeneralDownloader instanceOfDownloader() {
-        return new GeneralDownloader();
-    }
-
-    @NotNull
-    private static TempBinaryValidator instanceOfBinaryPropositionValidator() {
-        return new TempBinaryValidator(instanceOfBinaryValidator());
-    }
-
-    @NotNull
-    private static TempBundleValidator instanceOfBundlePropositionValidator() {
-        return new TempBundleValidator();
-    }
-
-    @NotNull
-    private static BinaryRemoteSource instanceOfBinaryRemoteSource() {
-        return new BinaryRemoteSource();
-    }
-
-    @NotNull
-    private static LocalBinaryVersions instanceOfLocalBinaryVersions() {
-        return new LocalBinaryVersions(instanceOfBinaryValidator());
-    }
-
-    @NotNull
-    private static BinaryValidator instanceOfBinaryValidator() {
-        return new BinaryValidator();
-    }
+  @NotNull
+  private static BinaryValidator instanceOfBinaryValidator() {
+    return new BinaryValidator();
+  }
 }

--- a/src/main/java/com/tabnine/general/ServiceLevel.java
+++ b/src/main/java/com/tabnine/general/ServiceLevel.java
@@ -3,12 +3,12 @@ package com.tabnine.general;
 import com.google.gson.annotations.SerializedName;
 
 public enum ServiceLevel {
-    @SerializedName("Free")
-    FREE,
-    @SerializedName("Pro")
-    PRO,
-    @SerializedName("Trial")
-    TRIAL,
-    @SerializedName("Business")
-    BUSINESS,
+  @SerializedName("Free")
+  FREE,
+  @SerializedName("Pro")
+  PRO,
+  @SerializedName("Trial")
+  TRIAL,
+  @SerializedName("Business")
+  BUSINESS,
 }

--- a/src/main/java/com/tabnine/general/StaticConfig.java
+++ b/src/main/java/com/tabnine/general/StaticConfig.java
@@ -156,17 +156,16 @@ public class StaticConfig {
 
   @NotNull
   public static String versionFullPath(String version) throws InvalidVersionPathException {
-    SemVer semVer = SemVer.parseFromText(version);
-    if (semVer == null) {
-      throw new InvalidVersionPathException(version);
-    }
-    return Paths.get(getBaseDirectory().toString(), semVer.toString(), TARGET_NAME, EXECUTABLE_NAME)
+    return Paths.get(
+            getBaseDirectory().toString(), validVersion(version), TARGET_NAME, EXECUTABLE_NAME)
         .toString();
   }
 
   @NotNull
   public static String bundleFullPath(String version) {
-    return Paths.get(getBaseDirectory().toString(), version, TARGET_NAME, "TabNine.zip").toString();
+    return Paths.get(
+            getBaseDirectory().toString(), validVersion(version), TARGET_NAME, "TabNine.zip")
+        .toString();
   }
 
   @NotNull
@@ -177,5 +176,15 @@ public class StaticConfig {
     jsonObject.put("request", value);
 
     return jsonObject;
+  }
+
+  @NotNull
+  private static String validVersion(String version) throws InvalidVersionPathException {
+    SemVer semVer = SemVer.parseFromText(version);
+    if (semVer == null) {
+      throw new InvalidVersionPathException(version);
+    }
+
+    return semVer.toString();
   }
 }

--- a/src/main/java/com/tabnine/general/StaticConfig.java
+++ b/src/main/java/com/tabnine/general/StaticConfig.java
@@ -160,7 +160,7 @@ public class StaticConfig {
     if (semVer == null) {
       throw new InvalidVersionPathException(version);
     }
-    return Paths.get(getBaseDirectory().toString(), version, TARGET_NAME, EXECUTABLE_NAME)
+    return Paths.get(getBaseDirectory().toString(), semVer.toString(), TARGET_NAME, EXECUTABLE_NAME)
         .toString();
   }
 

--- a/src/main/java/com/tabnine/general/StaticConfig.java
+++ b/src/main/java/com/tabnine/general/StaticConfig.java
@@ -1,168 +1,175 @@
 package com.tabnine.general;
 
+import static java.awt.Color.decode;
+
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.openapi.util.SystemInfo;
 import com.tabnine.userSettings.AppSettingsState;
-import org.jetbrains.annotations.NotNull;
-
-import javax.swing.*;
 import java.awt.*;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-
-import static java.awt.Color.decode;
+import javax.swing.*;
+import org.jetbrains.annotations.NotNull;
 
 public class StaticConfig {
-    // Must be identical to what is written under <id>com.tabnine.TabNine</id> in plugin.xml !!!
-    public static final String TABNINE_PLUGIN_ID_RAW = "com.tabnine.TabNine";
-    public static final PluginId TABNINE_PLUGIN_ID = PluginId.getId(TABNINE_PLUGIN_ID_RAW);
-    public static final int MAX_COMPLETIONS = 5;
-    public static final String BINARY_PROTOCOL_VERSION = "4.0.57";
-    public static final int COMPLETION_TIME_THRESHOLD = 1000;
-    public static final int NEWLINE_COMPLETION_TIME_THRESHOLD = 3000;
-    public static final int ILLEGAL_RESPONSE_THRESHOLD = 5;
-    public static final int CONSECUTIVE_RESTART_THRESHOLD = 5;
-    public static final int ADVERTISEMENT_MAX_LENGTH = 100;
-    public static final int MAX_OFFSET = 100000; // 100 KB
-    public static final int SLEEP_TIME_BETWEEN_FAILURES = 1000;
-    public static final int BINARY_MINIMUM_REASONABLE_SIZE = 1000 * 1000; // roughly 1MB
-    public static final String SET_STATE_RESPONSE_RESULT_STRING = "Done";
-    public static final String UNINSTALLING_FLAG = "--uninstalling";
-    public static final int CONSECUTIVE_TIMEOUTS_THRESHOLD = 20;
-    public static final String BRAND_NAME = "tabnine";
-    public static final String TARGET_NAME = getDistributionName();
-    public static final String EXECUTABLE_NAME = getExeName();
-    public static final String TABNINE_FOLDER_NAME = ".tabnine";
-    public static final int BINARY_READ_TIMEOUT = 5 * 60 * 1000; // 5 minutes
-    public static final int REMOTE_CONNECTION_TIMEOUT = 5_000; // 5 seconds
-    public static final long BINARY_NOTIFICATION_POLLING_INTERVAL = 10_000L; // 10 seconds
-    public static final String USER_HOME_PATH_PROPERTY = "user.home";
-    public static final String REMOTE_BASE_URL_PROPERTY = "TABNINE_REMOTE_BASE_URL";
-    public static final String REMOTE_VERSION_URL_PROPERTY = "TABNINE_REMOTE_VERSION_URL";
-    public static final String REMOTE_BETA_VERSION_URL_PROPERTY = "TABNINE_REMOTE_BETA_VERSION_URL";
-    public static final String LOG_FILE_PATH_PROPERTY = "TABNINE_LOG_FILE_PATH";
-    public static final Icon ICON = IconLoader.findIcon("/icons/tabnine-icon-13px.png");
-    public static final String ICON_AND_NAME_PATH = "/icons/tabnine-13px.png";
-    public static final Icon ICON_AND_NAME = IconLoader.findIcon(ICON_AND_NAME_PATH);
-    public static final Icon ICON_AND_NAME_PRO = IconLoader.findIcon("/icons/tabnine-pro-13px.png");
-    public static final Icon ICON_AND_NAME_BUSINESS = IconLoader.findIcon("/icons/tabnine-business-13px.png");
-    public static final Icon NOTIFICATION_ICON = IconLoader.findIcon("/icons/notification-icon.png");
-    public static final String LIMITATION_SYMBOL = "🔒";
-    public static final Color PROMOTION_TEXT_COLOR = decode("#e12fee");
-    public static final Color PROMOTION_LIGHT_TEXT_COLOR = decode("#FF99FF");
-    private static final int MAX_SLEEP_TIME_BETWEEN_FAILURES = 1_000 * 60 * 60; // 1 hour
-    public static final long BINARY_PROMOTION_POLLING_INTERVAL = 2 * 60 * 1_000L; // 2 minutes
-    public static final long BINARY_PROMOTION_POLLING_DELAY = 10_000L; // 10 seconds
+  // Must be identical to what is written under <id>com.tabnine.TabNine</id> in plugin.xml !!!
+  public static final String TABNINE_PLUGIN_ID_RAW = "com.tabnine.TabNine";
+  public static final PluginId TABNINE_PLUGIN_ID = PluginId.getId(TABNINE_PLUGIN_ID_RAW);
+  public static final int MAX_COMPLETIONS = 5;
+  public static final String BINARY_PROTOCOL_VERSION = "4.0.57";
+  public static final int COMPLETION_TIME_THRESHOLD = 1000;
+  public static final int NEWLINE_COMPLETION_TIME_THRESHOLD = 3000;
+  public static final int ILLEGAL_RESPONSE_THRESHOLD = 5;
+  public static final int CONSECUTIVE_RESTART_THRESHOLD = 5;
+  public static final int ADVERTISEMENT_MAX_LENGTH = 100;
+  public static final int MAX_OFFSET = 100000; // 100 KB
+  public static final int SLEEP_TIME_BETWEEN_FAILURES = 1000;
+  public static final int BINARY_MINIMUM_REASONABLE_SIZE = 1000 * 1000; // roughly 1MB
+  public static final String SET_STATE_RESPONSE_RESULT_STRING = "Done";
+  public static final String UNINSTALLING_FLAG = "--uninstalling";
+  public static final int CONSECUTIVE_TIMEOUTS_THRESHOLD = 20;
+  public static final String BRAND_NAME = "tabnine";
+  public static final String TARGET_NAME = getDistributionName();
+  public static final String EXECUTABLE_NAME = getExeName();
+  public static final String TABNINE_FOLDER_NAME = ".tabnine";
+  public static final int BINARY_READ_TIMEOUT = 5 * 60 * 1000; // 5 minutes
+  public static final int REMOTE_CONNECTION_TIMEOUT = 5_000; // 5 seconds
+  public static final long BINARY_NOTIFICATION_POLLING_INTERVAL = 10_000L; // 10 seconds
+  public static final String USER_HOME_PATH_PROPERTY = "user.home";
+  public static final String REMOTE_BASE_URL_PROPERTY = "TABNINE_REMOTE_BASE_URL";
+  public static final String REMOTE_VERSION_URL_PROPERTY = "TABNINE_REMOTE_VERSION_URL";
+  public static final String REMOTE_BETA_VERSION_URL_PROPERTY = "TABNINE_REMOTE_BETA_VERSION_URL";
+  public static final String LOG_FILE_PATH_PROPERTY = "TABNINE_LOG_FILE_PATH";
+  public static final Icon ICON = IconLoader.findIcon("/icons/tabnine-icon-13px.png");
+  public static final String ICON_AND_NAME_PATH = "/icons/tabnine-13px.png";
+  public static final Icon ICON_AND_NAME = IconLoader.findIcon(ICON_AND_NAME_PATH);
+  public static final Icon ICON_AND_NAME_PRO = IconLoader.findIcon("/icons/tabnine-pro-13px.png");
+  public static final Icon ICON_AND_NAME_BUSINESS =
+      IconLoader.findIcon("/icons/tabnine-business-13px.png");
+  public static final Icon NOTIFICATION_ICON = IconLoader.findIcon("/icons/notification-icon.png");
+  public static final String LIMITATION_SYMBOL = "🔒";
+  public static final Color PROMOTION_TEXT_COLOR = decode("#e12fee");
+  public static final Color PROMOTION_LIGHT_TEXT_COLOR = decode("#FF99FF");
+  private static final int MAX_SLEEP_TIME_BETWEEN_FAILURES = 1_000 * 60 * 60; // 1 hour
+  public static final long BINARY_PROMOTION_POLLING_INTERVAL = 2 * 60 * 1_000L; // 2 minutes
+  public static final long BINARY_PROMOTION_POLLING_DELAY = 10_000L; // 10 seconds
 
-    public static final String OPEN_HUB_ACTION = "OpenHub";
+  public static final String OPEN_HUB_ACTION = "OpenHub";
 
-    public static Optional<String> getLogFilePath() {
-        String logFilePathFromUserSettings = AppSettingsState.getInstance().getLogFilePath();
-        if (!logFilePathFromUserSettings.isEmpty()) {
-            return Optional.of(logFilePathFromUserSettings);
-        }
-
-        return Optional.ofNullable(System.getProperty(LOG_FILE_PATH_PROPERTY));
+  public static Optional<String> getLogFilePath() {
+    String logFilePathFromUserSettings = AppSettingsState.getInstance().getLogFilePath();
+    if (!logFilePathFromUserSettings.isEmpty()) {
+      return Optional.of(logFilePathFromUserSettings);
     }
 
-    public static String getServerUrl() {
-        return Optional.ofNullable(System.getProperty(REMOTE_BASE_URL_PROPERTY)).orElse("https://update.tabnine.com");
+    return Optional.ofNullable(System.getProperty(LOG_FILE_PATH_PROPERTY));
+  }
+
+  public static String getServerUrl() {
+    return Optional.ofNullable(System.getProperty(REMOTE_BASE_URL_PROPERTY))
+        .orElse("https://update.tabnine.com");
+  }
+
+  public static String getBundleServerUrl() {
+    return Optional.ofNullable(System.getProperty(REMOTE_BASE_URL_PROPERTY))
+        .orElse("https://update.tabnine.com/bundles");
+  }
+
+  @NotNull
+  public static String getTabNineVersionUrl() {
+    return Optional.ofNullable(System.getProperty(REMOTE_VERSION_URL_PROPERTY))
+        .orElse(getServerUrl() + "/version");
+  }
+
+  @NotNull
+  public static String getTabNineBundleVersionUrl() {
+    return Optional.ofNullable(System.getProperty(REMOTE_VERSION_URL_PROPERTY))
+        .orElse(getBundleServerUrl() + "/version");
+  }
+
+  @NotNull
+  public static String getTabNineBetaVersionUrl() {
+    return Optional.ofNullable(System.getProperty(REMOTE_BETA_VERSION_URL_PROPERTY))
+        .orElse(getServerUrl() + "/beta_version");
+  }
+
+  public static void sleepUponFailure(int attempt) throws InterruptedException {
+    Thread.sleep(Math.min(exponentialBackoff(attempt), MAX_SLEEP_TIME_BETWEEN_FAILURES));
+  }
+
+  private static int exponentialBackoff(int attempt) {
+    return SLEEP_TIME_BETWEEN_FAILURES * (int) Math.pow(2, Math.min(attempt, 30));
+  }
+
+  /**
+   * We would never like the plugin to stop trying to reload the binary. For it to not bombard the
+   * user, there is an executeSleepStrategy.
+   *
+   * @param attempt
+   * @return
+   */
+  public static boolean shouldTryStartingBinary(int attempt) {
+    return true;
+  }
+
+  private static String getDistributionName() {
+    String arch = SystemInfo.is32Bit ? "i686" : "x86_64";
+    if ("aarch64".equals(System.getProperty("os.arch"))) {
+      arch = "aarch64";
     }
 
-    public static String getBundleServerUrl() {
-        return Optional.ofNullable(System.getProperty(REMOTE_BASE_URL_PROPERTY)).orElse("https://update.tabnine.com/bundles");
+    String platform;
+
+    if (SystemInfo.isWindows) {
+      platform = "pc-windows-gnu";
+    } else if (SystemInfo.isMac) {
+      platform = "apple-darwin";
+    } else if (SystemInfo.isLinux) {
+      platform = "unknown-linux-musl";
+    } else if (SystemInfo.isFreeBSD) {
+      platform = "unknown-freebsd";
+    } else {
+      throw new RuntimeException(
+          "Platform was not recognized as any of Windows, macOS, Linux, FreeBSD");
     }
 
-    @NotNull
-    public static String getTabNineVersionUrl() {
-        return Optional.ofNullable(System.getProperty(REMOTE_VERSION_URL_PROPERTY)).orElse(getServerUrl() + "/version");
-    }
+    return arch + "-" + platform;
+  }
 
-    @NotNull
-    public static String getTabNineBundleVersionUrl() {
-        return Optional.ofNullable(System.getProperty(REMOTE_VERSION_URL_PROPERTY)).orElse(getBundleServerUrl() + "/version");
-    }
+  public static Path getBaseDirectory() {
+    return Paths.get(System.getProperty(USER_HOME_PATH_PROPERTY), TABNINE_FOLDER_NAME);
+  }
 
-    @NotNull
-    public static String getTabNineBetaVersionUrl() {
-        return Optional.ofNullable(System.getProperty(REMOTE_BETA_VERSION_URL_PROPERTY)).orElse(getServerUrl() + "/beta_version");
-    }
+  public static Path getActiveVersionPath() {
+    return getBaseDirectory().resolve(".active");
+  }
 
-    public static void sleepUponFailure(int attempt) throws InterruptedException {
-        Thread.sleep(Math.min(exponentialBackoff(attempt), MAX_SLEEP_TIME_BETWEEN_FAILURES));
-    }
+  private static String getExeName() {
+    return SystemInfo.isWindows ? "TabNine.exe" : "TabNine";
+  }
 
-    private static int exponentialBackoff(int attempt) {
-        return SLEEP_TIME_BETWEEN_FAILURES * (int) Math.pow(2, Math.min(attempt, 30));
-    }
+  @NotNull
+  public static String versionFullPath(String version) {
+    return Paths.get(getBaseDirectory().toString(), version, TARGET_NAME, EXECUTABLE_NAME)
+        .toString();
+  }
 
-    /**
-     * We would never like the plugin to stop trying to reload the binary. For it to not bombard the user, there is an
-     * executeSleepStrategy.
-     *
-     * @param attempt
-     * @return
-     */
-    public static boolean shouldTryStartingBinary(int attempt) {
-        return true;
-    }
+  @NotNull
+  public static String bundleFullPath(String version) {
+    return Paths.get(getBaseDirectory().toString(), version, TARGET_NAME, "TabNine.zip").toString();
+  }
 
-    private static String getDistributionName() {
-        String arch = SystemInfo.is32Bit ? "i686" : "x86_64";
-        if ("aarch64".equals(System.getProperty("os.arch"))) {
-            arch = "aarch64";
-        }
+  @NotNull
+  public static Map<String, Object> wrapWithBinaryRequest(Object value) {
+    Map<String, Object> jsonObject = new HashMap<>();
 
-        String platform;
+    jsonObject.put("version", BINARY_PROTOCOL_VERSION);
+    jsonObject.put("request", value);
 
-        if (SystemInfo.isWindows) {
-            platform = "pc-windows-gnu";
-        } else if (SystemInfo.isMac) {
-            platform = "apple-darwin";
-        } else if (SystemInfo.isLinux) {
-            platform = "unknown-linux-musl";
-        } else if (SystemInfo.isFreeBSD) {
-            platform = "unknown-freebsd";
-        } else {
-            throw new RuntimeException("Platform was not recognized as any of Windows, macOS, Linux, FreeBSD");
-        }
-
-        return arch + "-" + platform;
-    }
-
-    public static Path getBaseDirectory() {
-        return Paths.get(System.getProperty(USER_HOME_PATH_PROPERTY), TABNINE_FOLDER_NAME);
-    }
-
-    public static Path getActiveVersionPath() {
-        return getBaseDirectory().resolve(".active");
-    }
-
-    private static String getExeName() {
-        return SystemInfo.isWindows ? "TabNine.exe" : "TabNine";
-    }
-
-    @NotNull
-    public static String versionFullPath(String version) {
-        return Paths.get(getBaseDirectory().toString(), version, TARGET_NAME, EXECUTABLE_NAME).toString();
-    }
-
-    @NotNull
-    public static String bundleFullPath(String version) {
-        return Paths.get(getBaseDirectory().toString(), version, TARGET_NAME, "TabNine.zip").toString();
-    }
-
-    @NotNull
-    public static Map<String, Object> wrapWithBinaryRequest(Object value) {
-        Map<String, Object> jsonObject = new HashMap<>();
-
-        jsonObject.put("version", BINARY_PROTOCOL_VERSION);
-        jsonObject.put("request", value);
-
-        return jsonObject;
-    }
+    return jsonObject;
+  }
 }

--- a/src/main/java/com/tabnine/general/StaticConfig.java
+++ b/src/main/java/com/tabnine/general/StaticConfig.java
@@ -5,6 +5,8 @@ import static java.awt.Color.decode;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.openapi.util.SystemInfo;
+import com.intellij.util.text.SemVer;
+import com.tabnine.binary.exceptions.InvalidVersionPathException;
 import com.tabnine.userSettings.AppSettingsState;
 import java.awt.*;
 import java.nio.file.Path;
@@ -153,7 +155,11 @@ public class StaticConfig {
   }
 
   @NotNull
-  public static String versionFullPath(String version) {
+  public static String versionFullPath(String version) throws InvalidVersionPathException {
+    SemVer semVer = SemVer.parseFromText(version);
+    if (semVer == null) {
+      throw new InvalidVersionPathException(version);
+    }
     return Paths.get(getBaseDirectory().toString(), version, TARGET_NAME, EXECUTABLE_NAME)
         .toString();
   }

--- a/src/main/java/com/tabnine/general/Utils.java
+++ b/src/main/java/com/tabnine/general/Utils.java
@@ -1,78 +1,73 @@
 package com.tabnine.general;
 
-import com.intellij.codeInsight.lookup.impl.LookupCellRenderer;
+import static com.tabnine.general.StaticConfig.TABNINE_PLUGIN_ID;
+
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.util.TextRange;
-import com.intellij.util.containers.FList;
-import com.tabnine.prediction.TabNineCompletion;
-import org.jetbrains.annotations.NotNull;
-
-import org.jetbrains.annotations.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static com.tabnine.general.StaticConfig.TABNINE_PLUGIN_ID;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class Utils {
-    private static final String UNKNOWN = "Unknown";
+  private static final String UNKNOWN = "Unknown";
 
-    public static String getTabNinePluginVersion() {
-        return getTabNinePluginDescriptor().map(IdeaPluginDescriptor::getVersion).orElse(UNKNOWN);
+  public static String getTabNinePluginVersion() {
+    return getTabNinePluginDescriptor().map(IdeaPluginDescriptor::getVersion).orElse(UNKNOWN);
+  }
+
+  @NotNull
+  public static Optional<IdeaPluginDescriptor> getTabNinePluginDescriptor() {
+    return Arrays.stream(PluginManager.getPlugins())
+        .filter(plugin -> TABNINE_PLUGIN_ID.equals(plugin.getPluginId()))
+        .findAny();
+  }
+
+  public static boolean endsWithADot(Document doc, int positionBeforeSuggestionPrefix) {
+    int begin = positionBeforeSuggestionPrefix - ".".length();
+    if (begin < 0 || positionBeforeSuggestionPrefix > doc.getTextLength()) {
+      return false;
+    } else {
+      String tail = doc.getText(new TextRange(begin, positionBeforeSuggestionPrefix));
+      return tail.equals(".");
+    }
+  }
+
+  @NotNull
+  public static String readContent(InputStream inputStream) throws IOException {
+    ByteArrayOutputStream result = new ByteArrayOutputStream();
+    byte[] buffer = new byte[1024];
+    int length;
+
+    while ((length = inputStream.read(buffer)) != -1) {
+      result.write(buffer, 0, length);
     }
 
-    @NotNull
-    public static Optional<IdeaPluginDescriptor> getTabNinePluginDescriptor() {
-        return Arrays.stream(PluginManager.getPlugins())
-                .filter(plugin -> TABNINE_PLUGIN_ID.equals(plugin.getPluginId()))
-                .findAny();
+    return result.toString(StandardCharsets.UTF_8.name()).trim();
+  }
+
+  @NotNull
+  public static Integer toInt(@Nullable Long aLong) {
+    if (aLong == null) {
+      return 0;
     }
 
-    public static boolean endsWithADot(Document doc, int positionBeforeSuggestionPrefix) {
-        int begin = positionBeforeSuggestionPrefix - ".".length();
-        if (begin < 0 || positionBeforeSuggestionPrefix > doc.getTextLength()) {
-            return false;
-        } else {
-            String tail = doc.getText(new TextRange(begin, positionBeforeSuggestionPrefix));
-            return tail.equals(".");
-        }
-    }
+    return Math.toIntExact(aLong);
+  }
 
-    @NotNull
-    public static String readContent(InputStream inputStream) throws IOException {
-        ByteArrayOutputStream result = new ByteArrayOutputStream();
-        byte[] buffer = new byte[1024];
-        int length;
+  public static List<String> asLines(String block) {
+    return Arrays.stream(block.split("\n")).collect(Collectors.toList());
+  }
 
-        while ((length = inputStream.read(buffer)) != -1) {
-            result.write(buffer, 0, length);
-        }
-
-        return result.toString(StandardCharsets.UTF_8.name()).trim();
-    }
-
-    @NotNull
-    public static Integer toInt(@Nullable Long aLong) {
-        if(aLong == null) {
-            return 0;
-        }
-
-        return Math.toIntExact(aLong);
-    }
-
-    public static List<String> asLines(String block){
-        return Arrays.stream(block.split("\n")).collect(Collectors.toList());
-    }
-
-    public static String cmdSanitize(String text) {
-        return text.replace(" ", "");
-    }
+  public static String cmdSanitize(String text) {
+    return text.replace(" ", "");
+  }
 }

--- a/src/main/java/com/tabnine/inline/AcceptInlineCompletionAction.java
+++ b/src/main/java/com/tabnine/inline/AcceptInlineCompletionAction.java
@@ -6,10 +6,9 @@ import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.actionSystem.EditorAction;
 import com.intellij.openapi.editor.actionSystem.EditorWriteActionHandler;
+import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Objects;
 
 public class AcceptInlineCompletionAction extends EditorAction
     implements HintManagerImpl.ActionToIgnore, InlineCompletionAction {

--- a/src/main/java/com/tabnine/inline/CompletionPreview.java
+++ b/src/main/java/com/tabnine/inline/CompletionPreview.java
@@ -23,232 +23,228 @@ import com.tabnine.inline.render.TabnineInlay;
 import com.tabnine.prediction.TabNineCompletion;
 import com.tabnine.selections.AutoImporter;
 import com.tabnine.selections.CompletionPreviewListener;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.TestOnly;
-
-import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
+import javax.swing.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 public class CompletionPreview implements Disposable, EditorMouseMotionListener {
-    private static final int HINT_DELAY_MS = 100;
-    private static final Key<CompletionPreview> INLINE_COMPLETION_PREVIEW =
-            Key.create("INLINE_COMPLETION_PREVIEW");
+  private static final int HINT_DELAY_MS = 100;
+  private static final Key<CompletionPreview> INLINE_COMPLETION_PREVIEW =
+      Key.create("INLINE_COMPLETION_PREVIEW");
 
-    private final CompletionPreviewListener previewListener =
-            DependencyContainer.instanceOfCompletionPreviewListener();
-    public final Editor editor;
-    private final PsiFile file;
-    private Alarm alarm;
-    private List<TabNineCompletion> completions;
-    private int previewIndex;
-    private String suffix;
-    private final TabnineInlay tabnineInlay;
-    private final InlineKeyListener keyListener;
-    private final AtomicBoolean inApplyMode = new AtomicBoolean(false);
+  private final CompletionPreviewListener previewListener =
+      DependencyContainer.instanceOfCompletionPreviewListener();
+  public final Editor editor;
+  private final PsiFile file;
+  private Alarm alarm;
+  private List<TabNineCompletion> completions;
+  private int previewIndex;
+  private String suffix;
+  private final TabnineInlay tabnineInlay;
+  private final InlineKeyListener keyListener;
+  private final AtomicBoolean inApplyMode = new AtomicBoolean(false);
 
-    private CompletionPreview(@NotNull Editor editor, @NotNull PsiFile file) {
-        this.tabnineInlay = TabnineInlay.create();
-        this.editor = editor;
-        this.file = file;
-        this.keyListener = new InlineKeyListener(editor);
-        this.alarm = new Alarm(this);
+  private CompletionPreview(@NotNull Editor editor, @NotNull PsiFile file) {
+    this.tabnineInlay = TabnineInlay.create();
+    this.editor = editor;
+    this.file = file;
+    this.keyListener = new InlineKeyListener(editor);
+    this.alarm = new Alarm(this);
 
-        editor.getCaretModel().addCaretListener(new InlineCaretListener());
-        ObjectUtils.consumeIfCast(
-                editor,
-                EditorEx.class,
-                e -> e.addFocusListener(new InlineFocusListener())
-        );
+    editor.getCaretModel().addCaretListener(new InlineCaretListener());
+    ObjectUtils.consumeIfCast(
+        editor, EditorEx.class, e -> e.addFocusListener(new InlineFocusListener()));
+  }
+
+  public boolean isCurrentlyDisplayingInlays() {
+    return !tabnineInlay.isEmpty();
+  }
+
+  @Nullable
+  String updatePreview(@NotNull List<TabNineCompletion> completions, int previewIndex, int offset) {
+    if (SuggestionsMode.getSuggestionMode() != SuggestionsMode.INLINE) {
+      return null;
+    }
+    this.completions = completions;
+    this.previewIndex = previewIndex;
+    TabNineCompletion completion = completions.get(previewIndex);
+    this.tabnineInlay.clear();
+
+    suffix = completion.getSuffix();
+
+    if (!suffix.isEmpty()
+        && editor instanceof EditorImpl
+        && !editor.getSelectionModel().hasSelection()
+        && InplaceRefactoring.getActiveInplaceRenamer(editor) == null) {
+      editor.getDocument().startGuardedBlockChecking();
+
+      try {
+        tabnineInlay.render(this.editor, this.suffix, completion, offset);
+      } finally {
+        editor.getDocument().stopGuardedBlockChecking();
+      }
+      if (!tabnineInlay.isEmpty()) {
+        tabnineInlay.register(this);
+        editor.getContentComponent().addKeyListener(keyListener);
+        editor.addEditorMouseMotionListener(this);
+      }
+    }
+    return suffix;
+  }
+
+  public void clear() {
+    if (inApplyMode.get()) {
+      return;
     }
 
-    public boolean isCurrentlyDisplayingInlays() {
-        return !tabnineInlay.isEmpty();
+    if (!tabnineInlay.isEmpty()) {
+      tabnineInlay.clear();
+      editor.removeEditorMouseMotionListener(this);
     }
 
-    @Nullable
-    String updatePreview(@NotNull List<TabNineCompletion> completions, int previewIndex, int offset) {
-        if (SuggestionsMode.getSuggestionMode() != SuggestionsMode.INLINE) {
-            return null;
-        }
-        this.completions = completions;
-        this.previewIndex = previewIndex;
-        TabNineCompletion completion = completions.get(previewIndex);
-        this.tabnineInlay.clear();
+    editor.getContentComponent().removeKeyListener(keyListener);
 
-        suffix = completion.getSuffix();
+    completions = null;
+    suffix = null;
+  }
 
-        if (!suffix.isEmpty()
-                && editor instanceof EditorImpl
-                && !editor.getSelectionModel().hasSelection()
-                && InplaceRefactoring.getActiveInplaceRenamer(editor) == null) {
-            editor.getDocument().startGuardedBlockChecking();
+  @Override
+  public void dispose() {
+    clear();
+    editor.putUserData(INLINE_COMPLETION_PREVIEW, null);
+    CompletionState.clearCompletionState(editor);
+  }
 
-            try {
-                tabnineInlay.render(this.editor, this.suffix, completion, offset);
-            } finally {
-                editor.getDocument().stopGuardedBlockChecking();
-            }
-            if (!tabnineInlay.isEmpty()) {
-                tabnineInlay.register(this);
-                editor.getContentComponent().addKeyListener(keyListener);
-                editor.addEditorMouseMotionListener(this);
-            }
-        }
-        return suffix;
+  @Override
+  public void mouseMoved(@NotNull EditorMouseEvent e) {
+    alarm.cancelAllRequests();
+    if (tabnineInlay.isEmpty()) {
+      return;
+    }
+    if (e.getArea() == EditorMouseEventArea.EDITING_AREA) {
+      MouseEvent mouseEvent = e.getMouseEvent();
+      Point point = mouseEvent.getPoint();
+
+      if (isOverPreview(point)) {
+        alarm.addRequest(
+            () -> {
+              Point p =
+                  SwingUtilities.convertPoint(
+                      (Component) mouseEvent.getSource(),
+                      point,
+                      editor.getComponent().getRootPane().getLayeredPane());
+              InlineHints.showPreInsertionHint(editor, p);
+            },
+            HINT_DELAY_MS);
+      }
+    }
+  }
+
+  @Nullable
+  public Integer getStartOffset() {
+    return tabnineInlay.getOffset();
+  }
+
+  void applyPreview() {
+    inApplyMode.set(true);
+    TabnineDocumentListener.mute();
+    Integer renderedOffset = tabnineInlay.getOffset();
+    if (renderedOffset == null) {
+      return;
     }
 
-    public void clear() {
-        if (inApplyMode.get()) {
-            return;
-        }
+    try {
+      TabNineCompletion currentCompletion = completions.get(previewIndex);
+      int startOffset = renderedOffset - currentCompletion.oldPrefix.length();
+      int endOffset = renderedOffset + suffix.length();
+      if (currentCompletion.oldSuffix != null && !currentCompletion.oldSuffix.trim().isEmpty()) {
+        int deletingEndOffset = renderedOffset + currentCompletion.oldSuffix.length();
+        editor.getDocument().deleteString(renderedOffset, deletingEndOffset);
+      }
+      editor.getDocument().insertString(renderedOffset, suffix);
+      editor.getCaretModel().moveToOffset(endOffset);
+      AutoImporter.registerTabNineAutoImporter(editor, file.getProject(), startOffset, endOffset);
+      previewListener.previewSelected(
+          new CompletionPreviewListener.CompletionPreviewData(completions, previewIndex, file));
+      inApplyMode.set(false);
+      Disposer.dispose(CompletionPreview.this);
+    } catch (Throwable e) {
+      Logger.getInstance(getClass()).warn("Error on committing the renderedOffset completion", e);
+    } finally {
+      inApplyMode.set(false);
+      TabnineDocumentListener.unmute();
+    }
+  }
 
-        if (!tabnineInlay.isEmpty()) {
-            tabnineInlay.clear();
-            editor.removeEditorMouseMotionListener(this);
-        }
+  @NotNull
+  static CompletionPreview findOrCreateCompletionPreview(
+      @NotNull Editor editor, @NotNull PsiFile file) {
+    CompletionPreview preview = findCompletionPreview(editor);
+    if (preview == null) {
+      preview = new CompletionPreview(editor, file);
+      EditorUtil.disposeWithEditor(editor, preview);
+      editor.putUserData(INLINE_COMPLETION_PREVIEW, preview);
+    }
+    return preview;
+  }
 
-        editor.getContentComponent().removeKeyListener(keyListener);
+  @Nullable
+  public static CompletionPreview findCompletionPreview(@NotNull Editor editor) {
+    return editor.getUserData(INLINE_COMPLETION_PREVIEW);
+  }
 
-        completions = null;
-        suffix = null;
+  public static void disposeIfExists(@NotNull Editor editor) {
+    disposeIfExists(editor, preview -> true);
+  }
+
+  static void disposeIfExists(
+      @NotNull Editor editor, @NotNull Predicate<CompletionPreview> condition) {
+    CompletionPreview preview = findCompletionPreview(editor);
+    if (preview != null && condition.test(preview)) {
+      Disposer.dispose(preview);
+    }
+  }
+
+  @TestOnly
+  public static String getPreviewText(@NotNull Editor editor) {
+    CompletionPreview preview = editor.getUserData(INLINE_COMPLETION_PREVIEW);
+    if (preview != null) {
+      return preview.suffix;
+    }
+    return null;
+  }
+
+  @TestOnly
+  public void setAlarm(@NotNull Alarm alarm) {
+    this.alarm = alarm;
+  }
+
+  private boolean isOverPreview(@NotNull Point p) {
+    try {
+      Rectangle bounds = tabnineInlay.getBounds();
+      if (bounds != null) {
+        return bounds.contains(p);
+      }
+    } catch (Throwable e) {
+      // swallow
+    }
+    LogicalPosition pos = editor.xyToLogicalPosition(p);
+    int line = pos.line;
+
+    if (line >= editor.getDocument().getLineCount()) return false;
+
+    int pointOffset = editor.logicalPositionToOffset(pos);
+    Integer inlayOffset = tabnineInlay.getOffset();
+    if (inlayOffset == null) {
+      return false;
     }
 
-    @Override
-    public void dispose() {
-        clear();
-        editor.putUserData(INLINE_COMPLETION_PREVIEW, null);
-        CompletionState.clearCompletionState(editor);
-    }
-
-    @Override
-    public void mouseMoved(@NotNull EditorMouseEvent e) {
-        alarm.cancelAllRequests();
-        if (tabnineInlay.isEmpty()) {
-            return;
-        }
-        if (e.getArea() == EditorMouseEventArea.EDITING_AREA) {
-            MouseEvent mouseEvent = e.getMouseEvent();
-            Point point = mouseEvent.getPoint();
-
-            if (isOverPreview(point)) {
-                alarm.addRequest(
-                        () -> {
-                            Point p =
-                                    SwingUtilities.convertPoint(
-                                            (Component) mouseEvent.getSource(),
-                                            point,
-                                            editor.getComponent().getRootPane().getLayeredPane());
-                            InlineHints.showPreInsertionHint(editor, p);
-                        },
-                        HINT_DELAY_MS);
-            }
-        }
-    }
-
-    @Nullable
-    public Integer getStartOffset() {
-        return tabnineInlay.getOffset();
-    }
-
-    void applyPreview() {
-        inApplyMode.set(true);
-        TabnineDocumentListener.mute();
-        Integer renderedOffset = tabnineInlay.getOffset();
-        if (renderedOffset == null) {
-            return;
-        }
-
-        try {
-            TabNineCompletion currentCompletion = completions.get(previewIndex);
-            int startOffset = renderedOffset - currentCompletion.oldPrefix.length();
-            int endOffset = renderedOffset + suffix.length();
-            if (currentCompletion.oldSuffix != null && !currentCompletion.oldSuffix.trim().isEmpty()) {
-                int deletingEndOffset = renderedOffset + currentCompletion.oldSuffix.length();
-                editor.getDocument().deleteString(renderedOffset, deletingEndOffset);
-            }
-            editor.getDocument().insertString(renderedOffset, suffix);
-            editor.getCaretModel().moveToOffset(endOffset);
-            AutoImporter.registerTabNineAutoImporter(editor, file.getProject(), startOffset, endOffset);
-            previewListener.previewSelected(
-                    new CompletionPreviewListener.CompletionPreviewData(completions, previewIndex, file));
-            inApplyMode.set(false);
-            Disposer.dispose(CompletionPreview.this);
-        } catch (Throwable e) {
-            Logger.getInstance(getClass()).warn("Error on committing the renderedOffset completion", e);
-        } finally {
-            inApplyMode.set(false);
-            TabnineDocumentListener.unmute();
-        }
-    }
-
-    @NotNull
-    static CompletionPreview findOrCreateCompletionPreview(
-            @NotNull Editor editor, @NotNull PsiFile file) {
-        CompletionPreview preview = findCompletionPreview(editor);
-        if (preview == null) {
-            preview = new CompletionPreview(editor, file);
-            EditorUtil.disposeWithEditor(editor, preview);
-            editor.putUserData(INLINE_COMPLETION_PREVIEW, preview);
-        }
-        return preview;
-    }
-
-    @Nullable
-    public static CompletionPreview findCompletionPreview(@NotNull Editor editor) {
-        return editor.getUserData(INLINE_COMPLETION_PREVIEW);
-    }
-
-    public static void disposeIfExists(@NotNull Editor editor) {
-        disposeIfExists(editor, preview -> true);
-    }
-
-    static void disposeIfExists(
-            @NotNull Editor editor, @NotNull Predicate<CompletionPreview> condition) {
-        CompletionPreview preview = findCompletionPreview(editor);
-        if (preview != null && condition.test(preview)) {
-            Disposer.dispose(preview);
-        }
-    }
-
-    @TestOnly
-    public static String getPreviewText(@NotNull Editor editor) {
-        CompletionPreview preview = editor.getUserData(INLINE_COMPLETION_PREVIEW);
-        if (preview != null) {
-            return preview.suffix;
-        }
-        return null;
-    }
-
-    @TestOnly
-    public void setAlarm(@NotNull Alarm alarm) {
-        this.alarm = alarm;
-    }
-
-    private boolean isOverPreview(@NotNull Point p) {
-        try {
-            Rectangle bounds = tabnineInlay.getBounds();
-            if (bounds != null) {
-                return bounds.contains(p);
-            }
-        } catch (Throwable e) {
-            // swallow
-        }
-        LogicalPosition pos = editor.xyToLogicalPosition(p);
-        int line = pos.line;
-
-        if (line >= editor.getDocument().getLineCount()) return false;
-
-        int pointOffset = editor.logicalPositionToOffset(pos);
-        Integer inlayOffset = tabnineInlay.getOffset();
-        if (inlayOffset == null) {
-            return false;
-        }
-
-        return pointOffset >= inlayOffset && pointOffset <= inlayOffset + suffix.length();
-    }
+    return pointOffset >= inlayOffset && pointOffset <= inlayOffset + suffix.length();
+  }
 }

--- a/src/main/java/com/tabnine/inline/CompletionState.java
+++ b/src/main/java/com/tabnine/inline/CompletionState.java
@@ -3,43 +3,42 @@ package com.tabnine.inline;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.Key;
 import com.tabnine.prediction.TabNineCompletion;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-
 public class CompletionState {
-    private static final Key<CompletionState> INLINE_COMPLETION_STATE =
-            Key.create("INLINE_COMPLETION_STATE");
+  private static final Key<CompletionState> INLINE_COMPLETION_STATE =
+      Key.create("INLINE_COMPLETION_STATE");
 
-    int lastDisplayedCompletionIndex;
-    boolean preInsertionHintShown;
-    int lastStartOffset;
-    long lastModificationStamp;
-    String lastDisplayedPreview;
-    List<TabNineCompletion> suggestions;
+  int lastDisplayedCompletionIndex;
+  boolean preInsertionHintShown;
+  int lastStartOffset;
+  long lastModificationStamp;
+  String lastDisplayedPreview;
+  List<TabNineCompletion> suggestions;
 
-    void resetStats() {
-        this.lastModificationStamp = 0;
+  void resetStats() {
+    this.lastModificationStamp = 0;
+  }
+
+  public void preInsertionHintShown() {
+    this.preInsertionHintShown = true;
+  }
+
+  public boolean isPreInsertionHintShown() {
+    return this.preInsertionHintShown;
+  }
+
+  static CompletionState findOrCreateCompletionState(@NotNull Editor editor) {
+    CompletionState state = editor.getUserData(INLINE_COMPLETION_STATE);
+    if (state == null) {
+      state = new CompletionState();
+      editor.putUserData(INLINE_COMPLETION_STATE, state);
     }
+    return state;
+  }
 
-    public void preInsertionHintShown() {
-        this.preInsertionHintShown = true;
-    }
-
-    public boolean isPreInsertionHintShown() {
-        return this.preInsertionHintShown;
-    }
-
-    static CompletionState findOrCreateCompletionState(@NotNull Editor editor) {
-        CompletionState state = editor.getUserData(INLINE_COMPLETION_STATE);
-        if (state == null) {
-            state = new CompletionState();
-            editor.putUserData(INLINE_COMPLETION_STATE, state);
-        }
-        return state;
-    }
-
-    static void clearCompletionState(@NotNull Editor editor) {
-        editor.putUserData(INLINE_COMPLETION_STATE, null);
-    }
+  static void clearCompletionState(@NotNull Editor editor) {
+    editor.putUserData(INLINE_COMPLETION_STATE, null);
+  }
 }

--- a/src/main/java/com/tabnine/inline/InlineActionsPromoter.java
+++ b/src/main/java/com/tabnine/inline/InlineActionsPromoter.java
@@ -5,7 +5,6 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Editor;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
+++ b/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
@@ -24,202 +24,209 @@ import com.tabnine.intellij.completions.CompletionUtils;
 import com.tabnine.intellij.completions.LimitedSecletionsChangedNotifier;
 import com.tabnine.prediction.CompletionFacade;
 import com.tabnine.prediction.TabNineCompletion;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class InlineCompletionHandler implements CodeInsightActionHandler {
-    private static final Set<Character> CLOSING_CHARACTERS = ContainerUtil.set('\'', '"', '`', ']', '}', ')', '>');
-    public static final int DEBOUNCE_MILLIS = 350;
+  private static final Set<Character> CLOSING_CHARACTERS =
+      ContainerUtil.set('\'', '"', '`', ']', '}', ')', '>');
+  public static final int DEBOUNCE_MILLIS = 350;
 
-    private final CompletionFacade completionFacade =
-            DependencyContainer.instanceOfCompletionFacade();
-    private final BinaryRequestFacade binaryRequestFacade = DependencyContainer.instanceOfBinaryRequestFacade();
-    private final MessageBus messageBus = ApplicationManager.getApplication().getMessageBus();
-    private Future<?> lastPreviewTask = null;
-    private final boolean myForward;
+  private final CompletionFacade completionFacade =
+      DependencyContainer.instanceOfCompletionFacade();
+  private final BinaryRequestFacade binaryRequestFacade =
+      DependencyContainer.instanceOfBinaryRequestFacade();
+  private final MessageBus messageBus = ApplicationManager.getApplication().getMessageBus();
+  private Future<?> lastPreviewTask = null;
+  private final boolean myForward;
 
-    private static boolean isLocked;
+  private static boolean isLocked;
 
-    InlineCompletionHandler(boolean forward) {
-        this.myForward = forward;
+  InlineCompletionHandler(boolean forward) {
+    this.myForward = forward;
+  }
+
+  void invoke(@NotNull Editor editor, @NotNull PsiFile file, int offset) {
+    Document document = editor.getDocument();
+
+    // if we cannot modify this file, return
+    if (editor.isViewer() || document.getRangeGuard(offset, offset) != null) {
+      document.fireReadOnlyModificationAttempt();
+      EditorModificationUtil.checkModificationAllowed(editor);
+      return;
     }
 
-    void invoke(@NotNull Editor editor, @NotNull PsiFile file, int offset) {
-        Document document = editor.getDocument();
-
-        // if we cannot modify this file, return
-        if (editor.isViewer() || document.getRangeGuard(offset, offset) != null) {
-            document.fireReadOnlyModificationAttempt();
-            EditorModificationUtil.checkModificationAllowed(editor);
-            return;
-        }
-
-        if (isInTheMiddleOfWord(document, offset)) {
-            return;
-        }
-
-        // data about previous completions, or just a new fresh state for the editor
-        final CompletionState completionState = CompletionState.findOrCreateCompletionState(editor);
-        int lastDisplayedCompletionIndex = completionState.lastDisplayedCompletionIndex;
-
-        boolean noOldSuggestion = lastDisplayedCompletionIndex == -1;
-        boolean editorLocationHasChanged = completionState.lastStartOffset != offset;
-        boolean documentChanged =
-                completionState.lastModificationStamp != document.getModificationStamp();
-
-        if (noOldSuggestion || editorLocationHasChanged || documentChanged) {
-            // start a new query
-            completionState.lastDisplayedCompletionIndex = -1;
-            retrieveAndShowInlineCompletion(editor, file, completionState, offset);
-        } else {
-            showInlineCompletion(editor, file, completionState, completionState.lastStartOffset);
-        }
+    if (isInTheMiddleOfWord(document, offset)) {
+      return;
     }
 
-    private boolean isInTheMiddleOfWord(@NotNull Document document, int offset) {
-        try {
-            if (DocumentUtil.isAtLineEnd(offset, document)) {
-                return false;
-            }
-            char nextChar = document.getText(new TextRange(offset, offset + 1)).charAt(0);
-            return !CLOSING_CHARACTERS.contains(nextChar) && !Character.isWhitespace(nextChar);
-        } catch (Throwable e) {
-            Logger.getInstance(getClass()).debug("Could not determine if text is in the middle of word, skipping: ", e);
-        }
+    // data about previous completions, or just a new fresh state for the editor
+    final CompletionState completionState = CompletionState.findOrCreateCompletionState(editor);
+    int lastDisplayedCompletionIndex = completionState.lastDisplayedCompletionIndex;
 
+    boolean noOldSuggestion = lastDisplayedCompletionIndex == -1;
+    boolean editorLocationHasChanged = completionState.lastStartOffset != offset;
+    boolean documentChanged =
+        completionState.lastModificationStamp != document.getModificationStamp();
+
+    if (noOldSuggestion || editorLocationHasChanged || documentChanged) {
+      // start a new query
+      completionState.lastDisplayedCompletionIndex = -1;
+      retrieveAndShowInlineCompletion(editor, file, completionState, offset);
+    } else {
+      showInlineCompletion(editor, file, completionState, completionState.lastStartOffset);
+    }
+  }
+
+  private boolean isInTheMiddleOfWord(@NotNull Document document, int offset) {
+    try {
+      if (DocumentUtil.isAtLineEnd(offset, document)) {
         return false;
+      }
+      char nextChar = document.getText(new TextRange(offset, offset + 1)).charAt(0);
+      return !CLOSING_CHARACTERS.contains(nextChar) && !Character.isWhitespace(nextChar);
+    } catch (Throwable e) {
+      Logger.getInstance(getClass())
+          .debug("Could not determine if text is in the middle of word, skipping: ", e);
     }
 
-    @Override
-    public void invoke(@NotNull Project project, @NotNull Editor editor, @NotNull PsiFile file) {
-        int caretOffset = editor.getCaretModel().getOffset();
-        invoke(editor, file, caretOffset);
+    return false;
+  }
+
+  @Override
+  public void invoke(@NotNull Project project, @NotNull Editor editor, @NotNull PsiFile file) {
+    int caretOffset = editor.getCaretModel().getOffset();
+    invoke(editor, file, caretOffset);
+  }
+
+  private void showInlineCompletion(
+      @NotNull Editor editor,
+      @NotNull PsiFile file,
+      CompletionState completionState,
+      int startOffset) {
+    showInlineCompletion(editor, file, completionState, startOffset, null);
+  }
+
+  private void showInlineCompletion(
+      @NotNull Editor editor,
+      @NotNull PsiFile file,
+      CompletionState completionState,
+      int startOffset,
+      @Nullable OnCompletionPreviewUpdatedCallback onCompletionPreviewUpdatedCallback) {
+    if (completionState.suggestions == null || completionState.suggestions.isEmpty()) {
+      return;
+    }
+    int diff = myForward ? 1 : -1;
+    int size = completionState.suggestions.size();
+    // Make sure to keep the index in the valid range
+    int nextIndex = (completionState.lastDisplayedCompletionIndex + diff + size) % size;
+    final TabNineCompletion nextSuggestion = completionState.suggestions.get(nextIndex);
+    if (nextSuggestion == null) {
+      return;
     }
 
-    private void showInlineCompletion(
-            @NotNull Editor editor,
-            @NotNull PsiFile file,
-            CompletionState completionState,
-            int startOffset) {
-        showInlineCompletion(editor, file, completionState, startOffset, null);
+    CompletionPreview preview = CompletionPreview.findOrCreateCompletionPreview(editor, file);
+    completionState.lastDisplayedPreview =
+        preview.updatePreview(completionState.suggestions, nextIndex, startOffset);
+    if (onCompletionPreviewUpdatedCallback != null) {
+      onCompletionPreviewUpdatedCallback.onCompletionPreviewUpdated(
+          completionState.suggestions.get(nextIndex));
     }
+    completionState.lastDisplayedCompletionIndex = nextIndex;
+    completionState.lastStartOffset = startOffset;
+    completionState.lastModificationStamp = editor.getDocument().getModificationStamp();
+  }
 
-    private void showInlineCompletion(
-            @NotNull Editor editor,
-            @NotNull PsiFile file,
-            CompletionState completionState,
-            int startOffset,
-            @Nullable OnCompletionPreviewUpdatedCallback onCompletionPreviewUpdatedCallback) {
-        if (completionState.suggestions == null || completionState.suggestions.isEmpty()) {
-            return;
-        }
-        int diff = myForward ? 1 : -1;
-        int size = completionState.suggestions.size();
-        // Make sure to keep the index in the valid range
-        int nextIndex = (completionState.lastDisplayedCompletionIndex + diff + size) % size;
-        final TabNineCompletion nextSuggestion = completionState.suggestions.get(nextIndex);
-        if (nextSuggestion == null) {
-            return;
-        }
+  private void retrieveInlineCompletion(
+      @NotNull Document document, CompletionState completionState, int startOffset) {
+    AutocompleteResponse completionsResponse =
+        this.completionFacade.retrieveCompletions(document, startOffset);
 
-        CompletionPreview preview = CompletionPreview.findOrCreateCompletionPreview(editor, file);
-        completionState.lastDisplayedPreview =
-                preview.updatePreview(completionState.suggestions, nextIndex, startOffset);
-        if (onCompletionPreviewUpdatedCallback != null) {
-            onCompletionPreviewUpdatedCallback.onCompletionPreviewUpdated(completionState.suggestions.get(nextIndex));
-        }
-        completionState.lastDisplayedCompletionIndex = nextIndex;
-        completionState.lastStartOffset = startOffset;
-        completionState.lastModificationStamp = editor.getDocument().getModificationStamp();
+    if (completionsResponse == null || completionsResponse.results.length == 0) {
+      return;
     }
-
-    private void retrieveInlineCompletion(
-            @NotNull Document document, CompletionState completionState, int startOffset) {
-        AutocompleteResponse completionsResponse =
-                this.completionFacade.retrieveCompletions(document, startOffset);
-
-        if (completionsResponse == null || completionsResponse.results.length == 0) {
-            return;
-        }
-        if (isLocked != completionsResponse.is_locked) {
-            isLocked = completionsResponse.is_locked;
-            this.messageBus
-                    .syncPublisher(LimitedSecletionsChangedNotifier.LIMITED_SELECTIONS_CHANGED_TOPIC)
-                    .limitedChanged(completionsResponse.is_locked);
-        }
-        completionState.suggestions =
-                createCompletions(completionsResponse, document, startOffset);
+    if (isLocked != completionsResponse.is_locked) {
+      isLocked = completionsResponse.is_locked;
+      this.messageBus
+          .syncPublisher(LimitedSecletionsChangedNotifier.LIMITED_SELECTIONS_CHANGED_TOPIC)
+          .limitedChanged(completionsResponse.is_locked);
     }
+    completionState.suggestions = createCompletions(completionsResponse, document, startOffset);
+  }
 
-    private void retrieveAndShowInlineCompletion(
-            @NotNull Editor editor,
-            @NotNull PsiFile file,
-            CompletionState completionState,
-            int startOffset) {
-        final Document document = editor.getDocument();
-        final long lastModified = document.getModificationStamp();
+  private void retrieveAndShowInlineCompletion(
+      @NotNull Editor editor,
+      @NotNull PsiFile file,
+      CompletionState completionState,
+      int startOffset) {
+    final Document document = editor.getDocument();
+    final long lastModified = document.getModificationStamp();
 
-        if (ApplicationManager.getApplication().isUnitTestMode()) {
+    if (ApplicationManager.getApplication().isUnitTestMode()) {
+      retrieveInlineCompletion(document, completionState, startOffset);
+      completionState.resetStats();
+      showInlineCompletion(editor, file, completionState, startOffset);
+    } else {
+      ObjectUtils.doIfNotNull(lastPreviewTask, task -> task.cancel(false));
+
+      Callable<Void> runnable =
+          () -> {
+            long start = System.currentTimeMillis();
             retrieveInlineCompletion(document, completionState, startOffset);
-            completionState.resetStats();
-            showInlineCompletion(editor, file, completionState, startOffset);
-        } else {
-            ObjectUtils.doIfNotNull(lastPreviewTask, task -> task.cancel(false));
-
-            Callable<Void> runnable = () -> {
-                long start = System.currentTimeMillis();
-                retrieveInlineCompletion(document, completionState, startOffset);
-                long end = System.currentTimeMillis();
-                Thread.sleep(Math.max(0, DEBOUNCE_MILLIS - (end - start)));
-                if (editor.getDocument().getModificationStamp() != lastModified) {
-                    return null;
-                }
-                ApplicationManager.getApplication().invokeLater(() -> {
-                    completionState.resetStats();
-                    showInlineCompletion(editor, file, completionState, startOffset, this::afterCompletionShown);
-                }, (Condition<Void>) unused -> editor.getDocument().getModificationStamp() != lastModified);
-                return null;
-            };
-            lastPreviewTask = AppExecutorUtil.getAppExecutorService().submit(runnable);
-        }
-    }
-
-    private void afterCompletionShown(TabNineCompletion completion) {
-        // binary is not supporting api version ^4.0.57
-        if (completion.isCached == null) return;
-
-        if (completion.completionKind == CompletionKind.Snippet && !completion.isCached) {
-            try {
-                this.binaryRequestFacade.executeRequest(new SnippetShownRequest());
-            } catch (RuntimeException e) {
-                // swallow - nothing to do with this
+            long end = System.currentTimeMillis();
+            Thread.sleep(Math.max(0, DEBOUNCE_MILLIS - (end - start)));
+            if (editor.getDocument().getModificationStamp() != lastModified) {
+              return null;
             }
-        }
+            ApplicationManager.getApplication()
+                .invokeLater(
+                    () -> {
+                      completionState.resetStats();
+                      showInlineCompletion(
+                          editor, file, completionState, startOffset, this::afterCompletionShown);
+                    },
+                    (Condition<Void>)
+                        unused -> editor.getDocument().getModificationStamp() != lastModified);
+            return null;
+          };
+      lastPreviewTask = AppExecutorUtil.getAppExecutorService().submit(runnable);
+    }
+  }
+
+  private void afterCompletionShown(TabNineCompletion completion) {
+    // binary is not supporting api version ^4.0.57
+    if (completion.isCached == null) return;
+
+    if (completion.completionKind == CompletionKind.Snippet && !completion.isCached) {
+      try {
+        this.binaryRequestFacade.executeRequest(new SnippetShownRequest());
+      } catch (RuntimeException e) {
+        // swallow - nothing to do with this
+      }
+    }
+  }
+
+  private List<TabNineCompletion> createCompletions(
+      AutocompleteResponse completions, @NotNull Document document, int offset) {
+    List<TabNineCompletion> result = new ArrayList<>();
+    for (int index = 0;
+        index < completions.results.length
+            && index
+                < CompletionUtils.completionLimit(
+                    document, completions.old_prefix, offset, completions.is_locked);
+        index++) {
+      TabNineCompletion completion =
+          CompletionUtils.createTabnineCompletion(
+              document, offset, completions.old_prefix, completions.results[index], index);
+
+      result.add(completion);
     }
 
-    private List<TabNineCompletion> createCompletions(
-            AutocompleteResponse completions,
-            @NotNull Document document,
-            int offset) {
-        List<TabNineCompletion> result = new ArrayList<>();
-        for (int index = 0;
-             index < completions.results.length
-                     && index
-                     < CompletionUtils.completionLimit(document, completions.old_prefix, offset, completions.is_locked);
-             index++) {
-            TabNineCompletion completion =
-                    CompletionUtils.createTabnineCompletion(
-                            document, offset, completions.old_prefix, completions.results[index], index);
-
-            result.add(completion);
-        }
-
-        return result;
-    }
+    return result;
+  }
 }

--- a/src/main/java/com/tabnine/inline/InlineHints.java
+++ b/src/main/java/com/tabnine/inline/InlineHints.java
@@ -14,116 +14,115 @@ import com.intellij.ui.SimpleColoredText;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.ui.JBUI;
 import com.tabnine.general.StaticConfig;
+import java.awt.*;
+import java.awt.event.KeyEvent;
+import javax.swing.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.KeyEvent;
-
 public class InlineHints {
 
-    private static final HintManagerImpl hintManager = HintManagerImpl.getInstanceImpl();
-    private static String currentText;
-    private static JComponent preInsertionHintComponent;
+  private static final HintManagerImpl hintManager = HintManagerImpl.getInstanceImpl();
+  private static String currentText;
+  private static JComponent preInsertionHintComponent;
 
-    static {
-        initPreInsertionHint();
+  static {
+    initPreInsertionHint();
+  }
+
+  private static void initPreInsertionHint() {
+    String nextShortcut = getShortcutText(ShowNextInlineCompletionAction.ACTION_ID);
+    String prevShortcut = getShortcutText(ShowPreviousInlineCompletionAction.ACTION_ID);
+    String acceptShortcut = getShortcutText(AcceptInlineCompletionAction.ACTION_ID);
+    String cancelShortcut = KeymapUtil.getKeyText(KeyEvent.VK_ESCAPE);
+    String text =
+        "Next ("
+            + nextShortcut
+            + ") Prev ("
+            + prevShortcut
+            + ") Accept ("
+            + acceptShortcut
+            + ") Cancel ("
+            + cancelShortcut
+            + ")";
+    if (!text.equals(currentText) || preInsertionHintComponent == null) {
+      currentText = text;
+      preInsertionHintComponent = createInlineHintComponent(text);
+    }
+  }
+
+  private static String getShortcutText(String actionId) {
+    String shortcutText =
+        KeymapUtil.getFirstKeyboardShortcutText(ActionManager.getInstance().getAction(actionId));
+    return StringUtil.defaultIfEmpty(shortcutText, "Missing shortcut key");
+  }
+
+  private static JComponent createInlineHintComponent(String text) {
+    SimpleColoredComponent component = HintUtil.createInformationComponent();
+    component.setIconOnTheRight(true);
+    component.setIcon(StaticConfig.ICON_AND_NAME);
+    SimpleColoredText coloredText =
+        new SimpleColoredText(text, SimpleTextAttributes.REGULAR_ATTRIBUTES);
+    coloredText.appendToComponent(component);
+    return new InlineHintLabel(component);
+  }
+
+  public static void showPreInsertionHint(@NotNull Editor editor, @Nullable Point pos) {
+    try {
+      initPreInsertionHint();
+
+      LightweightHint hint = new LightweightHint(preInsertionHintComponent);
+      if (pos == null) {
+        pos = hintManager.getHintPosition(hint, editor, HintManager.ABOVE);
+      }
+      int flags = HintManager.HIDE_BY_ESCAPE | HintManager.UPDATE_BY_SCROLLING;
+      hintManager.showEditorHint(hint, editor, pos, flags, 0, false);
+    } catch (Throwable e) {
+      Logger.getInstance(InlineHints.class).warn("showPreInsertionHint failed", e);
+    }
+  }
+
+  private static class InlineHintLabel extends JPanel {
+
+    private JEditorPane myPane;
+    private SimpleColoredComponent myColoredComponent;
+
+    private InlineHintLabel(@NotNull SimpleColoredComponent component) {
+      super(new BorderLayout());
+      setBorder(JBUI.Borders.empty());
+      setText(component);
     }
 
-    private static void initPreInsertionHint() {
-        String nextShortcut = getShortcutText(ShowNextInlineCompletionAction.ACTION_ID);
-        String prevShortcut = getShortcutText(ShowPreviousInlineCompletionAction.ACTION_ID);
-        String acceptShortcut = getShortcutText(AcceptInlineCompletionAction.ACTION_ID);
-        String cancelShortcut = KeymapUtil.getKeyText(KeyEvent.VK_ESCAPE);
-        String text =
-                "Next ("
-                        + nextShortcut
-                        + ") Prev ("
-                        + prevShortcut
-                        + ") Accept ("
-                        + acceptShortcut
-                        + ") Cancel ("
-                        + cancelShortcut
-                        + ")";
-        if (!text.equals(currentText) || preInsertionHintComponent == null) {
-            currentText = text;
-            preInsertionHintComponent = createInlineHintComponent(text);
-        }
+    private void setText(@NotNull SimpleColoredComponent colored) {
+      clearText();
+      myColoredComponent = colored;
+      add(myColoredComponent, BorderLayout.CENTER);
+      setOpaque(true);
+      setBackground(colored.getBackground());
+      revalidate();
+      repaint();
     }
 
-    private static String getShortcutText(String actionId) {
-        String shortcutText =
-                KeymapUtil.getFirstKeyboardShortcutText(ActionManager.getInstance().getAction(actionId));
-        return StringUtil.defaultIfEmpty(shortcutText, "Missing shortcut key");
+    private void clearText() {
+      if (myPane != null) {
+        remove(myPane);
+        myPane = null;
+      }
+
+      if (myColoredComponent != null) {
+        remove(myColoredComponent);
+        myColoredComponent = null;
+      }
     }
 
-    private static JComponent createInlineHintComponent(String text) {
-        SimpleColoredComponent component = HintUtil.createInformationComponent();
-        component.setIconOnTheRight(true);
-        component.setIcon(StaticConfig.ICON_AND_NAME);
-        SimpleColoredText coloredText =
-                new SimpleColoredText(text, SimpleTextAttributes.REGULAR_ATTRIBUTES);
-        coloredText.appendToComponent(component);
-        return new InlineHintLabel(component);
+    @Override
+    public boolean requestFocusInWindow() {
+      if (myPane != null) {
+        return myPane.requestFocusInWindow();
+      } else if (myColoredComponent != null) {
+        return myColoredComponent.requestFocusInWindow();
+      }
+      return super.requestFocusInWindow();
     }
-
-    public static void showPreInsertionHint(@NotNull Editor editor, @Nullable Point pos) {
-        try {
-            initPreInsertionHint();
-
-            LightweightHint hint = new LightweightHint(preInsertionHintComponent);
-            if (pos == null) {
-                pos = hintManager.getHintPosition(hint, editor, HintManager.ABOVE);
-            }
-            int flags = HintManager.HIDE_BY_ESCAPE | HintManager.UPDATE_BY_SCROLLING;
-            hintManager.showEditorHint(hint, editor, pos, flags, 0, false);
-        } catch (Throwable e) {
-            Logger.getInstance(InlineHints.class).warn("showPreInsertionHint failed", e);
-        }
-    }
-
-    private static class InlineHintLabel extends JPanel {
-
-        private JEditorPane myPane;
-        private SimpleColoredComponent myColoredComponent;
-
-        private InlineHintLabel(@NotNull SimpleColoredComponent component) {
-            super(new BorderLayout());
-            setBorder(JBUI.Borders.empty());
-            setText(component);
-        }
-
-        private void setText(@NotNull SimpleColoredComponent colored) {
-            clearText();
-            myColoredComponent = colored;
-            add(myColoredComponent, BorderLayout.CENTER);
-            setOpaque(true);
-            setBackground(colored.getBackground());
-            revalidate();
-            repaint();
-        }
-
-        private void clearText() {
-            if (myPane != null) {
-                remove(myPane);
-                myPane = null;
-            }
-
-            if (myColoredComponent != null) {
-                remove(myColoredComponent);
-                myColoredComponent = null;
-            }
-        }
-
-        @Override
-        public boolean requestFocusInWindow() {
-            if (myPane != null) {
-                return myPane.requestFocusInWindow();
-            } else if (myColoredComponent != null) {
-                return myColoredComponent.requestFocusInWindow();
-            }
-            return super.requestFocusInWindow();
-        }
-    }
+  }
 }

--- a/src/main/java/com/tabnine/intellij/completions/CompletionUtils.java
+++ b/src/main/java/com/tabnine/intellij/completions/CompletionUtils.java
@@ -1,5 +1,8 @@
 package com.tabnine.intellij.completions;
 
+import static com.tabnine.general.StaticConfig.MAX_COMPLETIONS;
+import static com.tabnine.general.Utils.endsWithADot;
+
 import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.openapi.editor.Document;
@@ -8,69 +11,62 @@ import com.tabnine.binary.requests.autocomplete.ResultEntry;
 import com.tabnine.prediction.TabNineCompletion;
 import org.jetbrains.annotations.NotNull;
 
-import static com.tabnine.general.StaticConfig.MAX_COMPLETIONS;
-import static com.tabnine.general.Utils.endsWithADot;
-
 public class CompletionUtils {
 
-    private static String getCursorPrefix(@NotNull Document document, int cursorPosition) {
-        int lineNumber = document.getLineNumber(cursorPosition);
-        int lineStart = document.getLineStartOffset(lineNumber);
+  private static String getCursorPrefix(@NotNull Document document, int cursorPosition) {
+    int lineNumber = document.getLineNumber(cursorPosition);
+    int lineStart = document.getLineStartOffset(lineNumber);
 
-        return document.getText(TextRange.create(lineStart, cursorPosition)).trim();
+    return document.getText(TextRange.create(lineStart, cursorPosition)).trim();
+  }
+
+  private static String getCursorSuffix(@NotNull Document document, int cursorPosition) {
+    int lineNumber = document.getLineNumber(cursorPosition);
+    int lineEnd = document.getLineEndOffset(lineNumber);
+
+    return document.getText(TextRange.create(cursorPosition, lineEnd)).trim();
+  }
+
+  @NotNull
+  public static TabNineCompletion createTabnineCompletion(
+      @NotNull Document document, int offset, String oldPrefix, ResultEntry result, int index) {
+    TabNineCompletion completion =
+        new TabNineCompletion(
+            oldPrefix,
+            result.new_prefix,
+            result.old_suffix,
+            result.new_suffix,
+            index,
+            CompletionUtils.getCursorPrefix(document, offset),
+            CompletionUtils.getCursorSuffix(document, offset),
+            result.origin,
+            result.completion_kind,
+            result.is_cached);
+
+    completion.detail = result.detail;
+
+    if (result.deprecated != null) {
+      completion.deprecated = result.deprecated;
     }
+    return completion;
+  }
 
-    private static String getCursorSuffix(@NotNull Document document, int cursorPosition) {
-        int lineNumber = document.getLineNumber(cursorPosition);
-        int lineEnd = document.getLineEndOffset(lineNumber);
+  static int completionLimit(
+      CompletionParameters parameters, CompletionResultSet result, boolean isLocked) {
+    return completionLimit(
+        parameters.getEditor().getDocument(),
+        result.getPrefixMatcher().getPrefix(),
+        parameters.getOffset(),
+        isLocked);
+  }
 
-        return document.getText(TextRange.create(cursorPosition, lineEnd)).trim();
+  public static int completionLimit(
+      @NotNull Document document, @NotNull String prefix, int offset, boolean isLocked) {
+    if (isLocked) {
+      return 1;
     }
+    boolean preferTabNine = !endsWithADot(document, offset - prefix.length());
 
-    @NotNull
-    public static TabNineCompletion createTabnineCompletion(
-            @NotNull Document document,
-            int offset,
-            String oldPrefix,
-            ResultEntry result,
-            int index) {
-        TabNineCompletion completion =
-                new TabNineCompletion(
-                        oldPrefix,
-                        result.new_prefix,
-                        result.old_suffix,
-                        result.new_suffix,
-                        index,
-                        CompletionUtils.getCursorPrefix(document, offset),
-                        CompletionUtils.getCursorSuffix(document, offset),
-                        result.origin,
-                        result.completion_kind,
-                        result.is_cached);
-
-        completion.detail = result.detail;
-
-        if (result.deprecated != null) {
-            completion.deprecated = result.deprecated;
-        }
-        return completion;
-    }
-
-    static int completionLimit(
-            CompletionParameters parameters, CompletionResultSet result, boolean isLocked) {
-        return completionLimit(
-                parameters.getEditor().getDocument(),
-                result.getPrefixMatcher().getPrefix(),
-                parameters.getOffset(),
-                isLocked);
-    }
-
-    public static int completionLimit(
-            @NotNull Document document, @NotNull String prefix, int offset, boolean isLocked) {
-        if (isLocked) {
-            return 1;
-        }
-        boolean preferTabNine = !endsWithADot(document, offset - prefix.length());
-
-        return preferTabNine ? MAX_COMPLETIONS : 1;
-    }
+    return preferTabNine ? MAX_COMPLETIONS : 1;
+  }
 }

--- a/src/main/java/com/tabnine/intellij/completions/InlayHoverMouseMotionListener.java
+++ b/src/main/java/com/tabnine/intellij/completions/InlayHoverMouseMotionListener.java
@@ -20,155 +20,173 @@ import com.tabnine.binary.requests.notifications.shown.HoverShownRequest;
 import com.tabnine.general.DependencyContainer;
 import com.tabnine.general.NotificationOption;
 import com.tabnine.general.StaticConfig;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import javax.swing.event.HyperlinkEvent;
-import javax.swing.event.HyperlinkListener;
 import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.util.Arrays;
 import java.util.Optional;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.HyperlinkListener;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class InlayHoverMouseMotionListener implements EditorMouseMotionListener {
-    private final BinaryRequestFacade binaryRequestFacade;
-    //URLs for adding the tabnine icon to the inlay popup.
-    private final static String ICON_AND_NAME_URL;
-    private final static String ICON_AND_NAME_DARK_URL;
+  private final BinaryRequestFacade binaryRequestFacade;
+  // URLs for adding the tabnine icon to the inlay popup.
+  private static final String ICON_AND_NAME_URL;
+  private static final String ICON_AND_NAME_DARK_URL;
 
-    private final HoverBinaryResponse hoverBinaryResponse;
-    private final Inlay inlay;
-    private Balloon balloon;
+  private final HoverBinaryResponse hoverBinaryResponse;
+  private final Inlay inlay;
+  private Balloon balloon;
 
-    //This is a hack to get the light/dark icon URL for use in the popup html.
-    static {
-        ICON_AND_NAME_URL = "jar:" + LimitExceededLookupElement.class.getClassLoader()
-                .getResource(StaticConfig.ICON_AND_NAME_PATH).getPath();
-        final int suffixStartIndex = ICON_AND_NAME_URL.lastIndexOf(".");
-        if (suffixStartIndex > 0) {
-            ICON_AND_NAME_DARK_URL = ICON_AND_NAME_URL.substring(0, suffixStartIndex) + "_dark" +
-                    ICON_AND_NAME_URL.substring(suffixStartIndex);
-        } else {
-            ICON_AND_NAME_DARK_URL = null;
-        }
+  // This is a hack to get the light/dark icon URL for use in the popup html.
+  static {
+    ICON_AND_NAME_URL =
+        "jar:"
+            + LimitExceededLookupElement.class
+                .getClassLoader()
+                .getResource(StaticConfig.ICON_AND_NAME_PATH)
+                .getPath();
+    final int suffixStartIndex = ICON_AND_NAME_URL.lastIndexOf(".");
+    if (suffixStartIndex > 0) {
+      ICON_AND_NAME_DARK_URL =
+          ICON_AND_NAME_URL.substring(0, suffixStartIndex)
+              + "_dark"
+              + ICON_AND_NAME_URL.substring(suffixStartIndex);
+    } else {
+      ICON_AND_NAME_DARK_URL = null;
     }
+  }
 
-    public InlayHoverMouseMotionListener(BinaryRequestFacade binaryRequestFacade,
-                                         HoverBinaryResponse hoverBinaryResponse, Inlay inlay) {
-        this.binaryRequestFacade = binaryRequestFacade;
-        this.hoverBinaryResponse = hoverBinaryResponse;
-        this.inlay = inlay;
+  public InlayHoverMouseMotionListener(
+      BinaryRequestFacade binaryRequestFacade,
+      HoverBinaryResponse hoverBinaryResponse,
+      Inlay inlay) {
+    this.binaryRequestFacade = binaryRequestFacade;
+    this.hoverBinaryResponse = hoverBinaryResponse;
+    this.inlay = inlay;
+  }
+
+  @Override
+  public void mouseMoved(@NotNull EditorMouseEvent e) {
+    final MouseEvent mouseEvent = e.getMouseEvent();
+
+    // Without this, hovering over the gutter can trigger events
+    if (mouseEvent.getSource() != e.getEditor().getContentComponent()) {
+      return;
     }
-
-    @Override
-    public void mouseMoved(@NotNull EditorMouseEvent e) {
-        final MouseEvent mouseEvent = e.getMouseEvent();
-
-        // Without this, hovering over the gutter can trigger events
-        if (mouseEvent.getSource() != e.getEditor().getContentComponent()) {
-            return;
-        }
-        final Point point = new Point(mouseEvent.getPoint());
-        Rectangle inlayBounds = getInlayBounds(inlay, e.getEditor());
-        if (inlayBounds == null) {
-            return;
-        }
-        if (inlayBounds.contains(point)) {
-            if (this.balloon == null) {
-                this.balloon = createPopup();
-                Disposer.register(
-                        this.balloon,
-                        () -> {
-                            this.balloon.dispose();
-                            this.balloon = null;
-                        }
-                );
-                this.balloon.show(new RelativePoint(mouseEvent), Balloon.Position.atRight);
-            }
-        }
+    final Point point = new Point(mouseEvent.getPoint());
+    Rectangle inlayBounds = getInlayBounds(inlay, e.getEditor());
+    if (inlayBounds == null) {
+      return;
     }
+    if (inlayBounds.contains(point)) {
+      if (this.balloon == null) {
+        this.balloon = createPopup();
+        Disposer.register(
+            this.balloon,
+            () -> {
+              this.balloon.dispose();
+              this.balloon = null;
+            });
+        this.balloon.show(new RelativePoint(mouseEvent), Balloon.Position.atRight);
+      }
+    }
+  }
 
-    @NotNull
-    private Balloon createPopup() {
-        sendHoverShownRequest();
-        return JBPopupFactory.getInstance().createHtmlTextBalloonBuilder(
-                buildHtmlContent(hoverBinaryResponse.getMessage()),
-                null,
-                null,
-                MessageType.INFO.getPopupBackground(),
-                new HyperlinkListener() {
-                    @Override
-                    public void hyperlinkUpdate(HyperlinkEvent event) {
-                        try {
-                            if (event.getEventType() != HyperlinkEvent.EventType.ACTIVATED ||
-                                    event.getDescription() == null) {
-                                return;
-                            }
-                            Optional<NotificationOption> selectedOption =
-                                    Arrays.stream(hoverBinaryResponse.getOptions()).filter(
-                                            option -> option.getKey().equals(event.getDescription())).findFirst();
-                            if (!selectedOption.isPresent()) {
-                                Logger.getInstance(getClass()).warn(
-                                        "Error activating option: " + event.getDescription()
-                                                + ". No matching option found.");
-                                return;
-                            }
-                            //call the binary to handle the clicked action.
-                            ApplicationManager.getApplication().executeOnPooledThread(
-                                    () -> DependencyContainer.instanceOfBinaryRequestFacade()
-                                            .executeRequest(new HoverActionRequest(
-                                                    hoverBinaryResponse.getId(),
-                                                    event.getDescription(),
-                                                    hoverBinaryResponse.getState(),
-                                                    hoverBinaryResponse.getMessage(),
-                                                    hoverBinaryResponse.getNotificationType(),
-                                                    selectedOption.get().getActions())
-                                            )
-                            );
-                        } catch (Exception e) {
-                            Logger.getInstance(getClass())
-                                    .warn("Error handling locked inlay action.", e);
-                        }
-                    }
+  @NotNull
+  private Balloon createPopup() {
+    sendHoverShownRequest();
+    return JBPopupFactory.getInstance()
+        .createHtmlTextBalloonBuilder(
+            buildHtmlContent(hoverBinaryResponse.getMessage()),
+            null,
+            null,
+            MessageType.INFO.getPopupBackground(),
+            new HyperlinkListener() {
+              @Override
+              public void hyperlinkUpdate(HyperlinkEvent event) {
+                try {
+                  if (event.getEventType() != HyperlinkEvent.EventType.ACTIVATED
+                      || event.getDescription() == null) {
+                    return;
+                  }
+                  Optional<NotificationOption> selectedOption =
+                      Arrays.stream(hoverBinaryResponse.getOptions())
+                          .filter(option -> option.getKey().equals(event.getDescription()))
+                          .findFirst();
+                  if (!selectedOption.isPresent()) {
+                    Logger.getInstance(getClass())
+                        .warn(
+                            "Error activating option: "
+                                + event.getDescription()
+                                + ". No matching option found.");
+                    return;
+                  }
+                  // call the binary to handle the clicked action.
+                  ApplicationManager.getApplication()
+                      .executeOnPooledThread(
+                          () ->
+                              DependencyContainer.instanceOfBinaryRequestFacade()
+                                  .executeRequest(
+                                      new HoverActionRequest(
+                                          hoverBinaryResponse.getId(),
+                                          event.getDescription(),
+                                          hoverBinaryResponse.getState(),
+                                          hoverBinaryResponse.getMessage(),
+                                          hoverBinaryResponse.getNotificationType(),
+                                          selectedOption.get().getActions())));
+                } catch (Exception e) {
+                  Logger.getInstance(getClass()).warn("Error handling locked inlay action.", e);
                 }
-        ).setDisposable(inlay).createBalloon();
-    }
+              }
+            })
+        .setDisposable(inlay)
+        .createBalloon();
+  }
 
-    /*
-        This is a simple way to add the tabnine icon to the popup above the html content.
-     */
-    @Nullable
-    private String buildHtmlContent(String message) {
-        final String iconUrl =  EditorColorsManager.getInstance().isDarkEditor() ?
-                ICON_AND_NAME_DARK_URL : ICON_AND_NAME_URL;
-        if (iconUrl == null) {
-            return message;
-        } else {
-            return "<img src='" + iconUrl + "'> " + hoverBinaryResponse.getMessage();
-        }
+  /*
+     This is a simple way to add the tabnine icon to the popup above the html content.
+  */
+  @Nullable
+  private String buildHtmlContent(String message) {
+    final String iconUrl =
+        EditorColorsManager.getInstance().isDarkEditor()
+            ? ICON_AND_NAME_DARK_URL
+            : ICON_AND_NAME_URL;
+    if (iconUrl == null) {
+      return message;
+    } else {
+      return "<img src='" + iconUrl + "'> " + hoverBinaryResponse.getMessage();
     }
+  }
 
-    private void sendHoverShownRequest() {
-        ApplicationManager.getApplication().executeOnPooledThread(() -> {
-            try {
-                this.binaryRequestFacade.executeRequest(new HoverShownRequest(this.hoverBinaryResponse.getId(),
-                this.hoverBinaryResponse.getMessage(),this.hoverBinaryResponse.getNotificationType(),
-                this.hoverBinaryResponse.getState()));
-            } catch(RuntimeException e) {
-                //swallow - nothing to do with this
-            }
-        });
-    }
+  private void sendHoverShownRequest() {
+    ApplicationManager.getApplication()
+        .executeOnPooledThread(
+            () -> {
+              try {
+                this.binaryRequestFacade.executeRequest(
+                    new HoverShownRequest(
+                        this.hoverBinaryResponse.getId(),
+                        this.hoverBinaryResponse.getMessage(),
+                        this.hoverBinaryResponse.getNotificationType(),
+                        this.hoverBinaryResponse.getState()));
+              } catch (RuntimeException e) {
+                // swallow - nothing to do with this
+              }
+            });
+  }
 
-    /*
-        This code is copied from AfterLineEndInlayImpl since Inlay.getBounds method is only available
-        from IJ > 183.
-     */
-    @Nullable
-    private Rectangle getInlayBounds(Inlay inlay, Editor editor) {
-        int targetOffset = DocumentUtil.getLineEndOffset(inlay.getOffset(), editor.getDocument());
-        if (editor.getFoldingModel().isOffsetCollapsed(targetOffset)) return null;
-        final Point pos = editor.visualPositionToXY(inlay.getVisualPosition());
-        return new Rectangle(pos.x, pos.y, inlay.getWidthInPixels(), editor.getLineHeight());
-    }
+  /*
+     This code is copied from AfterLineEndInlayImpl since Inlay.getBounds method is only available
+     from IJ > 183.
+  */
+  @Nullable
+  private Rectangle getInlayBounds(Inlay inlay, Editor editor) {
+    int targetOffset = DocumentUtil.getLineEndOffset(inlay.getOffset(), editor.getDocument());
+    if (editor.getFoldingModel().isOffsetCollapsed(targetOffset)) return null;
+    final Point pos = editor.visualPositionToXY(inlay.getVisualPosition());
+    return new Rectangle(pos.x, pos.y, inlay.getWidthInPixels(), editor.getLineHeight());
+  }
 }

--- a/src/main/java/com/tabnine/intellij/completions/InsertNothingLookupElement.java
+++ b/src/main/java/com/tabnine/intellij/completions/InsertNothingLookupElement.java
@@ -7,40 +7,41 @@ import com.intellij.codeInsight.lookup.LookupListener;
 import org.jetbrains.annotations.NotNull;
 
 public class InsertNothingLookupElement extends LookupElementDecorator<LookupElement>
-        implements LookupListener {
-    private final String prefix;
-    private boolean selected;
+    implements LookupListener {
+  private final String prefix;
+  private boolean selected;
 
-    protected InsertNothingLookupElement(LookupElement delegate, String prefix) {
-        super(delegate);
-        this.prefix = prefix;
+  protected InsertNothingLookupElement(LookupElement delegate, String prefix) {
+    super(delegate);
+    this.prefix = prefix;
+  }
+
+  @NotNull
+  @Override
+  public String getLookupString() {
+    if (!this.selected) {
+      // When the item is selected, we don't want to insert its lookup string into the file, so we
+      // return an empty lookup string.
+      return super.getLookupString();
+    } else {
+      return prefix;
     }
+  }
 
-    @NotNull
-    @Override
-    public String getLookupString() {
-        if (!this.selected) {
-            //When the item is selected, we don't want to insert its lookup string into the file, so we
-            //return an empty lookup string.
-            return super.getLookupString();
-        } else {
-            return prefix;
-        }
+  @Override
+  public void lookupCanceled(@NotNull LookupEvent event) {
+    // backward compatibility with IJ 2017.1
+  }
+
+  @Override
+  public void currentItemChanged(LookupEvent event) {
+    // It would make more sense to do this in beforeItemSelected method, but that method doesn't
+    // exist in older
+    // IJ versions. So, once the popup is displayed, we can actually change this completion lookup
+    // string
+    // and it will only affect the text that is inserted when selecting it (i.e. insert nothing).
+    if (event.getItem() == this) {
+      this.selected = true;
     }
-
-    @Override
-    public void lookupCanceled(@NotNull LookupEvent event) {
-        //backward compatibility with IJ 2017.1
-    }
-
-    @Override
-    public void currentItemChanged(LookupEvent event) {
-        //It would make more sense to do this in beforeItemSelected method, but that method doesn't exist in older
-        //IJ versions. So, once the popup is displayed, we can actually change this completion lookup string
-        //and it will only affect the text that is inserted when selecting it (i.e. insert nothing).
-        if (event.getItem() == this) {
-            this.selected = true;
-        }
-    }
-
+  }
 }

--- a/src/main/java/com/tabnine/intellij/completions/LimitExceededLookupElement.java
+++ b/src/main/java/com/tabnine/intellij/completions/LimitExceededLookupElement.java
@@ -18,52 +18,58 @@ import com.tabnine.binary.BinaryRequestFacade;
 import com.tabnine.binary.requests.notifications.HoverBinaryRequest;
 import com.tabnine.binary.requests.notifications.HoverBinaryResponse;
 import com.tabnine.general.DependencyContainer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-
 /**
- * This is a lookup element for locked completions. Locked completions are completions that appear when the user
- * already exceeded the completions daily quota. The completion text appears as usual and its type text contains a
- * lock symobl. When selecting such a completion no text is inserted and instead, a gray inlay is shown, with a message
- * indicating the quota was exceeded. Hovering the mouse over this inlay open a balloon with more details and possibly
- * CTA links.
+ * This is a lookup element for locked completions. Locked completions are completions that appear
+ * when the user already exceeded the completions daily quota. The completion text appears as usual
+ * and its type text contains a lock symobl. When selecting such a completion no text is inserted
+ * and instead, a gray inlay is shown, with a message indicating the quota was exceeded. Hovering
+ * the mouse over this inlay open a balloon with more details and possibly CTA links.
  */
 public class LimitExceededLookupElement extends LookupElementDecorator<LookupElement>
-        implements LookupListener {
-    private final BinaryRequestFacade binaryRequestFacade = DependencyContainer.instanceOfBinaryRequestFacade();
+    implements LookupListener {
+  private final BinaryRequestFacade binaryRequestFacade =
+      DependencyContainer.instanceOfBinaryRequestFacade();
 
-    protected LimitExceededLookupElement(LookupElement delegate) {
-        super(delegate);
+  protected LimitExceededLookupElement(LookupElement delegate) {
+    super(delegate);
+  }
+
+  @Override
+  public void itemSelected(@NotNull LookupEvent lookupEvent) {
+    if (lookupEvent.getItem() != this) {
+      return; // handle only selection of this item.
     }
+    final Editor editor = lookupEvent.getLookup().getEditor();
+    final int caretOffset = editor.getCaretModel().getOffset();
+    final AtomicReference<Inlay> inlayHolder = new AtomicReference<>();
+    final AtomicBoolean documentChanged = new AtomicBoolean(false);
+    addInlayDisposer(editor, inlayHolder, documentChanged);
+    tryAddLimitExceededInlay(editor, caretOffset, inlayHolder, documentChanged);
+  }
 
-    @Override
-    public void itemSelected(@NotNull LookupEvent lookupEvent) {
-        if (lookupEvent.getItem() != this) {
-            return; //handle only selection of this item.
-        }
-        final Editor editor = lookupEvent.getLookup().getEditor();
-        final int caretOffset = editor.getCaretModel().getOffset();
-        final AtomicReference<Inlay> inlayHolder = new AtomicReference<>();
-        final AtomicBoolean documentChanged = new AtomicBoolean(false);
-        addInlayDisposer(editor, inlayHolder, documentChanged);
-        tryAddLimitExceededInlay(editor, caretOffset, inlayHolder, documentChanged);
-    }
-
-    private void tryAddLimitExceededInlay(Editor editor, int caretOffset, AtomicReference<Inlay> inlayHolder, AtomicBoolean documentChanged) {
-        ApplicationManager.getApplication().executeOnPooledThread(
+  private void tryAddLimitExceededInlay(
+      Editor editor,
+      int caretOffset,
+      AtomicReference<Inlay> inlayHolder,
+      AtomicBoolean documentChanged) {
+    ApplicationManager.getApplication()
+        .executeOnPooledThread(
             () -> {
               try {
                 final Document document = editor.getDocument();
-                //add the inlay at the end of the line. Ideally we would use 'addAfterLineEndElement' but that's
-                //only available from IJ > 191.
+                // add the inlay at the end of the line. Ideally we would use
+                // 'addAfterLineEndElement' but that's
+                // only available from IJ > 191.
                 final int currentLineNumber = document.getLineNumber(caretOffset);
                 final int inlayOffset = document.getLineEndOffset(currentLineNumber);
                 if (isInlayAlreadyDisplayed(editor, inlayOffset, currentLineNumber)) {
-                    //inlay already displayed at the end of this line - don't add another one.
-                    return;
+                  // inlay already displayed at the end of this line - don't add another one.
+                  return;
                 }
                 handleInlayCreation(inlayHolder, documentChanged, editor, inlayOffset);
               } catch (Exception e) {
@@ -73,92 +79,105 @@ public class LimitExceededLookupElement extends LookupElementDecorator<LookupEle
                 Logger.getInstance(getClass()).warn("Error on locked item selection.", e);
               }
             });
+  }
+
+  private boolean isInlayAlreadyDisplayed(
+      Editor editor, int inlayStartOffset, int currentLineNumber) {
+    // search for our inlay between the current line end offset and the next line start offset.
+    final int inlayEndOffset;
+    if (currentLineNumber + 1 < editor.getDocument().getLineCount()) {
+      inlayEndOffset = editor.getDocument().getLineEndOffset(currentLineNumber + 1);
+    } else {
+      inlayEndOffset = editor.getDocument().getTextLength(); // we're already at the last line.
     }
+    return editor
+        .getInlayModel()
+        .getInlineElementsInRange(inlayStartOffset, inlayEndOffset)
+        .stream()
+        .anyMatch(s -> s.getRenderer() instanceof LimitExceededHintRenderer && s.isValid());
+  }
 
-    private boolean isInlayAlreadyDisplayed(Editor editor, int inlayStartOffset, int currentLineNumber) {
-        //search for our inlay between the current line end offset and the next line start offset.
-        final int inlayEndOffset;
-        if (currentLineNumber + 1 < editor.getDocument().getLineCount()) {
-            inlayEndOffset = editor.getDocument().getLineEndOffset(currentLineNumber + 1);
-        } else {
-            inlayEndOffset = editor.getDocument().getTextLength(); //we're already at the last line.
-        }
-        return editor.getInlayModel().getInlineElementsInRange(inlayStartOffset, inlayEndOffset)
-                .stream().anyMatch(s -> s.getRenderer() instanceof LimitExceededHintRenderer && s.isValid());
-
+  private void handleInlayCreation(
+      AtomicReference<Inlay> inlayHolder,
+      AtomicBoolean documentChanged,
+      Editor editor,
+      int inlayOffset) {
+    // get the inlay and hover popup data
+    HoverBinaryResponse hoverBinaryResponse =
+        this.binaryRequestFacade.executeRequest(new HoverBinaryRequest());
+    if (hoverBinaryResponse == null
+        || hoverBinaryResponse.getTitle() == null
+        || documentChanged.get()) {
+      return;
     }
-
-    private void handleInlayCreation(AtomicReference<Inlay> inlayHolder, AtomicBoolean documentChanged,
-                                    Editor editor, int inlayOffset) {
-        //get the inlay and hover popup data
-        HoverBinaryResponse hoverBinaryResponse =
-                this.binaryRequestFacade.executeRequest(new HoverBinaryRequest());
-        if (hoverBinaryResponse == null || hoverBinaryResponse.getTitle() == null ||
-                documentChanged.get()) {
-            return;
-        }
-        //inlay must be added from UI thread
-        ApplicationManager.getApplication().invokeLater(
-                () -> {
-                    try {
-                        addInlay(editor, inlayOffset, inlayHolder, documentChanged, hoverBinaryResponse);
-                    } catch(Exception e) {
-                        if (e instanceof ControlFlowException) {
-                            throw e;
-                        }
-                        Logger.getInstance(getClass()).warn("Error adding locked item inlay.", e);
-                    }
+    // inlay must be added from UI thread
+    ApplicationManager.getApplication()
+        .invokeLater(
+            () -> {
+              try {
+                addInlay(editor, inlayOffset, inlayHolder, documentChanged, hoverBinaryResponse);
+              } catch (Exception e) {
+                if (e instanceof ControlFlowException) {
+                  throw e;
                 }
-        );
-    }
+                Logger.getInstance(getClass()).warn("Error adding locked item inlay.", e);
+              }
+            });
+  }
 
-    private void addInlay(Editor editor, int inlayOffset, AtomicReference<Inlay> inlayHolder,
-                          AtomicBoolean documentChanged, HoverBinaryResponse hoverBinaryResponse) {
-        synchronized(documentChanged) {
-            if (documentChanged.get()) {
-                return;
-            }
-            final Inlay inlay = editor.getInlayModel().addInlineElement(
-                    inlayOffset,
-                    true,
-                    new LimitExceededHintRenderer(hoverBinaryResponse.getTitle())
-            );
-            if (inlay != null) {
-                inlayHolder.set(inlay);
-                editor.addEditorMouseMotionListener(new InlayHoverMouseMotionListener(this.binaryRequestFacade,
-                        hoverBinaryResponse, inlay), inlay);
-            }
-        }
+  private void addInlay(
+      Editor editor,
+      int inlayOffset,
+      AtomicReference<Inlay> inlayHolder,
+      AtomicBoolean documentChanged,
+      HoverBinaryResponse hoverBinaryResponse) {
+    synchronized (documentChanged) {
+      if (documentChanged.get()) {
+        return;
+      }
+      final Inlay inlay =
+          editor
+              .getInlayModel()
+              .addInlineElement(
+                  inlayOffset, true, new LimitExceededHintRenderer(hoverBinaryResponse.getTitle()));
+      if (inlay != null) {
+        inlayHolder.set(inlay);
+        editor.addEditorMouseMotionListener(
+            new InlayHoverMouseMotionListener(this.binaryRequestFacade, hoverBinaryResponse, inlay),
+            inlay);
+      }
     }
+  }
 
-    /*
-        Creates a document listener that removes the inlay (and popup, if visible) when the user continues to edit the
-        doc (i.e. when the document changes).
-     */
-    private void addInlayDisposer(Editor editor, AtomicReference<Inlay> inlayHolder, AtomicBoolean documentChanged) {
-        editor.getDocument().addDocumentListener(
-                new DocumentListener() {
-                    @Override
-                    public void documentChanged(@NotNull DocumentEvent event) {
-                        synchronized (documentChanged) {//sync to prevent race with inlay creation
-                            documentChanged.set(true); //mark that doc has changed
-                            if (inlayHolder.get() != null) {
-                                Disposer.dispose(inlayHolder.get());
-                            }
-                            // doc changed, no need to keep listening
-                            editor.getDocument().removeDocumentListener(this);
-                        }
-                    }
+  /*
+     Creates a document listener that removes the inlay (and popup, if visible) when the user continues to edit the
+     doc (i.e. when the document changes).
+  */
+  private void addInlayDisposer(
+      Editor editor, AtomicReference<Inlay> inlayHolder, AtomicBoolean documentChanged) {
+    editor
+        .getDocument()
+        .addDocumentListener(
+            new DocumentListener() {
+              @Override
+              public void documentChanged(@NotNull DocumentEvent event) {
+                synchronized (documentChanged) { // sync to prevent race with inlay creation
+                  documentChanged.set(true); // mark that doc has changed
+                  if (inlayHolder.get() != null) {
+                    Disposer.dispose(inlayHolder.get());
+                  }
+                  // doc changed, no need to keep listening
+                  editor.getDocument().removeDocumentListener(this);
                 }
-        );
-    }
+              }
+            });
+  }
 
-    //This is just a marker class to identify already displayed inlays.
-    private static class LimitExceededHintRenderer extends HintRenderer {
+  // This is just a marker class to identify already displayed inlays.
+  private static class LimitExceededHintRenderer extends HintRenderer {
 
-        public LimitExceededHintRenderer(@Nullable String text) {
-            super(text);
-        }
+    public LimitExceededHintRenderer(@Nullable String text) {
+      super(text);
     }
+  }
 }
-

--- a/src/main/java/com/tabnine/intellij/completions/LimitedSecletionsChangedNotifier.java
+++ b/src/main/java/com/tabnine/intellij/completions/LimitedSecletionsChangedNotifier.java
@@ -3,8 +3,8 @@ package com.tabnine.intellij.completions;
 import com.intellij.util.messages.Topic;
 
 public interface LimitedSecletionsChangedNotifier {
-    Topic<LimitedSecletionsChangedNotifier> LIMITED_SELECTIONS_CHANGED_TOPIC =
-            Topic.create("Limited Selections Changed Notifier", LimitedSecletionsChangedNotifier.class);
+  Topic<LimitedSecletionsChangedNotifier> LIMITED_SELECTIONS_CHANGED_TOPIC =
+      Topic.create("Limited Selections Changed Notifier", LimitedSecletionsChangedNotifier.class);
 
-    void limitedChanged(boolean limited);
+  void limitedChanged(boolean limited);
 }

--- a/src/main/java/com/tabnine/intellij/completions/TabNineCompletionContributor.java
+++ b/src/main/java/com/tabnine/intellij/completions/TabNineCompletionContributor.java
@@ -1,5 +1,7 @@
 package com.tabnine.intellij.completions;
 
+import static com.tabnine.general.StaticConfig.*;
+
 import com.intellij.codeInsight.completion.*;
 import com.intellij.codeInsight.lookup.*;
 import com.intellij.openapi.application.ApplicationManager;
@@ -17,88 +19,106 @@ import com.tabnine.prediction.TabNinePrefixMatcher;
 import com.tabnine.prediction.TabNineWeigher;
 import com.tabnine.selections.AutoImporter;
 import com.tabnine.selections.TabNineLookupListener;
+import java.util.ArrayList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-
-import static com.tabnine.general.StaticConfig.*;
-
 public class TabNineCompletionContributor extends CompletionContributor {
-    private final CompletionFacade completionFacade = DependencyContainer.instanceOfCompletionFacade();
-    private final TabNineLookupListener tabNineLookupListener = DependencyContainer.instanceOfTabNineLookupListener();
-    private final MessageBus messageBus = ApplicationManager.getApplication().getMessageBus();
-    private boolean isLocked;
+  private final CompletionFacade completionFacade =
+      DependencyContainer.instanceOfCompletionFacade();
+  private final TabNineLookupListener tabNineLookupListener =
+      DependencyContainer.instanceOfTabNineLookupListener();
+  private final MessageBus messageBus = ApplicationManager.getApplication().getMessageBus();
+  private boolean isLocked;
 
-    @Override
-    public void fillCompletionVariants(@NotNull CompletionParameters parameters, @NotNull CompletionResultSet resultSet) {
-        if (SuggestionsMode.getSuggestionMode() != SuggestionsMode.AUTOCOMPLETE) {
-            return;
-        }
-
-        registerLookupListener(parameters);
-        AutocompleteResponse completions = this.completionFacade.retrieveCompletions(parameters);
-
-        if (completions == null) {
-            return;
-        }
-
-        PrefixMatcher originalMatcher = resultSet.getPrefixMatcher();
-
-        if (originalMatcher.getPrefix().length() == 0 && completions.results.length == 0) {
-            return;
-        }
-        if (this.isLocked != completions.is_locked) {
-            this.isLocked = completions.is_locked;
-            this.messageBus
-              .syncPublisher(LimitedSecletionsChangedNotifier.LIMITED_SELECTIONS_CHANGED_TOPIC)
-              .limitedChanged(completions.is_locked);
-        }
-
-        resultSet = resultSet.withPrefixMatcher(new TabNinePrefixMatcher(originalMatcher.cloneWithPrefix(completions.old_prefix)))
-                .withRelevanceSorter(CompletionSorter.defaultSorter(parameters, originalMatcher).weigh(new TabNineWeigher()));
-        resultSet.restartCompletionOnAnyPrefixChange();
-
-        addAdvertisement(resultSet, completions);
-
-        resultSet.addAllElements(createCompletions(completions, parameters, resultSet));
+  @Override
+  public void fillCompletionVariants(
+      @NotNull CompletionParameters parameters, @NotNull CompletionResultSet resultSet) {
+    if (SuggestionsMode.getSuggestionMode() != SuggestionsMode.AUTOCOMPLETE) {
+      return;
     }
 
-    private ArrayList<LookupElement> createCompletions(AutocompleteResponse completions, @NotNull CompletionParameters parameters, @NotNull CompletionResultSet resultSet) {
-        ArrayList<LookupElement> elements = new ArrayList<>();
-        final Lookup activeLookup = LookupManager.getActiveLookup(parameters.getEditor());
-        for (int index = 0; index < completions.results.length && index < CompletionUtils.completionLimit(parameters, resultSet, completions.is_locked); index++) {
-            LookupElement lookupElement = createCompletion(
-                    parameters, completions.old_prefix,
-                    completions.results[index], index, completions.is_locked, activeLookup);
+    registerLookupListener(parameters);
+    AutocompleteResponse completions = this.completionFacade.retrieveCompletions(parameters);
 
-            if (resultSet.getPrefixMatcher().prefixMatches(lookupElement)) {
-                elements.add(lookupElement);
-            }
-        }
-
-        return elements;
+    if (completions == null) {
+      return;
     }
 
-    @NotNull
-    private LookupElement createCompletion(CompletionParameters parameters,
-                                                  String oldPrefix, ResultEntry result, int index,
-                                           boolean locked, @Nullable Lookup activeLookup) {
-        TabNineCompletion completion = CompletionUtils.createTabnineCompletion(
-                parameters.getEditor().getDocument(),
-                parameters.getOffset(),
-                oldPrefix,
-                result,
-                index);
+    PrefixMatcher originalMatcher = resultSet.getPrefixMatcher();
 
-        completion.detail = result.detail;
+    if (originalMatcher.getPrefix().length() == 0 && completions.results.length == 0) {
+      return;
+    }
+    if (this.isLocked != completions.is_locked) {
+      this.isLocked = completions.is_locked;
+      this.messageBus
+          .syncPublisher(LimitedSecletionsChangedNotifier.LIMITED_SELECTIONS_CHANGED_TOPIC)
+          .limitedChanged(completions.is_locked);
+    }
 
-        if (result.deprecated != null) {
-            completion.deprecated = result.deprecated;
-        }
+    resultSet =
+        resultSet
+            .withPrefixMatcher(
+                new TabNinePrefixMatcher(originalMatcher.cloneWithPrefix(completions.old_prefix)))
+            .withRelevanceSorter(
+                CompletionSorter.defaultSorter(parameters, originalMatcher)
+                    .weigh(new TabNineWeigher()));
+    resultSet.restartCompletionOnAnyPrefixChange();
 
-        LookupElementBuilder lookupElementBuilder =
-            LookupElementBuilder.create(completion, result.new_prefix)
+    addAdvertisement(resultSet, completions);
+
+    resultSet.addAllElements(createCompletions(completions, parameters, resultSet));
+  }
+
+  private ArrayList<LookupElement> createCompletions(
+      AutocompleteResponse completions,
+      @NotNull CompletionParameters parameters,
+      @NotNull CompletionResultSet resultSet) {
+    ArrayList<LookupElement> elements = new ArrayList<>();
+    final Lookup activeLookup = LookupManager.getActiveLookup(parameters.getEditor());
+    for (int index = 0;
+        index < completions.results.length
+            && index
+                < CompletionUtils.completionLimit(parameters, resultSet, completions.is_locked);
+        index++) {
+      LookupElement lookupElement =
+          createCompletion(
+              parameters,
+              completions.old_prefix,
+              completions.results[index],
+              index,
+              completions.is_locked,
+              activeLookup);
+
+      if (resultSet.getPrefixMatcher().prefixMatches(lookupElement)) {
+        elements.add(lookupElement);
+      }
+    }
+
+    return elements;
+  }
+
+  @NotNull
+  private LookupElement createCompletion(
+      CompletionParameters parameters,
+      String oldPrefix,
+      ResultEntry result,
+      int index,
+      boolean locked,
+      @Nullable Lookup activeLookup) {
+    TabNineCompletion completion =
+        CompletionUtils.createTabnineCompletion(
+            parameters.getEditor().getDocument(), parameters.getOffset(), oldPrefix, result, index);
+
+    completion.detail = result.detail;
+
+    if (result.deprecated != null) {
+      completion.deprecated = result.deprecated;
+    }
+
+    LookupElementBuilder lookupElementBuilder =
+        LookupElementBuilder.create(completion, result.new_prefix)
             .withRenderer(
                 new LookupElementRenderer<LookupElement>() {
                   @Override
@@ -118,47 +138,63 @@ public class TabNineCompletionContributor extends CompletionContributor {
                     presentation.setIcon(ICON);
                   }
                 });
-        if (locked) {
-            final LimitExceededLookupElement lookupElement = new LimitExceededLookupElement(
-                    lookupElementBuilder);
-            if (activeLookup != null) {
-                activeLookup.addLookupListener(lookupElement);
-            }
-            return lookupElement;
-        } else {
-            lookupElementBuilder = lookupElementBuilder.withInsertHandler((context, item) -> {
+    if (locked) {
+      final LimitExceededLookupElement lookupElement =
+          new LimitExceededLookupElement(lookupElementBuilder);
+      if (activeLookup != null) {
+        activeLookup.addLookupListener(lookupElement);
+      }
+      return lookupElement;
+    } else {
+      lookupElementBuilder =
+          lookupElementBuilder.withInsertHandler(
+              (context, item) -> {
                 int end = context.getTailOffset();
                 TabNineCompletion lookupElement = (TabNineCompletion) item.getObject();
                 try {
-                    context.getDocument().insertString(end + lookupElement.oldSuffix.length(), lookupElement.newSuffix);
-                    context.getDocument().deleteString(end, end + lookupElement.oldSuffix.length());
-                    AutoImporter.registerTabNineAutoImporter(context.getEditor(), context.getProject(), context.getStartOffset(), context.getTailOffset());
-                } catch(RuntimeException re) {
-                    Logger.getInstance(getClass()).warn("Error inserting new suffix. End = " + end +
-                            ", old suffix length = " + lookupElement.oldSuffix.length() + ", new suffix length = "
-                            + lookupElement.newSuffix.length(), re);
+                  context
+                      .getDocument()
+                      .insertString(
+                          end + lookupElement.oldSuffix.length(), lookupElement.newSuffix);
+                  context.getDocument().deleteString(end, end + lookupElement.oldSuffix.length());
+                  AutoImporter.registerTabNineAutoImporter(
+                      context.getEditor(),
+                      context.getProject(),
+                      context.getStartOffset(),
+                      context.getTailOffset());
+                } catch (RuntimeException re) {
+                  Logger.getInstance(getClass())
+                      .warn(
+                          "Error inserting new suffix. End = "
+                              + end
+                              + ", old suffix length = "
+                              + lookupElement.oldSuffix.length()
+                              + ", new suffix length = "
+                              + lookupElement.newSuffix.length(),
+                          re);
                 }
-            });
-        }
-        return lookupElementBuilder;
+              });
     }
+    return lookupElementBuilder;
+  }
 
-    private void addAdvertisement(@NotNull CompletionResultSet result, AutocompleteResponse completions) {
-        if (completions.user_message.length >= 1) {
-            String details = String.join(" ", completions.user_message);
+  private void addAdvertisement(
+      @NotNull CompletionResultSet result, AutocompleteResponse completions) {
+    if (completions.user_message.length >= 1) {
+      String details = String.join(" ", completions.user_message);
 
-            details = details.substring(0, Math.min(details.length(), ADVERTISEMENT_MAX_LENGTH));
+      details = details.substring(0, Math.min(details.length(), ADVERTISEMENT_MAX_LENGTH));
 
-            result.addLookupAdvertisement(details);
-        }
+      result.addLookupAdvertisement(details);
     }
+  }
 
-    private void registerLookupListener(CompletionParameters parameters) {
-        final LookupEx lookupEx = LookupManager.getActiveLookup(parameters.getEditor());
-        if (lookupEx == null) {
-            return;
-        }
-        lookupEx.removeLookupListener(tabNineLookupListener);
-        lookupEx.addLookupListener(tabNineLookupListener);
+  private void registerLookupListener(CompletionParameters parameters) {
+    final LookupEx lookupEx = LookupManager.getActiveLookup(parameters.getEditor());
+    if (lookupEx == null) {
+      return;
     }
+    lookupEx.removeLookupListener(tabNineLookupListener);
+    lookupEx.addLookupListener(tabNineLookupListener);
+  }
 }

--- a/src/main/java/com/tabnine/lifecycle/BinaryStateChangeNotifier.java
+++ b/src/main/java/com/tabnine/lifecycle/BinaryStateChangeNotifier.java
@@ -4,8 +4,8 @@ import com.intellij.util.messages.Topic;
 import com.tabnine.binary.requests.config.StateResponse;
 
 public interface BinaryStateChangeNotifier {
-    Topic<BinaryStateChangeNotifier> STATE_CHANGED_TOPIC =
-            Topic.create("Binary State Changed Notifier", BinaryStateChangeNotifier.class);
+  Topic<BinaryStateChangeNotifier> STATE_CHANGED_TOPIC =
+      Topic.create("Binary State Changed Notifier", BinaryStateChangeNotifier.class);
 
-    void stateChanged(StateResponse state);
+  void stateChanged(StateResponse state);
 }

--- a/src/main/java/com/tabnine/lifecycle/BinaryStateService.java
+++ b/src/main/java/com/tabnine/lifecycle/BinaryStateService.java
@@ -1,6 +1,5 @@
 package com.tabnine.lifecycle;
 
-import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.intellij.util.messages.MessageBus;
@@ -8,35 +7,36 @@ import com.tabnine.binary.BinaryRequestFacade;
 import com.tabnine.binary.requests.config.StateRequest;
 import com.tabnine.binary.requests.config.StateResponse;
 import com.tabnine.general.DependencyContainer;
-
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class BinaryStateService {
 
-    private static final ScheduledExecutorService scheduler = AppExecutorUtil.getAppScheduledExecutorService();
-    private final BinaryRequestFacade binaryRequestFacade = DependencyContainer.instanceOfBinaryRequestFacade();
-    private final MessageBus messageBus;
-    private StateResponse lastStateResponse;
+  private static final ScheduledExecutorService scheduler =
+      AppExecutorUtil.getAppScheduledExecutorService();
+  private final BinaryRequestFacade binaryRequestFacade =
+      DependencyContainer.instanceOfBinaryRequestFacade();
+  private final MessageBus messageBus;
+  private StateResponse lastStateResponse;
 
-    public BinaryStateService() {
-        this.messageBus = ApplicationManager.getApplication().getMessageBus();
-        scheduler.scheduleWithFixedDelay(this::updateState, 0, 2, TimeUnit.SECONDS);
+  public BinaryStateService() {
+    this.messageBus = ApplicationManager.getApplication().getMessageBus();
+    scheduler.scheduleWithFixedDelay(this::updateState, 0, 2, TimeUnit.SECONDS);
+  }
+
+  public StateResponse getLastStateResponse() {
+    return this.lastStateResponse;
+  }
+
+  private void updateState() {
+    final StateResponse stateResponse = this.binaryRequestFacade.executeRequest(new StateRequest());
+    if (stateResponse != null) {
+      if (!stateResponse.equals(this.lastStateResponse)) {
+        this.messageBus
+            .syncPublisher(BinaryStateChangeNotifier.STATE_CHANGED_TOPIC)
+            .stateChanged(stateResponse);
+      }
+      this.lastStateResponse = stateResponse;
     }
-
-    public StateResponse getLastStateResponse() {
-        return this.lastStateResponse;
-    }
-
-    private void updateState() {
-        final StateResponse stateResponse = this.binaryRequestFacade.executeRequest(new StateRequest());
-        if (stateResponse != null) {
-            if (!stateResponse.equals(this.lastStateResponse)) {
-                this.messageBus.syncPublisher(BinaryStateChangeNotifier.STATE_CHANGED_TOPIC)
-                        .stateChanged(stateResponse);
-            }
-            this.lastStateResponse = stateResponse;
-        }
-    }
-
+  }
 }

--- a/src/main/java/com/tabnine/lifecycle/TabNineDisablePluginListener.java
+++ b/src/main/java/com/tabnine/lifecycle/TabNineDisablePluginListener.java
@@ -1,39 +1,40 @@
 package com.tabnine.lifecycle;
 
-import com.tabnine.binary.BinaryRequestFacade;
-import com.tabnine.binary.requests.uninstall.UninstallRequest;
-
 import static com.tabnine.general.Utils.getTabNinePluginDescriptor;
 import static java.util.Collections.singletonMap;
 
+import com.tabnine.binary.BinaryRequestFacade;
+import com.tabnine.binary.requests.uninstall.UninstallRequest;
+
 public class TabNineDisablePluginListener {
-    private final UninstallReporter uninstallReporter;
-    private final BinaryRequestFacade binaryRequestFacade;
-    private boolean isDisabled;
+  private final UninstallReporter uninstallReporter;
+  private final BinaryRequestFacade binaryRequestFacade;
+  private boolean isDisabled;
 
-    public TabNineDisablePluginListener(UninstallReporter uninstallReporter, BinaryRequestFacade binaryRequestFacade) {
-        this.uninstallReporter = uninstallReporter;
-        this.binaryRequestFacade = binaryRequestFacade;
-        this.isDisabled = pluginIsDisabled();
+  public TabNineDisablePluginListener(
+      UninstallReporter uninstallReporter, BinaryRequestFacade binaryRequestFacade) {
+    this.uninstallReporter = uninstallReporter;
+    this.binaryRequestFacade = binaryRequestFacade;
+    this.isDisabled = pluginIsDisabled();
+  }
+
+  private static boolean pluginIsDisabled() {
+    return getTabNinePluginDescriptor().map(plugin -> !plugin.isEnabled()).orElse(false);
+  }
+
+  public void onDisable() {
+    if (this.isDisabled) {
+      return;
     }
 
-    private static boolean pluginIsDisabled() {
-        return getTabNinePluginDescriptor().map(plugin -> !plugin.isEnabled()).orElse(false);
+    if (pluginIsDisabled()) {
+      this.isDisabled = true;
+
+      if (binaryRequestFacade.executeRequest(new UninstallRequest()) == null) {
+        uninstallReporter.reportUninstall(singletonMap("disable", true));
+      }
+    } else {
+      this.isDisabled = false;
     }
-
-    public void onDisable() {
-        if (this.isDisabled) {
-            return;
-        }
-
-        if (pluginIsDisabled()) {
-            this.isDisabled = true;
-
-            if (binaryRequestFacade.executeRequest(new UninstallRequest()) == null) {
-                uninstallReporter.reportUninstall(singletonMap("disable", true));
-            }
-        } else {
-            this.isDisabled = false;
-        }
-    }
+  }
 }

--- a/src/main/java/com/tabnine/lifecycle/TabNinePluginStateListener.java
+++ b/src/main/java/com/tabnine/lifecycle/TabNinePluginStateListener.java
@@ -1,35 +1,38 @@
 package com.tabnine.lifecycle;
 
+import static com.tabnine.general.StaticConfig.TABNINE_PLUGIN_ID;
+
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginStateListener;
 import com.tabnine.binary.BinaryRequestFacade;
 import com.tabnine.binary.requests.uninstall.UninstallRequest;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Optional;
-
-import static com.tabnine.general.StaticConfig.TABNINE_PLUGIN_ID;
-
 public class TabNinePluginStateListener implements PluginStateListener {
-    private final UninstallReporter uninstallReporter;
-    private final BinaryRequestFacade binaryRequestFacade;
+  private final UninstallReporter uninstallReporter;
+  private final BinaryRequestFacade binaryRequestFacade;
 
-    public TabNinePluginStateListener(UninstallReporter uninstallReporter, BinaryRequestFacade binaryRequestFacade) {
-        this.uninstallReporter = uninstallReporter;
-        this.binaryRequestFacade = binaryRequestFacade;
-    }
+  public TabNinePluginStateListener(
+      UninstallReporter uninstallReporter, BinaryRequestFacade binaryRequestFacade) {
+    this.uninstallReporter = uninstallReporter;
+    this.binaryRequestFacade = binaryRequestFacade;
+  }
 
-    @Override
-    public void install(@NotNull IdeaPluginDescriptor descriptor) {
-        // Nothing
-    }
+  @Override
+  public void install(@NotNull IdeaPluginDescriptor descriptor) {
+    // Nothing
+  }
 
-    @Override
-    public void uninstall(@NotNull IdeaPluginDescriptor descriptor) {
-        Optional.ofNullable(descriptor.getPluginId()).filter(TABNINE_PLUGIN_ID::equals).ifPresent(pluginId -> {
-            if(binaryRequestFacade.executeRequest(new UninstallRequest()) == null) {
+  @Override
+  public void uninstall(@NotNull IdeaPluginDescriptor descriptor) {
+    Optional.ofNullable(descriptor.getPluginId())
+        .filter(TABNINE_PLUGIN_ID::equals)
+        .ifPresent(
+            pluginId -> {
+              if (binaryRequestFacade.executeRequest(new UninstallRequest()) == null) {
                 uninstallReporter.reportUninstall(null);
-            }
-        });
-    }
+              }
+            });
+  }
 }

--- a/src/main/java/com/tabnine/lifecycle/TabnineUpdater.java
+++ b/src/main/java/com/tabnine/lifecycle/TabnineUpdater.java
@@ -10,7 +10,6 @@ import com.intellij.openapi.updateSettings.impl.PluginDownloader;
 import com.intellij.openapi.updateSettings.impl.UpdateChecker;
 import com.intellij.openapi.updateSettings.impl.UpdateInstaller;
 import com.intellij.util.Alarm;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -18,61 +17,67 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 public class TabnineUpdater {
-    private Alarm alarm = new Alarm(Alarm.ThreadToUse.SWING_THREAD);
-    private static TabnineUpdater instance = new TabnineUpdater();
-    private static AtomicBoolean initialized = new AtomicBoolean(false);
-    public static void pollUpdates() {
-        if (initialized.compareAndSet(false, true)) {
-            instance.enqueueUpdate(60 * 3 * 1000, 3);
-        }
-    }
+  private Alarm alarm = new Alarm(Alarm.ThreadToUse.SWING_THREAD);
+  private static TabnineUpdater instance = new TabnineUpdater();
+  private static AtomicBoolean initialized = new AtomicBoolean(false);
 
-    private void enqueueUpdate(long delay, long retries) {
-        alarm.addRequest(() -> {
-            try {
-                tryUpdate();
-            } catch (Exception e) {
-                Logger.getInstance(getClass()).warn("Error fetching updates.", e);
-                if (retries > 0 ) {
-                    Logger.getInstance(getClass()).warn("Will try again.");
-                    enqueueUpdate(60 * 1000, retries - 1);
-                    return;
-                }
+  public static void pollUpdates() {
+    if (initialized.compareAndSet(false, true)) {
+      instance.enqueueUpdate(60 * 3 * 1000, 3);
+    }
+  }
+
+  private void enqueueUpdate(long delay, long retries) {
+    alarm.addRequest(
+        () -> {
+          try {
+            tryUpdate();
+          } catch (Exception e) {
+            Logger.getInstance(getClass()).warn("Error fetching updates.", e);
+            if (retries > 0) {
+              Logger.getInstance(getClass()).warn("Will try again.");
+              enqueueUpdate(60 * 1000, retries - 1);
+              return;
             }
+          }
 
-            enqueueUpdate(24 * 60 * 60 * 1000, 3);
-        }, delay);
-    }
+          enqueueUpdate(24 * 60 * 60 * 1000, 3);
+        },
+        delay);
+  }
 
-    private void tryUpdate() {
-        PluginId pluginId = PluginManager.getPluginByClassName(TabnineUpdater.class.getName());
-        String pluginIdString =
-                (pluginId != null) ? pluginId.getIdString() : "com.tabnine.TabNine";
-        List<String> plugins = Collections.singletonList(pluginIdString);
-        ApplicationManager.getApplication().executeOnPooledThread(() -> {
-            Application application = ApplicationManager.getApplication();
-            // in the future we can add this: || !UpdateSettings.getInstance().isCheckNeeded()
-            if (application == null || application.isDisposed() || application.isDisposeInProgress()) {
+  private void tryUpdate() {
+    PluginId pluginId = PluginManager.getPluginByClassName(TabnineUpdater.class.getName());
+    String pluginIdString = (pluginId != null) ? pluginId.getIdString() : "com.tabnine.TabNine";
+    List<String> plugins = Collections.singletonList(pluginIdString);
+    ApplicationManager.getApplication()
+        .executeOnPooledThread(
+            () -> {
+              Application application = ApplicationManager.getApplication();
+              // in the future we can add this: || !UpdateSettings.getInstance().isCheckNeeded()
+              if (application == null
+                  || application.isDisposed()
+                  || application.isDisposeInProgress()) {
                 // we won't perform the update now
                 return;
-            }
+              }
 
-            Collection<PluginDownloader> availableUpdates = UpdateChecker.getPluginUpdates();
+              Collection<PluginDownloader> availableUpdates = UpdateChecker.getPluginUpdates();
 
-
-            if (availableUpdates == null) {
+              if (availableUpdates == null) {
                 return;
-            }
+              }
 
-            List<PluginDownloader> pluginsToUpdate = availableUpdates.stream()
-                    .filter(downloader -> plugins.contains(downloader.getPluginId()))
-                    .collect(Collectors.toList());
+              List<PluginDownloader> pluginsToUpdate =
+                  availableUpdates.stream()
+                      .filter(downloader -> plugins.contains(downloader.getPluginId()))
+                      .collect(Collectors.toList());
 
-            if (pluginsToUpdate.isEmpty()) {
+              if (pluginsToUpdate.isEmpty()) {
 
                 return;
-            }
-            UpdateInstaller.installPluginUpdates(pluginsToUpdate, new EmptyProgressIndicator());
-        });
-    }
+              }
+              UpdateInstaller.installPluginUpdates(pluginsToUpdate, new EmptyProgressIndicator());
+            });
+  }
 }

--- a/src/main/java/com/tabnine/lifecycle/UninstallReporter.java
+++ b/src/main/java/com/tabnine/lifecycle/UninstallReporter.java
@@ -1,30 +1,30 @@
 package com.tabnine.lifecycle;
 
+import static java.lang.String.format;
+
 import com.intellij.openapi.diagnostic.Logger;
 import com.tabnine.binary.BinaryRun;
 import com.tabnine.binary.exceptions.NoValidBinaryToRunException;
 import com.tabnine.binary.exceptions.TabNineDeadException;
-
 import java.util.Map;
 
-import static java.lang.String.format;
-
 public class UninstallReporter {
-    private final BinaryRun binaryRun;
+  private final BinaryRun binaryRun;
 
-    public UninstallReporter(BinaryRun binaryRun) {
-        this.binaryRun = binaryRun;
-    }
+  public UninstallReporter(BinaryRun binaryRun) {
+    this.binaryRun = binaryRun;
+  }
 
-    public void reportUninstall(Map<String, Object> additionalMetadata) {
-        try {
-            binaryRun.reportUninstall(additionalMetadata).waitFor();
-        } catch (NoValidBinaryToRunException e) {
-            Logger.getInstance(getClass()).warn("Couldn't find a binary to run", e);
-        } catch (TabNineDeadException e) {
-            Logger.getInstance(getClass()).warn(format("Couldn't communicate uninstalling to binary at: %s", e.getLocation()), e);
-        } catch (InterruptedException e) {
-            Logger.getInstance(getClass()).warn("Couldn't communicate uninstalling to binary.", e);
-        }
+  public void reportUninstall(Map<String, Object> additionalMetadata) {
+    try {
+      binaryRun.reportUninstall(additionalMetadata).waitFor();
+    } catch (NoValidBinaryToRunException e) {
+      Logger.getInstance(getClass()).warn("Couldn't find a binary to run", e);
+    } catch (TabNineDeadException e) {
+      Logger.getInstance(getClass())
+          .warn(format("Couldn't communicate uninstalling to binary at: %s", e.getLocation()), e);
+    } catch (InterruptedException e) {
+      Logger.getInstance(getClass()).warn("Couldn't communicate uninstalling to binary.", e);
     }
+  }
 }

--- a/src/main/java/com/tabnine/logging/LogsGatewayAppender.java
+++ b/src/main/java/com/tabnine/logging/LogsGatewayAppender.java
@@ -1,5 +1,7 @@
 package com.tabnine.logging;
 
+import static org.apache.commons.lang.exception.ExceptionUtils.getStackTrace;
+
 import com.google.gson.JsonObject;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
@@ -13,65 +15,58 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.spi.LoggingEvent;
 
-import static org.apache.commons.lang.exception.ExceptionUtils.getStackTrace;
-
 public class LogsGatewayAppender extends AppenderSkeleton {
-    final JsonObject baseRequestBody = buildRequestBody();
+  final JsonObject baseRequestBody = buildRequestBody();
 
-    private JsonObject buildRequestBody() {
-        JsonObject body = new JsonObject();
-        body.addProperty("appName", "tabnine-plugin-JB");
-        body.addProperty("category", "extensions");
-        body.addProperty("ide", ApplicationInfo.getInstance().getVersionName());
-        body.addProperty("ideVersion", ApplicationInfo.getInstance().getFullVersion());
-        body.addProperty("pluginVersion", Utils.cmdSanitize(Utils.getTabNinePluginVersion()));
-        body.addProperty("os", System.getProperty("os.name"));
-        body.addProperty("channel", Config.CHANNEL);
-        body.addProperty("userId", PermanentInstallationID.get());
-        return body;
-    }
+  private JsonObject buildRequestBody() {
+    JsonObject body = new JsonObject();
+    body.addProperty("appName", "tabnine-plugin-JB");
+    body.addProperty("category", "extensions");
+    body.addProperty("ide", ApplicationInfo.getInstance().getVersionName());
+    body.addProperty("ideVersion", ApplicationInfo.getInstance().getFullVersion());
+    body.addProperty("pluginVersion", Utils.cmdSanitize(Utils.getTabNinePluginVersion()));
+    body.addProperty("os", System.getProperty("os.name"));
+    body.addProperty("channel", Config.CHANNEL);
+    body.addProperty("userId", PermanentInstallationID.get());
+    return body;
+  }
 
-    private void dispatchLog(String level, String message, String stackTrace) throws Exception {
-        HttpPost postRequest = new HttpPost(String.format(
-                "%s/logs/%s",
-                Config.LOGGER_HOST,
-                level
-        ));
+  private void dispatchLog(String level, String message, String stackTrace) throws Exception {
+    HttpPost postRequest = new HttpPost(String.format("%s/logs/%s", Config.LOGGER_HOST, level));
 
-        JsonObject requestBody = baseRequestBody.deepCopy();
-        requestBody.addProperty("message", message);
-        // requestBody.addProperty("stackTrace", stackTrace);
+    JsonObject requestBody = baseRequestBody.deepCopy();
+    requestBody.addProperty("message", message);
+    // requestBody.addProperty("stackTrace", stackTrace);
 
-        postRequest.setEntity(new StringEntity(requestBody.toString()));
-        postRequest.setHeader("Content-Type", "application/json");
+    postRequest.setEntity(new StringEntity(requestBody.toString()));
+    postRequest.setHeader("Content-Type", "application/json");
 
-        CloseableHttpClient httpClient = HttpClients.createDefault();
-        httpClient.execute(postRequest);
-    }
+    CloseableHttpClient httpClient = HttpClients.createDefault();
+    httpClient.execute(postRequest);
+  }
 
-    @Override
-    protected void append(LoggingEvent loggingEvent) {
-        ApplicationManager.getApplication().executeOnPooledThread((() -> {
-            if (loggingEvent.getThrowableInformation() != null) {
+  @Override
+  protected void append(LoggingEvent loggingEvent) {
+    ApplicationManager.getApplication()
+        .executeOnPooledThread(
+            (() -> {
+              if (loggingEvent.getThrowableInformation() != null) {
                 try {
-                    dispatchLog(
-                            loggingEvent.getLevel().toString().toLowerCase(),
-                            loggingEvent.getMessage().toString(),
-                            getStackTrace(loggingEvent.getThrowableInformation().getThrowable())
-                    );
+                  dispatchLog(
+                      loggingEvent.getLevel().toString().toLowerCase(),
+                      loggingEvent.getMessage().toString(),
+                      getStackTrace(loggingEvent.getThrowableInformation().getThrowable()));
                 } catch (Exception ignored) {
                 }
-            }
-        }));
-    }
+              }
+            }));
+  }
 
-    @Override
-    public void close() {
+  @Override
+  public void close() {}
 
-    }
-
-    @Override
-    public boolean requiresLayout() {
-        return false;
-    }
+  @Override
+  public boolean requiresLayout() {
+    return false;
+  }
 }

--- a/src/main/java/com/tabnine/prediction/CompletionFacade.java
+++ b/src/main/java/com/tabnine/prediction/CompletionFacade.java
@@ -1,5 +1,7 @@
 package com.tabnine.prediction;
 
+import static com.tabnine.general.StaticConfig.*;
+
 import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.openapi.application.ex.ApplicationUtil;
 import com.intellij.openapi.editor.Document;
@@ -15,75 +17,74 @@ import com.tabnine.binary.requests.autocomplete.AutocompleteResponse;
 import com.tabnine.capabilities.SuggestionsMode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import static com.tabnine.general.StaticConfig.*;
 
 public class CompletionFacade {
-    private final BinaryRequestFacade binaryRequestFacade;
+  private final BinaryRequestFacade binaryRequestFacade;
 
-    public CompletionFacade(BinaryRequestFacade binaryRequestFacade) {
-        this.binaryRequestFacade = binaryRequestFacade;
+  public CompletionFacade(BinaryRequestFacade binaryRequestFacade) {
+    this.binaryRequestFacade = binaryRequestFacade;
+  }
+
+  @Nullable
+  public AutocompleteResponse retrieveCompletions(CompletionParameters parameters) {
+    try {
+      String filename = getFilename(parameters.getOriginalFile().getVirtualFile());
+      return ApplicationUtil.runWithCheckCanceled(
+          () ->
+              retrieveCompletions(
+                  parameters.getEditor().getDocument(), parameters.getOffset(), filename),
+          ProgressManager.getInstance().getProgressIndicator());
+    } catch (BinaryCannotRecoverException e) {
+      throw e;
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  @Nullable
+  public AutocompleteResponse retrieveCompletions(@NotNull Document document, int offset) {
+    try {
+      String filename = getFilename(FileDocumentManager.getInstance().getFile(document));
+      return retrieveCompletions(document, offset, filename);
+    } catch (BinaryCannotRecoverException e) {
+      throw e;
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  @Nullable
+  private String getFilename(@Nullable VirtualFile file) {
+    return ObjectUtils.doIfNotNull(file, VirtualFile::getPath);
+  }
+
+  @Nullable
+  private AutocompleteResponse retrieveCompletions(
+      @NotNull Document document, int offset, @Nullable String filename) {
+    int begin = Integer.max(0, offset - MAX_OFFSET);
+    int end = Integer.min(document.getTextLength(), offset + MAX_OFFSET);
+    AutocompleteRequest req = new AutocompleteRequest();
+    req.before = document.getText(new TextRange(begin, offset));
+    req.after = document.getText(new TextRange(offset, end));
+    req.filename = filename;
+    req.maxResults = MAX_COMPLETIONS;
+    req.regionIncludesBeginning = (begin == 0);
+    req.regionIncludesEnd = (end == document.getTextLength());
+    req.offset = offset;
+    req.line = document.getLineNumber(offset);
+    req.character = offset - document.getLineStartOffset(req.line);
+
+    return binaryRequestFacade.executeRequest(req, determineTimeoutBy(req.before));
+  }
+
+  private int determineTimeoutBy(@NotNull String before) {
+    if (SuggestionsMode.getSuggestionMode() != SuggestionsMode.INLINE) {
+      return COMPLETION_TIME_THRESHOLD;
     }
 
-    @Nullable
-    public AutocompleteResponse retrieveCompletions(CompletionParameters parameters) {
-        try {
-            String filename = getFilename(parameters.getOriginalFile().getVirtualFile());
-            return ApplicationUtil.runWithCheckCanceled(() -> retrieveCompletions(
-                        parameters.getEditor().getDocument(),
-                        parameters.getOffset(),
-                        filename
-                    ),
-                    ProgressManager.getInstance().getProgressIndicator());
-        } catch (BinaryCannotRecoverException e) {
-            throw e;
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    @Nullable
-    public AutocompleteResponse retrieveCompletions(@NotNull Document document, int offset) {
-        try {
-            String filename = getFilename(FileDocumentManager.getInstance().getFile(document));
-            return retrieveCompletions(document, offset, filename);
-        } catch (BinaryCannotRecoverException e) {
-            throw e;
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    @Nullable
-    private String getFilename(@Nullable VirtualFile file) {
-        return ObjectUtils.doIfNotNull(file, VirtualFile::getPath);
-    }
-
-    @Nullable
-    private AutocompleteResponse retrieveCompletions(@NotNull Document document, int offset, @Nullable String filename) {
-        int begin = Integer.max(0, offset - MAX_OFFSET);
-        int end = Integer.min(document.getTextLength(), offset + MAX_OFFSET);
-        AutocompleteRequest req = new AutocompleteRequest();
-        req.before = document.getText(new TextRange(begin, offset));
-        req.after = document.getText(new TextRange(offset, end));
-        req.filename = filename;
-        req.maxResults = MAX_COMPLETIONS;
-        req.regionIncludesBeginning = (begin == 0);
-        req.regionIncludesEnd = (end == document.getTextLength());
-        req.offset = offset;
-        req.line = document.getLineNumber(offset);
-        req.character = offset - document.getLineStartOffset(req.line);
-
-        return binaryRequestFacade.executeRequest(req, determineTimeoutBy(req.before));
-    }
-
-    private int determineTimeoutBy(@NotNull String before) {
-        if (SuggestionsMode.getSuggestionMode() != SuggestionsMode.INLINE) {
-            return  COMPLETION_TIME_THRESHOLD;
-        }
-
-        int lastNewline = before.lastIndexOf("\n");
-        String lastLine = lastNewline >= 0 ? before.substring(lastNewline) : "";
-        boolean endsWithWhitespacesOnly = lastLine.trim().isEmpty();
-        return endsWithWhitespacesOnly ? NEWLINE_COMPLETION_TIME_THRESHOLD : COMPLETION_TIME_THRESHOLD;
-    }
+    int lastNewline = before.lastIndexOf("\n");
+    String lastLine = lastNewline >= 0 ? before.substring(lastNewline) : "";
+    boolean endsWithWhitespacesOnly = lastLine.trim().isEmpty();
+    return endsWithWhitespacesOnly ? NEWLINE_COMPLETION_TIME_THRESHOLD : COMPLETION_TIME_THRESHOLD;
+  }
 }

--- a/src/main/java/com/tabnine/prediction/TabNineCompletion.java
+++ b/src/main/java/com/tabnine/prediction/TabNineCompletion.java
@@ -5,54 +5,63 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.util.containers.FList;
 import com.tabnine.general.CompletionKind;
 import com.tabnine.general.CompletionOrigin;
-
 import java.util.ArrayList;
 import java.util.List;
 
 public class TabNineCompletion {
-    public final String oldPrefix;
-    public final String newPrefix;
-    public final String oldSuffix;
-    public final String newSuffix;
-    public final int index;
-    public String cursorPrefix;
-    public String cursorSuffix;
-    public CompletionOrigin origin;
-    public CompletionKind completionKind;
-    public Boolean isCached;
+  public final String oldPrefix;
+  public final String newPrefix;
+  public final String oldSuffix;
+  public final String newSuffix;
+  public final int index;
+  public String cursorPrefix;
+  public String cursorSuffix;
+  public CompletionOrigin origin;
+  public CompletionKind completionKind;
+  public Boolean isCached;
 
-    public String detail = null;
-    public boolean deprecated = false;
+  public String detail = null;
+  public boolean deprecated = false;
 
-    public TabNineCompletion(String oldPrefix, String newPrefix, String oldSuffix, String newSuffix, int index, String cursorPrefix, String cursorSuffix, CompletionOrigin origin, CompletionKind completionKind, Boolean isCached) {
-        this.oldPrefix = oldPrefix;
-        this.newPrefix = newPrefix;
-        this.oldSuffix = oldSuffix;
-        this.newSuffix = newSuffix;
-        this.index = index;
-        this.cursorPrefix = cursorPrefix;
-        this.cursorSuffix = cursorSuffix;
-        this.origin = origin;
-        this.completionKind = completionKind;
-        this.isCached = isCached;
+  public TabNineCompletion(
+      String oldPrefix,
+      String newPrefix,
+      String oldSuffix,
+      String newSuffix,
+      int index,
+      String cursorPrefix,
+      String cursorSuffix,
+      CompletionOrigin origin,
+      CompletionKind completionKind,
+      Boolean isCached) {
+    this.oldPrefix = oldPrefix;
+    this.newPrefix = newPrefix;
+    this.oldSuffix = oldSuffix;
+    this.newSuffix = newSuffix;
+    this.index = index;
+    this.cursorPrefix = cursorPrefix;
+    this.cursorSuffix = cursorSuffix;
+    this.origin = origin;
+    this.completionKind = completionKind;
+    this.isCached = isCached;
+  }
+
+  public CompletionOrigin getOrigin() {
+    return origin;
+  }
+
+  public String getSuffix() {
+    String itemText = this.newPrefix + this.newSuffix;
+    String prefix = this.oldPrefix;
+    if (prefix.isEmpty()) {
+      return itemText;
     }
 
-    public CompletionOrigin getOrigin() {
-        return origin;
+    FList<TextRange> fragments = LookupCellRenderer.getMatchingFragments(prefix, itemText);
+    if (fragments != null && !fragments.isEmpty()) {
+      List<TextRange> list = new ArrayList<>(fragments);
+      return itemText.substring(list.get(list.size() - 1).getEndOffset());
     }
-
-    public String getSuffix() {
-        String itemText = this.newPrefix + this.newSuffix;
-        String prefix = this.oldPrefix;
-        if (prefix.isEmpty()) {
-            return itemText;
-        }
-
-        FList<TextRange> fragments = LookupCellRenderer.getMatchingFragments(prefix, itemText);
-        if (fragments != null && !fragments.isEmpty()) {
-            List<TextRange> list = new ArrayList<>(fragments);
-            return itemText.substring(list.get(list.size() - 1).getEndOffset());
-        }
-        return "";
-    }
+    return "";
+  }
 }

--- a/src/main/java/com/tabnine/prediction/TabNinePrefixMatcher.java
+++ b/src/main/java/com/tabnine/prediction/TabNinePrefixMatcher.java
@@ -6,41 +6,41 @@ import com.intellij.codeInsight.lookup.LookupElementDecorator;
 import org.jetbrains.annotations.NotNull;
 
 public class TabNinePrefixMatcher extends PrefixMatcher {
-    final PrefixMatcher inner;
+  final PrefixMatcher inner;
 
-    public TabNinePrefixMatcher(PrefixMatcher inner) {
-        super(inner.getPrefix());
-        this.inner = inner;
+  public TabNinePrefixMatcher(PrefixMatcher inner) {
+    super(inner.getPrefix());
+    this.inner = inner;
+  }
+
+  @Override
+  public boolean prefixMatches(@NotNull LookupElement element) {
+    if (element.getObject() instanceof TabNineCompletion) {
+      return true;
+    } else if (element instanceof LookupElementDecorator) {
+      return prefixMatches(((LookupElementDecorator) element).getDelegate());
     }
 
-    @Override
-    public boolean prefixMatches(@NotNull LookupElement element) {
-        if (element.getObject() instanceof TabNineCompletion) {
-            return true;
-        } else if (element instanceof LookupElementDecorator) {
-            return prefixMatches(((LookupElementDecorator) element).getDelegate());
-        }
+    return super.prefixMatches(element);
+  }
 
-        return super.prefixMatches(element);
+  @Override
+  public boolean isStartMatch(LookupElement element) {
+    if (element.getObject() instanceof TabNineCompletion) {
+      return true;
     }
 
-    @Override
-    public boolean isStartMatch(LookupElement element) {
-        if (element.getObject() instanceof TabNineCompletion) {
-            return true;
-        }
+    return super.isStartMatch(element);
+  }
 
-        return super.isStartMatch(element);
-    }
+  @Override
+  public boolean prefixMatches(@NotNull String name) {
+    return this.inner.prefixMatches(name);
+  }
 
-    @Override
-    public boolean prefixMatches(@NotNull String name) {
-        return this.inner.prefixMatches(name);
-    }
-
-    @NotNull
-    @Override
-    public PrefixMatcher cloneWithPrefix(@NotNull String prefix) {
-        return new TabNinePrefixMatcher(this.inner.cloneWithPrefix(prefix));
-    }
+  @NotNull
+  @Override
+  public PrefixMatcher cloneWithPrefix(@NotNull String prefix) {
+    return new TabNinePrefixMatcher(this.inner.cloneWithPrefix(prefix));
+  }
 }

--- a/src/main/java/com/tabnine/prediction/TabNineWeigher.java
+++ b/src/main/java/com/tabnine/prediction/TabNineWeigher.java
@@ -4,16 +4,16 @@ import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementWeigher;
 
 public class TabNineWeigher extends LookupElementWeigher {
-    public TabNineWeigher() {
-        super("TabNineLookupElementWeigher", false, true);
+  public TabNineWeigher() {
+    super("TabNineLookupElementWeigher", false, true);
+  }
+
+  @Override
+  public Integer weigh(LookupElement element) {
+    if (element.getObject() instanceof TabNineCompletion) {
+      return ((TabNineCompletion) element.getObject()).index;
     }
 
-    @Override
-    public Integer weigh(LookupElement element) {
-        if (element.getObject() instanceof TabNineCompletion) {
-            return ((TabNineCompletion) element.getObject()).index;
-        }
-
-        return Integer.MAX_VALUE;
-    }
+    return Integer.MAX_VALUE;
+  }
 }

--- a/src/main/java/com/tabnine/selections/AutoImporter.java
+++ b/src/main/java/com/tabnine/selections/AutoImporter.java
@@ -22,207 +22,215 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.ObjectUtils;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class AutoImporter implements MarkupModelListener {
 
-    private static final int MAX_ATTEMPTS = 2;
-    private static final Key<AutoImporter> TABNINE_AUTO_IMPORTER_KEY =
-            Key.create("TABNINE_AUTO_IMPORTER");
+  private static final int MAX_ATTEMPTS = 2;
+  private static final Key<AutoImporter> TABNINE_AUTO_IMPORTER_KEY =
+      Key.create("TABNINE_AUTO_IMPORTER");
 
-    private int startOffset;
-    private int endOffset;
-    private boolean offsetRangeVisited = false;
-    private final AtomicBoolean codeAnalyzerAutoImportInvoked = new AtomicBoolean(false);
-    @NotNull
-    private final Project project;
-    @NotNull Editor editor;
-    private Disposable myDisposable;
-    private final Map<String, Integer> importCandidates = new HashMap<>();
-    private String lastCandidate;
-    private final Set<String> foundImportsSet = new HashSet<>();
-    private final List<HighlightInfo.IntentionActionDescriptor> importFixes = new ArrayList<>();
+  private int startOffset;
+  private int endOffset;
+  private boolean offsetRangeVisited = false;
+  private final AtomicBoolean codeAnalyzerAutoImportInvoked = new AtomicBoolean(false);
+  @NotNull private final Project project;
+  @NotNull Editor editor;
+  private Disposable myDisposable;
+  private final Map<String, Integer> importCandidates = new HashMap<>();
+  private String lastCandidate;
+  private final Set<String> foundImportsSet = new HashSet<>();
+  private final List<HighlightInfo.IntentionActionDescriptor> importFixes = new ArrayList<>();
 
-    private AutoImporter(@NotNull Editor editor, @NotNull Project project, int startOffset, int endOffset) {
-        this.editor = editor;
-        this.project = project;
-        this.startOffset = startOffset;
-        this.endOffset = endOffset;
+  private AutoImporter(
+      @NotNull Editor editor, @NotNull Project project, int startOffset, int endOffset) {
+    this.editor = editor;
+    this.project = project;
+    this.startOffset = startOffset;
+    this.endOffset = endOffset;
+  }
+
+  private void init() {
+    String insertedText = editor.getDocument().getText(new TextRange(startOffset, endOffset));
+    String[] terms = insertedText.split("\\W+");
+    if (terms.length > 0) {
+      for (String term : terms) {
+        importCandidates.put(term, MAX_ATTEMPTS);
+      }
+      lastCandidate = terms[terms.length - 1];
+      myDisposable = Disposer.newDisposable();
+      EditorUtil.disposeWithEditor(editor, myDisposable);
+      ((EditorEx) editor)
+          .getFilteredDocumentMarkupModel()
+          .addMarkupModelListener(myDisposable, this);
     }
+  }
 
-    private void init() {
-        String insertedText = editor.getDocument().getText(new TextRange(startOffset, endOffset));
-        String[] terms = insertedText.split("\\W+");
-        if (terms.length > 0) {
-            for (String term : terms) {
-                importCandidates.put(term, MAX_ATTEMPTS);
-            }
-            lastCandidate = terms[terms.length - 1];
-            myDisposable = Disposer.newDisposable();
-            EditorUtil.disposeWithEditor(editor, myDisposable);
-            ((EditorEx) editor)
-                    .getFilteredDocumentMarkupModel()
-                    .addMarkupModelListener(myDisposable, this);
-        }
+  public static void registerTabNineAutoImporter(
+      @NotNull Editor editor, @NotNull Project project, int startOffset, int endOffset) {
+    AutoImporter autoImporter = editor.getUserData(TABNINE_AUTO_IMPORTER_KEY);
+    if (autoImporter != null) {
+      autoImporter.cleanup();
+      editor.putUserData(TABNINE_AUTO_IMPORTER_KEY, null);
     }
+    autoImporter = new AutoImporter(editor, project, startOffset, endOffset);
+    editor.putUserData(TABNINE_AUTO_IMPORTER_KEY, autoImporter);
+    autoImporter.init();
+  }
 
-    public static void registerTabNineAutoImporter(@NotNull Editor editor, @NotNull Project project, int startOffset, int endOffset) {
-        AutoImporter autoImporter = editor.getUserData(TABNINE_AUTO_IMPORTER_KEY);
-        if (autoImporter != null) {
-            autoImporter.cleanup();
-            editor.putUserData(TABNINE_AUTO_IMPORTER_KEY, null);
-        }
-        autoImporter = new AutoImporter(editor, project, startOffset, endOffset);
-        editor.putUserData(TABNINE_AUTO_IMPORTER_KEY, autoImporter);
-        autoImporter.init();
-    }
+  private boolean isPriorHighlighter(@NotNull RangeHighlighterEx highlighter) {
+    return startOffset > highlighter.getAffectedAreaStartOffset();
+  }
 
-    private boolean isPriorHighlighter(@NotNull RangeHighlighterEx highlighter) {
-        return startOffset > highlighter.getAffectedAreaStartOffset();
-    }
+  private boolean isPosteriorHighlighter(@NotNull RangeHighlighterEx highlighter) {
+    return endOffset < highlighter.getAffectedAreaEndOffset();
+  }
 
-    private boolean isPosteriorHighlighter(@NotNull RangeHighlighterEx highlighter) {
-        return endOffset < highlighter.getAffectedAreaEndOffset();
-    }
+  @Nullable
+  private PsiFile getFile(@NotNull RangeHighlighterEx highlighter) {
+    final Document document = highlighter.getDocument();
+    return PsiDocumentManager.getInstance(project).getPsiFile(document);
+  }
 
-    @Nullable
-    private PsiFile getFile(@NotNull RangeHighlighterEx highlighter) {
-        final Document document = highlighter.getDocument();
-        return PsiDocumentManager.getInstance(project).getPsiFile(document);
-    }
+  @Nullable
+  private HighlightInfo getHighlightInfo(@NotNull RangeHighlighterEx highlighter) {
+    Object errorTooltip = highlighter.getErrorStripeTooltip();
+    return ObjectUtils.tryCast(errorTooltip, HighlightInfo.class);
+  }
 
-    @Nullable
-    private HighlightInfo getHighlightInfo(@NotNull RangeHighlighterEx highlighter) {
-        Object errorTooltip = highlighter.getErrorStripeTooltip();
-        return ObjectUtils.tryCast(errorTooltip, HighlightInfo.class);
-    }
+  private void invokeLater(@NotNull Runnable task) {
+    ApplicationManager.getApplication().invokeLater(task);
+  }
 
-    private void invokeLater(@NotNull Runnable task) {
-        ApplicationManager.getApplication().invokeLater(task);
+  private void autoImportUsingCodeAnalyzer(@NotNull final PsiFile file) {
+    if (codeAnalyzerAutoImportInvoked.get()) {
+      return;
     }
+    final DaemonCodeAnalyzerImpl codeAnalyzer =
+        (DaemonCodeAnalyzerImpl) DaemonCodeAnalyzer.getInstance(project);
+    CommandProcessor.getInstance()
+        .runUndoTransparentAction(
+            () ->
+                invokeLater(
+                    () -> {
+                      codeAnalyzerAutoImportInvoked.set(true);
+                      codeAnalyzer.autoImportReferenceAtCursor(editor, file);
+                    }));
+  }
 
-    private void autoImportUsingCodeAnalyzer(@NotNull final PsiFile file) {
-        if (codeAnalyzerAutoImportInvoked.get()) {
-            return;
-        }
-        final DaemonCodeAnalyzerImpl codeAnalyzer =
-                (DaemonCodeAnalyzerImpl) DaemonCodeAnalyzer.getInstance(project);
-        CommandProcessor.getInstance()
-                .runUndoTransparentAction(() -> invokeLater(() -> {
-                    codeAnalyzerAutoImportInvoked.set(true);
-                    codeAnalyzer.autoImportReferenceAtCursor(editor, file);
-                }));
+  private void collectImportFixes(
+      @NotNull PsiFile file,
+      @NotNull RangeHighlighterEx highlighter,
+      @NotNull String highlightedText) {
+    List<HighlightInfo.IntentionActionDescriptor> availableFixes =
+        ShowIntentionsPass.getAvailableFixes(editor, file, -1, highlighter.getEndOffset());
+    List<HighlightInfo.IntentionActionDescriptor> importActions =
+        availableFixes.stream()
+            .filter(
+                f -> {
+                  String actionText = f.getAction().getText().toLowerCase();
+                  return actionText.contains("import") && !actionText.contains("remove");
+                })
+            .collect(Collectors.toList());
+    if (importActions.stream()
+            .filter(f -> f.getAction().getText().contains(highlightedText))
+            .count()
+        > 1) {
+      // Skip highlight in case of ambiguity
+      return;
     }
+    if (!importActions.isEmpty()) {
+      foundImportsSet.add(highlightedText);
+      importCandidates.remove(highlightedText);
+      importFixes.add(importActions.get(0));
+    }
+  }
 
-    private void collectImportFixes(
-            @NotNull PsiFile file,
-            @NotNull RangeHighlighterEx highlighter,
-            @NotNull String highlightedText) {
-        List<HighlightInfo.IntentionActionDescriptor> availableFixes =
-                ShowIntentionsPass.getAvailableFixes(editor, file, -1, highlighter.getEndOffset());
-        List<HighlightInfo.IntentionActionDescriptor> importActions =
-                availableFixes.stream()
-                        .filter(f -> {
-                            String actionText = f.getAction().getText().toLowerCase();
-                            return actionText.contains("import") && !actionText.contains("remove");
-                        })
-                        .collect(Collectors.toList());
-        if (importActions.stream()
-                .filter(f -> f.getAction().getText().contains(highlightedText))
-                .count()
-                > 1) {
-            // Skip highlight in case of ambiguity
-            return;
-        }
-        if (!importActions.isEmpty()) {
-            foundImportsSet.add(highlightedText);
-            importCandidates.remove(highlightedText);
-            importFixes.add(importActions.get(0));
-        }
+  @Override
+  public void afterAdded(@NotNull RangeHighlighterEx highlighter) {
+    try {
+      if (isPriorHighlighter(highlighter)) {
+        // Irrelevant
+        return;
+      }
+      PsiFile file = getFile(highlighter);
+      if (file == null) {
+        return;
+      }
+      if ((isPosteriorHighlighter(highlighter) && offsetRangeVisited)
+          || importCandidates.isEmpty()) {
+        // Moved on to other highlighters - invoke the collected actions (if any)
+        invokeImportActions(file);
+        return;
+      }
+      offsetRangeVisited = true;
+      HighlightInfo highlightInfo = getHighlightInfo(highlighter);
+      if (highlightInfo == null) {
+        return;
+      }
+      String highlightedText = highlightInfo.getText();
+      if (!importCandidates.containsKey(highlightedText)) {
+        // Irrelevant
+        return;
+      }
+      // Try auto import
+      autoImportUsingCodeAnalyzer(file);
+      // Collect import fixes
+      collectImportFixes(file, highlighter, highlightedText);
+      markAsVisited(highlightedText);
+      if (shouldFinishListening(highlightedText)) {
+        // Invoke actions and cleanup
+        invokeImportActions(file);
+      }
+    } catch (Throwable e) {
+      Logger.getInstance(getClass())
+          .warn("Failed to process highlighter: " + highlighter + " for auto-import", e);
     }
+  }
 
-    @Override
-    public void afterAdded(@NotNull RangeHighlighterEx highlighter) {
-        try {
-            if (isPriorHighlighter(highlighter)) {
-                // Irrelevant
-                return;
-            }
-            PsiFile file = getFile(highlighter);
-            if (file == null) {
-                return;
-            }
-            if ((isPosteriorHighlighter(highlighter) && offsetRangeVisited) || importCandidates.isEmpty()) {
-                // Moved on to other highlighters - invoke the collected actions (if any)
-                invokeImportActions(file);
-                return;
-            }
-            offsetRangeVisited = true;
-            HighlightInfo highlightInfo = getHighlightInfo(highlighter);
-            if (highlightInfo == null) {
-                return;
-            }
-            String highlightedText = highlightInfo.getText();
-            if (!importCandidates.containsKey(highlightedText)) {
-                // Irrelevant
-                return;
-            }
-            // Try auto import
-            autoImportUsingCodeAnalyzer(file);
-            // Collect import fixes
-            collectImportFixes(file, highlighter, highlightedText);
-            markAsVisited(highlightedText);
-            if (shouldFinishListening(highlightedText)) {
-                // Invoke actions and cleanup
-                invokeImportActions(file);
-            }
-        } catch (Throwable e) {
-            Logger.getInstance(getClass()).warn("Failed to process highlighter: " + highlighter + " for auto-import", e);
-        }
-    }
+  private boolean shouldFinishListening(@NotNull String term) {
+    return (term.equals(lastCandidate) && foundImportsSet.contains(term))
+        || importCandidates.isEmpty();
+  }
 
-    private boolean shouldFinishListening(@NotNull String term) {
-        return (term.equals(lastCandidate) && foundImportsSet.contains(term))
-                || importCandidates.isEmpty();
-    }
+  private void markAsVisited(@NotNull String term) {
+    importCandidates.computeIfPresent(term, (k, v) -> v == 1 ? null : v - 1);
+  }
 
-    private void markAsVisited(@NotNull String term) {
-        importCandidates.computeIfPresent(term, (k, v) -> v == 1 ? null : v - 1);
+  private void invokeImportActions(@NotNull PsiFile file) {
+    try {
+      final List<HighlightInfo.IntentionActionDescriptor> importFixActions =
+          new ArrayList<>(importFixes);
+      invokeLater(
+          () ->
+              importFixActions.forEach(
+                  fix ->
+                      ShowIntentionActionsHandler.chooseActionAndInvoke(
+                          file, editor, fix.getAction(), fix.getAction().getText())));
+    } catch (Throwable e) {
+      Logger.getInstance(getClass()).warn("Failed to auto import", e);
+    } finally {
+      cleanup();
     }
+  }
 
-    private void invokeImportActions(@NotNull PsiFile file) {
-        try {
-            final List<HighlightInfo.IntentionActionDescriptor> importFixActions =
-                    new ArrayList<>(importFixes);
-            invokeLater(
-                    () -> importFixActions.forEach(
-                            fix -> ShowIntentionActionsHandler.chooseActionAndInvoke(
-                                    file, editor, fix.getAction(), fix.getAction().getText())));
-        } catch (Throwable e) {
-            Logger.getInstance(getClass()).warn("Failed to auto import", e);
-        } finally {
-            cleanup();
-        }
-    }
+  private void cleanup() {
+    unregisteredAsMarkupModelListener();
+    importCandidates.clear();
+    lastCandidate = null;
+    foundImportsSet.clear();
+    importFixes.clear();
+    offsetRangeVisited = false;
+    codeAnalyzerAutoImportInvoked.set(false);
+  }
 
-    private void cleanup() {
-        unregisteredAsMarkupModelListener();
-        importCandidates.clear();
-        lastCandidate = null;
-        foundImportsSet.clear();
-        importFixes.clear();
-        offsetRangeVisited = false;
-        codeAnalyzerAutoImportInvoked.set(false);
+  private void unregisteredAsMarkupModelListener() {
+    if (myDisposable != null && !Disposer.isDisposed(myDisposable)) {
+      Disposer.dispose(myDisposable);
     }
-
-    private void unregisteredAsMarkupModelListener() {
-        if (myDisposable != null && !Disposer.isDisposed(myDisposable)) {
-            Disposer.dispose(myDisposable);
-        }
-    }
+  }
 }

--- a/src/main/java/com/tabnine/selections/CompletionPreviewListener.java
+++ b/src/main/java/com/tabnine/selections/CompletionPreviewListener.java
@@ -6,49 +6,50 @@ import com.tabnine.binary.requests.selection.SelectionRequest;
 import com.tabnine.binary.requests.selection.SetStateBinaryRequest;
 import com.tabnine.prediction.TabNineCompletion;
 import com.tabnine.statusBar.StatusBarUpdater;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-
 public class CompletionPreviewListener {
-    private final BinaryRequestFacade binaryRequestFacade;
-    private final StatusBarUpdater statusBarUpdater;
+  private final BinaryRequestFacade binaryRequestFacade;
+  private final StatusBarUpdater statusBarUpdater;
 
-    public CompletionPreviewListener(BinaryRequestFacade binaryRequestFacade,
-                                 StatusBarUpdater statusBarUpdater) {
-        this.binaryRequestFacade = binaryRequestFacade;
-        this.statusBarUpdater = statusBarUpdater;
+  public CompletionPreviewListener(
+      BinaryRequestFacade binaryRequestFacade, StatusBarUpdater statusBarUpdater) {
+    this.binaryRequestFacade = binaryRequestFacade;
+    this.statusBarUpdater = statusBarUpdater;
+  }
+
+  public void previewSelected(CompletionPreviewData data) {
+    TabNineCompletion completion = data.completions.get(data.previewIndex);
+    SelectionRequest selection = new SelectionRequest();
+
+    selection.language = SelectionUtil.asLanguage(data.file.getName());
+    selection.netLength =
+        completion.newPrefix.replaceFirst("^" + completion.oldPrefix, "").length();
+    selection.linePrefixLength = completion.cursorPrefix.length();
+    selection.lineNetPrefixLength = selection.linePrefixLength - completion.oldPrefix.length();
+    selection.lineSuffixLength = completion.cursorSuffix.length();
+    selection.index = data.previewIndex;
+    selection.origin = completion.origin;
+    selection.length = completion.newPrefix.length();
+    selection.strength = SelectionUtil.getStrength(completion);
+    selection.completionKind = completion.completionKind;
+    SelectionUtil.addSuggestionsCount(selection, data.completions);
+
+    binaryRequestFacade.executeRequest(new SetStateBinaryRequest(selection));
+    this.statusBarUpdater.updateStatusBar();
+  }
+
+  public static class CompletionPreviewData {
+    List<TabNineCompletion> completions;
+    int previewIndex;
+    @NotNull PsiFile file;
+
+    public CompletionPreviewData(
+        List<TabNineCompletion> completions, int previewIndex, @NotNull PsiFile file) {
+      this.completions = completions;
+      this.previewIndex = previewIndex;
+      this.file = file;
     }
-
-    public void previewSelected(CompletionPreviewData data) {
-        TabNineCompletion completion = data.completions.get(data.previewIndex);
-        SelectionRequest selection = new SelectionRequest();
-
-        selection.language = SelectionUtil.asLanguage(data.file.getName());
-        selection.netLength = completion.newPrefix.replaceFirst("^" + completion.oldPrefix, "").length();
-        selection.linePrefixLength = completion.cursorPrefix.length();
-        selection.lineNetPrefixLength = selection.linePrefixLength - completion.oldPrefix.length();
-        selection.lineSuffixLength = completion.cursorSuffix.length();
-        selection.index = data.previewIndex;
-        selection.origin = completion.origin;
-        selection.length = completion.newPrefix.length();
-        selection.strength = SelectionUtil.getStrength(completion);
-        selection.completionKind = completion.completionKind;
-        SelectionUtil.addSuggestionsCount(selection, data.completions);
-
-        binaryRequestFacade.executeRequest(new SetStateBinaryRequest(selection));
-        this.statusBarUpdater.updateStatusBar();
-    }
-
-    public static class CompletionPreviewData {
-        List<TabNineCompletion> completions;
-        int previewIndex;
-        @NotNull PsiFile file;
-
-        public CompletionPreviewData(List<TabNineCompletion> completions, int previewIndex, @NotNull PsiFile file) {
-            this.completions = completions;
-            this.previewIndex = previewIndex;
-            this.file = file;
-        }
-    }
+  }
 }

--- a/src/main/java/com/tabnine/selections/SelectionUtil.java
+++ b/src/main/java/com/tabnine/selections/SelectionUtil.java
@@ -1,47 +1,52 @@
 package com.tabnine.selections;
 
+import static com.tabnine.general.Utils.toInt;
+import static java.util.stream.Collectors.*;
+
 import com.tabnine.binary.requests.selection.SelectionRequest;
 import com.tabnine.binary.requests.selection.SelectionSuggestionRequest;
 import com.tabnine.general.CompletionOrigin;
 import com.tabnine.prediction.TabNineCompletion;
-import org.jetbrains.annotations.NotNull;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
-import static com.tabnine.general.Utils.toInt;
-import static java.util.stream.Collectors.*;
+import org.jetbrains.annotations.NotNull;
 
 class SelectionUtil {
 
-    static void addSuggestionsCount(SelectionRequest selection, List<TabNineCompletion> suggestions) {
-        Map<CompletionOrigin, Long> originCount = suggestions.stream()
-                .collect(groupingBy(TabNineCompletion::getOrigin, counting()));
+  static void addSuggestionsCount(SelectionRequest selection, List<TabNineCompletion> suggestions) {
+    Map<CompletionOrigin, Long> originCount =
+        suggestions.stream().collect(groupingBy(TabNineCompletion::getOrigin, counting()));
 
-        selection.suggestionsCount = suggestions.size();
-        selection.deepCloudSuggestionsCount = toInt(originCount.get(CompletionOrigin.CLOUD));
-        selection.deepLocalSuggestionsCount = toInt(originCount.get(CompletionOrigin.LOCAL));
-        selection.lspSuggestionsCount = toInt(originCount.get(CompletionOrigin.LSP));
-        selection.vanillaSuggestionsCount = toInt(originCount.get(CompletionOrigin.VANILLA));
+    selection.suggestionsCount = suggestions.size();
+    selection.deepCloudSuggestionsCount = toInt(originCount.get(CompletionOrigin.CLOUD));
+    selection.deepLocalSuggestionsCount = toInt(originCount.get(CompletionOrigin.LOCAL));
+    selection.lspSuggestionsCount = toInt(originCount.get(CompletionOrigin.LSP));
+    selection.vanillaSuggestionsCount = toInt(originCount.get(CompletionOrigin.VANILLA));
 
-        selection.suggestions = suggestions.stream()
-                .map(suggestion -> new SelectionSuggestionRequest(suggestion.newPrefix.length(), getStrength(suggestion), suggestion.origin.name()))
-                .collect(toList());
+    selection.suggestions =
+        suggestions.stream()
+            .map(
+                suggestion ->
+                    new SelectionSuggestionRequest(
+                        suggestion.newPrefix.length(),
+                        getStrength(suggestion),
+                        suggestion.origin.name()))
+            .collect(toList());
+  }
+
+  static String getStrength(TabNineCompletion item) {
+    if (item.origin == CompletionOrigin.LSP) {
+      return null;
     }
 
-    static String getStrength(TabNineCompletion item) {
-        if (item.origin == CompletionOrigin.LSP) {
-            return null;
-        }
+    return item.detail;
+  }
 
-        return item.detail;
-    }
+  @NotNull
+  static String asLanguage(String name) {
+    String[] split = name.split("\\.");
 
-    @NotNull
-    static String asLanguage(String name) {
-        String[] split = name.split("\\.");
-
-        return Arrays.stream(split).skip(Math.max(1, split.length - 1)).findAny().orElse("undefined");
-    }
+    return Arrays.stream(split).skip(Math.max(1, split.length - 1)).findAny().orElse("undefined");
+  }
 }

--- a/src/main/java/com/tabnine/selections/TabNineLookupListener.java
+++ b/src/main/java/com/tabnine/selections/TabNineLookupListener.java
@@ -1,5 +1,7 @@
 package com.tabnine.selections;
 
+import static java.util.stream.Collectors.toList;
+
 import com.intellij.codeInsight.lookup.LookupEvent;
 import com.intellij.codeInsight.lookup.LookupListener;
 import com.intellij.codeInsight.lookup.impl.LookupImpl;
@@ -8,70 +10,70 @@ import com.tabnine.binary.requests.selection.SelectionRequest;
 import com.tabnine.binary.requests.selection.SetStateBinaryRequest;
 import com.tabnine.prediction.TabNineCompletion;
 import com.tabnine.statusBar.StatusBarUpdater;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-
-import static java.util.stream.Collectors.toList;
-
 public class TabNineLookupListener implements LookupListener {
-    private final BinaryRequestFacade binaryRequestFacade;
-    private final StatusBarUpdater statusBarUpdater;
+  private final BinaryRequestFacade binaryRequestFacade;
+  private final StatusBarUpdater statusBarUpdater;
 
-    public TabNineLookupListener(BinaryRequestFacade binaryRequestFacade,
-                                 StatusBarUpdater statusBarUpdater) {
-        this.binaryRequestFacade = binaryRequestFacade;
-        this.statusBarUpdater = statusBarUpdater;
+  public TabNineLookupListener(
+      BinaryRequestFacade binaryRequestFacade, StatusBarUpdater statusBarUpdater) {
+    this.binaryRequestFacade = binaryRequestFacade;
+    this.statusBarUpdater = statusBarUpdater;
+  }
+
+  @Override
+  public void currentItemChanged(@NotNull LookupEvent event) {
+    // Do nothing, but the validator is furious if we don't implement this.
+    // Probably because in older versions this was not implemented.
+  }
+
+  @Override
+  public void lookupCanceled(@NotNull LookupEvent event) {
+    // Do nothing, but the validator is furious if we don't implement this.
+    // Probably because in older versions this was not implemented.
+  }
+
+  @Override
+  public void itemSelected(@NotNull LookupEvent event) {
+    if (event.isCanceledExplicitly()) {
+      return;
     }
 
-    @Override
-    public void currentItemChanged(@NotNull LookupEvent event) {
-        // Do nothing, but the validator is furious if we don't implement this.
-        // Probably because in older versions this was not implemented.
+    if (event.getItem() != null && event.getItem().getObject() instanceof TabNineCompletion) {
+      // They picked us, yay!
+      TabNineCompletion item = (TabNineCompletion) event.getItem().getObject();
+      List<TabNineCompletion> suggestions =
+          event.getLookup().getItems().stream()
+              .map(
+                  l -> {
+                    try {
+                      return l.getObject();
+                    } catch (RuntimeException re) {
+                      return null;
+                    }
+                  })
+              .filter(TabNineCompletion.class::isInstance)
+              .map(TabNineCompletion.class::cast)
+              .collect(toList());
+
+      SelectionRequest selection = new SelectionRequest();
+
+      selection.language = SelectionUtil.asLanguage(event.getLookup().getPsiFile().getName());
+      selection.netLength = item.newPrefix.replaceFirst("^" + item.oldPrefix, "").length();
+      selection.linePrefixLength = item.cursorPrefix.length();
+      selection.lineNetPrefixLength = selection.linePrefixLength - item.oldPrefix.length();
+      selection.lineSuffixLength = item.cursorSuffix.length();
+      selection.index = ((LookupImpl) event.getLookup()).getSelectedIndex();
+      selection.origin = item.origin;
+      selection.length = item.newPrefix.length();
+      selection.strength = SelectionUtil.getStrength(item);
+      selection.completionKind = item.completionKind;
+      SelectionUtil.addSuggestionsCount(selection, suggestions);
+
+      binaryRequestFacade.executeRequest(new SetStateBinaryRequest(selection));
+      this.statusBarUpdater.updateStatusBar();
     }
-
-    @Override
-    public void lookupCanceled(@NotNull LookupEvent event) {
-        // Do nothing, but the validator is furious if we don't implement this.
-        // Probably because in older versions this was not implemented.
-    }
-
-    @Override
-    public void itemSelected(@NotNull LookupEvent event) {
-        if (event.isCanceledExplicitly()) {
-            return;
-        }
-
-        if (event.getItem() != null && event.getItem().getObject() instanceof TabNineCompletion) {
-            // They picked us, yay!
-            TabNineCompletion item = (TabNineCompletion) event.getItem().getObject();
-            List<TabNineCompletion> suggestions = event.getLookup().getItems().stream()
-                    .map(l -> {
-                        try {
-                            return l.getObject();
-                        } catch (RuntimeException re) {
-                            return null;
-                        }
-                    })
-                    .filter(TabNineCompletion.class::isInstance)
-                    .map(TabNineCompletion.class::cast).collect(toList());
-
-            SelectionRequest selection = new SelectionRequest();
-
-            selection.language = SelectionUtil.asLanguage(event.getLookup().getPsiFile().getName());
-            selection.netLength = item.newPrefix.replaceFirst("^" + item.oldPrefix, "").length();
-            selection.linePrefixLength = item.cursorPrefix.length();
-            selection.lineNetPrefixLength = selection.linePrefixLength - item.oldPrefix.length();
-            selection.lineSuffixLength = item.cursorSuffix.length();
-            selection.index = ((LookupImpl) event.getLookup()).getSelectedIndex();
-            selection.origin = item.origin;
-            selection.length = item.newPrefix.length();
-            selection.strength = SelectionUtil.getStrength(item);
-            selection.completionKind = item.completionKind;
-            SelectionUtil.addSuggestionsCount(selection, suggestions);
-
-            binaryRequestFacade.executeRequest(new SetStateBinaryRequest(selection));
-            this.statusBarUpdater.updateStatusBar();
-        }
-    }
+  }
 }

--- a/src/main/java/com/tabnine/statusBar/StatusBarPromotionProvider.java
+++ b/src/main/java/com/tabnine/statusBar/StatusBarPromotionProvider.java
@@ -1,5 +1,8 @@
 package com.tabnine.statusBar;
 
+import static com.tabnine.general.DependencyContainer.instanceOfBinaryRequestFacade;
+import static com.tabnine.general.DependencyContainer.instanceOfGlobalActionVisitor;
+
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.openapi.wm.StatusBarWidgetProvider;
@@ -8,22 +11,19 @@ import com.tabnine.lifecycle.BinaryInstantiatedActions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static com.tabnine.general.DependencyContainer.instanceOfBinaryRequestFacade;
-import static com.tabnine.general.DependencyContainer.instanceOfGlobalActionVisitor;
-
 public class StatusBarPromotionProvider implements StatusBarWidgetProvider {
-    private final BinaryRequestFacade binaryRequestFacade = instanceOfBinaryRequestFacade();
-    private final BinaryInstantiatedActions actionVisitor = instanceOfGlobalActionVisitor();
+  private final BinaryRequestFacade binaryRequestFacade = instanceOfBinaryRequestFacade();
+  private final BinaryInstantiatedActions actionVisitor = instanceOfGlobalActionVisitor();
 
-    @Nullable
-    @Override
-    public com.intellij.openapi.wm.StatusBarWidget getWidget(@NotNull Project project) {
-        return new StatusBarPromotionWidget(project, binaryRequestFacade, actionVisitor);
-    }
+  @Nullable
+  @Override
+  public com.intellij.openapi.wm.StatusBarWidget getWidget(@NotNull Project project) {
+    return new StatusBarPromotionWidget(project, binaryRequestFacade, actionVisitor);
+  }
 
-    @NotNull
-    @Override
-    public String getAnchor() {
-        return StatusBar.Anchors.after(TabnineStatusBarWidget.class.getName());
-    }
+  @NotNull
+  @Override
+  public String getAnchor() {
+    return StatusBar.Anchors.after(TabnineStatusBarWidget.class.getName());
+  }
 }

--- a/src/main/java/com/tabnine/statusBar/StatusBarPromotionWidget.java
+++ b/src/main/java/com/tabnine/statusBar/StatusBarPromotionWidget.java
@@ -1,5 +1,8 @@
 package com.tabnine.statusBar;
 
+import static com.tabnine.general.StaticConfig.PROMOTION_LIGHT_TEXT_COLOR;
+import static com.tabnine.general.StaticConfig.PROMOTION_TEXT_COLOR;
+
 import com.intellij.openapi.editor.colors.EditorColorsManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.CustomStatusBarWidget;
@@ -11,138 +14,139 @@ import com.tabnine.binary.BinaryRequestFacade;
 import com.tabnine.binary.requests.statusBar.StatusBarPromotionActionRequest;
 import com.tabnine.general.StaticConfig;
 import com.tabnine.lifecycle.BinaryInstantiatedActions;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.List;
+import java.util.Objects;
+import javax.swing.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.util.Objects;
-import java.util.List;
+public class StatusBarPromotionWidget extends EditorBasedWidget
+    implements CustomStatusBarWidget, StatusBarWidget.WidgetPresentation {
+  private final BinaryRequestFacade binaryRequestFacade;
+  private final BinaryInstantiatedActions actionVisitor;
+  private StatusBarPromotionComponent component = null;
 
-import static com.tabnine.general.StaticConfig.PROMOTION_LIGHT_TEXT_COLOR;
-import static com.tabnine.general.StaticConfig.PROMOTION_TEXT_COLOR;
+  public StatusBarPromotionWidget(
+      @NotNull Project project,
+      BinaryRequestFacade binaryRequestFacade,
+      BinaryInstantiatedActions actionVisitor) {
+    super(project);
+    this.binaryRequestFacade = binaryRequestFacade;
+    this.actionVisitor = actionVisitor;
+  }
 
-public class StatusBarPromotionWidget extends EditorBasedWidget implements CustomStatusBarWidget, StatusBarWidget.WidgetPresentation {
-    private final BinaryRequestFacade binaryRequestFacade;
-    private final BinaryInstantiatedActions actionVisitor;
-    private StatusBarPromotionComponent component = null;
+  @NotNull
+  @Override
+  public String ID() {
+    return getClass().getName();
+  }
 
-    public StatusBarPromotionWidget(@NotNull Project project, BinaryRequestFacade binaryRequestFacade, BinaryInstantiatedActions actionVisitor) {
-        super(project);
-        this.binaryRequestFacade = binaryRequestFacade;
-        this.actionVisitor = actionVisitor;
+  // Compatability implementation. DO NOT ADD @Override.
+  @NotNull
+  public JComponent getComponent() {
+    if (component != null) {
+      return component;
     }
 
-    @NotNull
-    @Override
-    public String ID() {
-        return getClass().getName();
-    }
+    component = new StatusBarPromotionComponent();
 
-    // Compatability implementation. DO NOT ADD @Override.
-    @NotNull
-    public JComponent getComponent() {
-        if (component != null) {
-            return component;
-        }
-
-        component = new StatusBarPromotionComponent();
-
-
-        component.setForeground(EditorColorsManager.getInstance().isDarkEditor() ? PROMOTION_LIGHT_TEXT_COLOR : PROMOTION_TEXT_COLOR);
-        component.setToolTipText(getTooltipText());
-        component.setText(null);
-        component.setVisible(false);
-        component.addMouseListener(new MouseAdapter() {
-            @Override
-            public void mousePressed(final MouseEvent e) {
-                Objects.requireNonNull(getClickConsumer()).consume(e);
-            }
+    component.setForeground(
+        EditorColorsManager.getInstance().isDarkEditor()
+            ? PROMOTION_LIGHT_TEXT_COLOR
+            : PROMOTION_TEXT_COLOR);
+    component.setToolTipText(getTooltipText());
+    component.setText(null);
+    component.setVisible(false);
+    component.addMouseListener(
+        new MouseAdapter() {
+          @Override
+          public void mousePressed(final MouseEvent e) {
+            Objects.requireNonNull(getClickConsumer()).consume(e);
+          }
         });
 
-        return component;
+    return component;
+  }
+
+  // Compatability implementation. DO NOT ADD @Override.
+  @Nullable
+  public WidgetPresentation getPresentation() {
+    return this;
+  }
+
+  // Compatability implementation. DO NOT ADD @Override.
+  @Nullable
+  public WidgetPresentation getPresentation(@NotNull PlatformType type) {
+    return this;
+  }
+
+  // Compatability implementation. DO NOT ADD @Override.
+  @Nullable
+  public String getTooltipText() {
+    return "Tabnine (Click to open)";
+  }
+
+  // Compatability implementation. DO NOT ADD @Override.
+  @Nullable
+  public Consumer<MouseEvent> getClickConsumer() {
+    return e -> {
+      if (!e.isPopupTrigger() && MouseEvent.BUTTON1 == e.getButton()) {
+        binaryRequestFacade.executeRequest(
+            new StatusBarPromotionActionRequest(
+                component.getId(), component.getText(), component.getActions()));
+        List<Object> actions = component.getActions();
+        if (actions != null && actions.stream().anyMatch(StaticConfig.OPEN_HUB_ACTION::equals)) {
+          actionVisitor.openHub();
+        }
+        clearMessage();
+      }
+    };
+  }
+
+  public void clearMessage() {
+    final StatusBarPromotionComponent component = (StatusBarPromotionComponent) getComponent();
+    if (component != null) {
+      component.clearMessage();
+    }
+  }
+
+  public static class StatusBarPromotionComponent extends TextPanel.WithIconAndArrows {
+    @Nullable private String id;
+    @Nullable private List<Object> actions;
+    @Nullable private String notificationType;
+
+    public @Nullable String getId() {
+      return id;
     }
 
-    // Compatability implementation. DO NOT ADD @Override.
-    @Nullable
-    public WidgetPresentation getPresentation() {
-        return this;
+    public void setId(@Nullable String id) {
+      this.id = id;
     }
 
-    // Compatability implementation. DO NOT ADD @Override.
-    @Nullable
-    public WidgetPresentation getPresentation(@NotNull PlatformType type) {
-        return this;
+    public @Nullable List<Object> getActions() {
+      return actions;
     }
 
-    // Compatability implementation. DO NOT ADD @Override.
-    @Nullable
-    public String getTooltipText() {
-        return "Tabnine (Click to open)";
+    public void setActions(@Nullable List<Object> actions) {
+      this.actions = actions;
     }
 
-    // Compatability implementation. DO NOT ADD @Override.
-    @Nullable
-    public Consumer<MouseEvent> getClickConsumer() {
-        return e -> {
-            if (!e.isPopupTrigger() && MouseEvent.BUTTON1 == e.getButton()) {
-                binaryRequestFacade.executeRequest(new StatusBarPromotionActionRequest(
-                        component.getId(), component.getText(), component.getActions()));
-                List<Object> actions = component.getActions();
-                if(actions != null && actions.stream().anyMatch(StaticConfig.OPEN_HUB_ACTION::equals)){
-                    actionVisitor.openHub();
-                }
-                clearMessage();
-            }
-        };
+    public @Nullable String getNotificationType() {
+      return notificationType;
+    }
+
+    public void setNotificationType(@Nullable String notificationType) {
+      this.notificationType = notificationType;
     }
 
     public void clearMessage() {
-        final StatusBarPromotionComponent component = (StatusBarPromotionComponent)getComponent();
-        if (component != null) {
-            component.clearMessage();
-        }
+      setVisible(false);
+      setText(null);
+      setId(null);
+      setActions(null);
+      setNotificationType(null);
     }
-
-    public static class StatusBarPromotionComponent extends TextPanel.WithIconAndArrows {
-        @Nullable
-        private String id;
-        @Nullable
-        private List<Object> actions;
-        @Nullable
-        private String notificationType;
-
-        public @Nullable String getId() {
-            return id;
-        }
-
-        public void setId(@Nullable String id) {
-            this.id = id;
-        }
-
-        public @Nullable List<Object> getActions() {
-            return actions;
-        }
-
-        public void setActions(@Nullable List<Object> actions) {
-            this.actions = actions;
-        }
-
-        public @Nullable String getNotificationType() {
-            return notificationType;
-        }
-
-        public void setNotificationType(@Nullable String notificationType) {
-            this.notificationType = notificationType;
-        }
-
-        public void clearMessage() {
-            setVisible(false);
-            setText(null);
-            setId(null);
-            setActions(null);
-            setNotificationType(null);
-        }
-    }
+  }
 }

--- a/src/main/java/com/tabnine/statusBar/StatusBarProvider.java
+++ b/src/main/java/com/tabnine/statusBar/StatusBarProvider.java
@@ -9,17 +9,18 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class StatusBarProvider implements StatusBarWidgetProvider {
-    private BinaryRequestFacade binaryRequestFacade = DependencyContainer.instanceOfBinaryRequestFacade();
+  private BinaryRequestFacade binaryRequestFacade =
+      DependencyContainer.instanceOfBinaryRequestFacade();
 
-    @Nullable
-    @Override
-    public com.intellij.openapi.wm.StatusBarWidget getWidget(@NotNull Project project) {
-        return new TabnineStatusBarWidget(project, binaryRequestFacade);
-    }
+  @Nullable
+  @Override
+  public com.intellij.openapi.wm.StatusBarWidget getWidget(@NotNull Project project) {
+    return new TabnineStatusBarWidget(project, binaryRequestFacade);
+  }
 
-    @NotNull
-    @Override
-    public String getAnchor() {
-        return StatusBar.Anchors.before(StatusBar.StandardWidgets.POSITION_PANEL);
-    }
+  @NotNull
+  @Override
+  public String getAnchor() {
+    return StatusBar.Anchors.before(StatusBar.StandardWidgets.POSITION_PANEL);
+  }
 }

--- a/src/main/java/com/tabnine/statusBar/TabnineStatusBarWidget.java
+++ b/src/main/java/com/tabnine/statusBar/TabnineStatusBarWidget.java
@@ -1,5 +1,7 @@
 package com.tabnine.statusBar;
 
+import static com.tabnine.general.StaticConfig.*;
+
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.components.ServiceManager;
@@ -10,144 +12,149 @@ import com.intellij.openapi.wm.WindowManager;
 import com.intellij.openapi.wm.impl.status.EditorBasedWidget;
 import com.intellij.openapi.wm.impl.status.TextPanel;
 import com.intellij.util.Consumer;
-import com.tabnine.intellij.completions.LimitedSecletionsChangedNotifier;
 import com.tabnine.binary.BinaryRequestFacade;
 import com.tabnine.binary.requests.config.ConfigRequest;
 import com.tabnine.binary.requests.config.StateResponse;
 import com.tabnine.binary.requests.statusBar.ConfigOpenedFromStatusBarRequest;
 import com.tabnine.general.ServiceLevel;
+import com.tabnine.intellij.completions.LimitedSecletionsChangedNotifier;
 import com.tabnine.lifecycle.BinaryStateChangeNotifier;
 import com.tabnine.lifecycle.BinaryStateService;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Set;
+import javax.swing.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import static com.tabnine.general.StaticConfig.*;
+public class TabnineStatusBarWidget extends EditorBasedWidget
+    implements CustomStatusBarWidget, com.intellij.openapi.wm.StatusBarWidget.WidgetPresentation {
+  private final BinaryRequestFacade binaryRequestFacade;
+  private TextPanel.WithIconAndArrows component;
 
-public class TabnineStatusBarWidget extends EditorBasedWidget implements CustomStatusBarWidget,
-        com.intellij.openapi.wm.StatusBarWidget.WidgetPresentation {
-    private final BinaryRequestFacade binaryRequestFacade;
-    private TextPanel.WithIconAndArrows component;
+  private static final Set<ServiceLevel> PRO_SERVICE_LEVELS =
+      EnumSet.of(ServiceLevel.PRO, ServiceLevel.TRIAL);
 
-    private static final Set<ServiceLevel> PRO_SERVICE_LEVELS = EnumSet.of(ServiceLevel.PRO, ServiceLevel.TRIAL);
+  public TabnineStatusBarWidget(@NotNull Project project, BinaryRequestFacade binaryRequestFacade) {
+    super(project);
+    this.binaryRequestFacade = binaryRequestFacade;
+    // register for state changes (we will get notified whenever the state changes)
+    ApplicationManager.getApplication()
+        .getMessageBus()
+        .connect(this)
+        .subscribe(BinaryStateChangeNotifier.STATE_CHANGED_TOPIC, stateResponse -> update());
+    ApplicationManager.getApplication()
+        .getMessageBus()
+        .connect(this)
+        .subscribe(LimitedSecletionsChangedNotifier.LIMITED_SELECTIONS_CHANGED_TOPIC, this::update);
+  }
 
-    public TabnineStatusBarWidget(@NotNull Project project, BinaryRequestFacade binaryRequestFacade) {
-        super(project);
-        this.binaryRequestFacade = binaryRequestFacade;
-        //register for state changes (we will get notified whenever the state changes)
-        ApplicationManager.getApplication().getMessageBus().connect(this)
-                .subscribe(BinaryStateChangeNotifier.STATE_CHANGED_TOPIC, stateResponse -> update());
-        ApplicationManager.getApplication().getMessageBus().connect(this)
-                .subscribe(LimitedSecletionsChangedNotifier.LIMITED_SELECTIONS_CHANGED_TOPIC, this::update);
-    }
+  @NotNull
+  @Override
+  public String ID() {
+    return getClass().getName();
+  }
 
-    @NotNull
-    @Override
-    public String ID() {
-        return getClass().getName();
-    }
-
-    // Compatability implementation. DO NOT ADD @Override.
-    public JComponent getComponent() {
-        final TextPanel.WithIconAndArrows component = new TextPanel.WithIconAndArrows();
-        final Icon icon = getIcon(getServiceLevel());
-        component.setIcon(icon);
-        component.setToolTipText(getTooltipText());
-        component.addMouseListener(new MouseAdapter() {
-            @Override
-            public void mousePressed(final MouseEvent e) {
-                Objects.requireNonNull(getClickConsumer()).consume(e);
-            }
+  // Compatability implementation. DO NOT ADD @Override.
+  public JComponent getComponent() {
+    final TextPanel.WithIconAndArrows component = new TextPanel.WithIconAndArrows();
+    final Icon icon = getIcon(getServiceLevel());
+    component.setIcon(icon);
+    component.setToolTipText(getTooltipText());
+    component.addMouseListener(
+        new MouseAdapter() {
+          @Override
+          public void mousePressed(final MouseEvent e) {
+            Objects.requireNonNull(getClickConsumer()).consume(e);
+          }
         });
-        this.component = component;
-        return component;
-    }
+    this.component = component;
+    return component;
+  }
 
-    private Icon getIcon(ServiceLevel serviceLevel) {
-        if (serviceLevel == ServiceLevel.BUSINESS) {
-            return ICON_AND_NAME_BUSINESS;
-        }
-        if (PRO_SERVICE_LEVELS.contains(serviceLevel)) {
-            return ICON_AND_NAME_PRO;
-        }
-        return ICON_AND_NAME;
+  private Icon getIcon(ServiceLevel serviceLevel) {
+    if (serviceLevel == ServiceLevel.BUSINESS) {
+      return ICON_AND_NAME_BUSINESS;
     }
-
-    private ServiceLevel getServiceLevel() {
-        final StateResponse stateResponse = ServiceManager.getService(BinaryStateService.class).getLastStateResponse();
-        return stateResponse != null ? stateResponse.getServiceLevel() : null;
+    if (PRO_SERVICE_LEVELS.contains(serviceLevel)) {
+      return ICON_AND_NAME_PRO;
     }
+    return ICON_AND_NAME;
+  }
 
-    // Compatability implementation. DO NOT ADD @Override.
-    @Nullable
-    public WidgetPresentation getPresentation() {
-        return this;
+  private ServiceLevel getServiceLevel() {
+    final StateResponse stateResponse =
+        ServiceManager.getService(BinaryStateService.class).getLastStateResponse();
+    return stateResponse != null ? stateResponse.getServiceLevel() : null;
+  }
+
+  // Compatability implementation. DO NOT ADD @Override.
+  @Nullable
+  public WidgetPresentation getPresentation() {
+    return this;
+  }
+
+  // Compatability implementation. DO NOT ADD @Override.
+  @Nullable
+  public WidgetPresentation getPresentation(@NotNull PlatformType type) {
+    return this;
+  }
+
+  // Compatability implementation. DO NOT ADD @Override.
+  @Nullable
+  public String getTooltipText() {
+    return "Tabnine (Click to open settings)";
+  }
+
+  // Compatability implementation. DO NOT ADD @Override.
+  @Nullable
+  public Consumer<MouseEvent> getClickConsumer() {
+    return (e) -> {
+      if (!e.isPopupTrigger() && MouseEvent.BUTTON1 == e.getButton()) {
+        binaryRequestFacade.executeRequest(new ConfigRequest());
+        binaryRequestFacade.executeRequest(new ConfigOpenedFromStatusBarRequest());
+      }
+    };
+  }
+
+  private void update(boolean limited) {
+    if (limited) {
+      this.component.setText(LIMITATION_SYMBOL);
+    } else {
+      this.component.setText(null);
     }
+    update();
+  }
 
-    // Compatability implementation. DO NOT ADD @Override.
-    @Nullable
-    public WidgetPresentation getPresentation(@NotNull PlatformType type) {
-        return this;
-    }
-
-    // Compatability implementation. DO NOT ADD @Override.
-    @Nullable
-    public String getTooltipText() {
-        return "Tabnine (Click to open settings)";
-    }
-
-    // Compatability implementation. DO NOT ADD @Override.
-    @Nullable
-    public Consumer<MouseEvent> getClickConsumer() {
-        return (e) -> {
-            if (!e.isPopupTrigger() && MouseEvent.BUTTON1 == e.getButton()) {
-                binaryRequestFacade.executeRequest(new ConfigRequest());
-                binaryRequestFacade.executeRequest(new ConfigOpenedFromStatusBarRequest());
-            }
-        };
-    }
-
-    private void update(boolean limited) {
-        if (limited) {
-            this.component.setText(LIMITATION_SYMBOL);
-        } else {
-            this.component.setText(null);
-        }
-        update();
-    }
-
-    private void update() {
-        ApplicationManager.getApplication().invokeLater(() -> {
-            //noinspection ConstantConditions
-            if ((myProject == null) || myProject.isDisposed() || (myStatusBar == null)) {
+  private void update() {
+    ApplicationManager.getApplication()
+        .invokeLater(
+            () -> {
+              //noinspection ConstantConditions
+              if ((myProject == null) || myProject.isDisposed() || (myStatusBar == null)) {
                 return;
-            }
-            final ServiceLevel serviceLevel = getServiceLevel();
-            final Icon icon = getIcon(serviceLevel);
-            this.component.setIcon(icon);
-            if (serviceLevel == ServiceLevel.PRO || serviceLevel == ServiceLevel.BUSINESS) {
-                //remove the locked icon. We do this here to handle the case where service
-                //level changed but limited wasn't updated yet (i.e. user didn't perform a
-                //completion yet).
+              }
+              final ServiceLevel serviceLevel = getServiceLevel();
+              final Icon icon = getIcon(serviceLevel);
+              this.component.setIcon(icon);
+              if (serviceLevel == ServiceLevel.PRO || serviceLevel == ServiceLevel.BUSINESS) {
+                // remove the locked icon. We do this here to handle the case where service
+                // level changed but limited wasn't updated yet (i.e. user didn't perform a
+                // completion yet).
                 component.setText(null);
-            }
-            this.component.setSize(new Dimension(icon.getIconWidth(), icon.getIconHeight()));
-            myStatusBar.updateWidget(ID());
-            //Since the widget size changes, we need to repaint the whole status bar so it will
-            //be positioned correctly
-            final StatusBar statusBar = WindowManager.getInstance().getStatusBar(myProject);
-            if (statusBar != null) {
+              }
+              this.component.setSize(new Dimension(icon.getIconWidth(), icon.getIconHeight()));
+              myStatusBar.updateWidget(ID());
+              // Since the widget size changes, we need to repaint the whole status bar so it will
+              // be positioned correctly
+              final StatusBar statusBar = WindowManager.getInstance().getStatusBar(myProject);
+              if (statusBar != null) {
                 statusBar.getComponent().updateUI();
-            }
-        }, ModalityState.any());
-    }
-
-
+              }
+            },
+            ModalityState.any());
+  }
 }

--- a/src/test/java/com/tabnine/binary/BinaryRunTests.java
+++ b/src/test/java/com/tabnine/binary/BinaryRunTests.java
@@ -1,16 +1,5 @@
 package com.tabnine.binary;
 
-import com.tabnine.binary.fetch.BinaryVersionFetcher;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-
 import static com.tabnine.general.StaticConfig.UNINSTALLING_FLAG;
 import static com.tabnine.testUtils.TabnineMatchers.hasItemInPosition;
 import static com.tabnine.testUtils.TestData.A_NON_EXISTING_BINARY_PATH;
@@ -18,26 +7,41 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
+import com.tabnine.binary.fetch.BinaryVersionFetcher;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 @ExtendWith(MockitoExtension.class)
 public class BinaryRunTests {
-    @Mock
-    private BinaryVersionFetcher binaryVersionFetcher;
-    @InjectMocks
-    private BinaryRun binaryRun;
+  @Mock private BinaryVersionFetcher binaryVersionFetcher;
+  @InjectMocks private BinaryRun binaryRun;
 
-    @Test
-    public void givenInitWhenGetBinaryRunCommandThenCommandFromFetchBinaryReturned() throws Exception {
-        when(binaryVersionFetcher.fetchBinary()).thenReturn(A_NON_EXISTING_BINARY_PATH);
+  @Test
+  public void givenInitWhenGetBinaryRunCommandThenCommandFromFetchBinaryReturned()
+      throws Exception {
+    when(binaryVersionFetcher.fetchBinary()).thenReturn(A_NON_EXISTING_BINARY_PATH);
 
-        assertThat(binaryRun.generateRunCommand(null), hasItemInPosition(0, equalTo(A_NON_EXISTING_BINARY_PATH)));
-    }
+    assertThat(
+        binaryRun.generateRunCommand(null),
+        hasItemInPosition(0, equalTo(A_NON_EXISTING_BINARY_PATH)));
+  }
 
-    @Test
-    public void givenBinaryIsEchoWhenReportingUninstallThenBinaryStartedWithUninstallFlag() throws Exception {
-        when(binaryVersionFetcher.fetchBinary()).thenReturn("echo");
+  @Test
+  public void givenBinaryIsEchoWhenReportingUninstallThenBinaryStartedWithUninstallFlag()
+      throws Exception {
+    when(binaryVersionFetcher.fetchBinary()).thenReturn("echo");
 
-        Process process = binaryRun.reportUninstall(null);
+    Process process = binaryRun.reportUninstall(null);
 
-        assertThat(new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8)).readLine(), equalTo(UNINSTALLING_FLAG));
-    }
+    assertThat(
+        new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))
+            .readLine(),
+        equalTo(UNINSTALLING_FLAG));
+  }
 }

--- a/src/test/java/com/tabnine/binary/BinaryVersionFetcherTests.java
+++ b/src/test/java/com/tabnine/binary/BinaryVersionFetcherTests.java
@@ -1,19 +1,5 @@
 package com.tabnine.binary;
 
-import com.tabnine.binary.exceptions.NoValidBinaryToRunException;
-import com.tabnine.binary.fetch.*;
-import com.tabnine.general.StaticConfig;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
-import java.util.prefs.BackingStoreException;
-import java.util.prefs.Preferences;
-
 import static com.tabnine.general.StaticConfig.versionFullPath;
 import static com.tabnine.testUtils.TestData.*;
 import static java.util.Collections.emptyList;
@@ -22,59 +8,77 @@ import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import com.tabnine.binary.exceptions.NoValidBinaryToRunException;
+import com.tabnine.binary.fetch.*;
+import com.tabnine.general.StaticConfig;
+import java.util.Optional;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 @ExtendWith(MockitoExtension.class)
 public class BinaryVersionFetcherTests {
-    @Mock
-    private LocalBinaryVersions localBinaryVersions;
-    @Mock
-    private BinaryRemoteSource binaryRemoteSource;
-    @Mock
-    private BinaryDownloader binaryDownloader;
-    @Mock
-    private BundleDownloader bundleDownloader;
-    @InjectMocks
-    private BinaryVersionFetcher binaryVersionFetcher;
+  @Mock private LocalBinaryVersions localBinaryVersions;
+  @Mock private BinaryRemoteSource binaryRemoteSource;
+  @Mock private BinaryDownloader binaryDownloader;
+  @Mock private BundleDownloader bundleDownloader;
+  @InjectMocks private BinaryVersionFetcher binaryVersionFetcher;
 
-    @BeforeEach
-    public void setUp() throws BackingStoreException {
-        Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
-        preferences.clear();
-        when(binaryRemoteSource.fetchPreferredVersion(StaticConfig.getTabNineBundleVersionUrl())).thenReturn(Optional.of(PREFERRED_VERSION));
-    }
+  @BeforeEach
+  public void setUp() throws BackingStoreException {
+    Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
+    preferences.clear();
+    when(binaryRemoteSource.fetchPreferredVersion(StaticConfig.getTabNineBundleVersionUrl()))
+        .thenReturn(Optional.of(PREFERRED_VERSION));
+  }
 
-    @Test
-    public void givenBetaVersionThatAvailableLocallyWhenFetchBinaryThenBetaVersionReturned() throws Exception {
-        when(localBinaryVersions.listExisting()).thenReturn(aVersions());
-        when(binaryRemoteSource.existingLocalBetaVersion(aVersions())).thenReturn(Optional.of(new BinaryVersion(BETA_VERSION)));
-        assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath(BETA_VERSION)));
-    }
+  @Test
+  public void givenBetaVersionThatAvailableLocallyWhenFetchBinaryThenBetaVersionReturned()
+      throws Exception {
+    when(localBinaryVersions.listExisting()).thenReturn(aVersions());
+    when(binaryRemoteSource.existingLocalBetaVersion(aVersions()))
+        .thenReturn(Optional.of(new BinaryVersion(BETA_VERSION)));
+    assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath(BETA_VERSION)));
+  }
 
-    @Test
-    public void givenPreferredVersionAvailableLocallyWhenFetchBinaryThenLocalVersionIsReturned() throws Exception {
-        when(localBinaryVersions.listExisting()).thenReturn(versions(A_VERSION, ANOTHER_VERSION, PREFERRED_VERSION));
-        when(binaryRemoteSource.fetchPreferredVersion()).thenReturn(Optional.of(PREFERRED_VERSION));
-        assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath(PREFERRED_VERSION)));
-    }
+  @Test
+  public void givenPreferredVersionAvailableLocallyWhenFetchBinaryThenLocalVersionIsReturned()
+      throws Exception {
+    when(localBinaryVersions.listExisting())
+        .thenReturn(versions(A_VERSION, ANOTHER_VERSION, PREFERRED_VERSION));
+    when(binaryRemoteSource.fetchPreferredVersion()).thenReturn(Optional.of(PREFERRED_VERSION));
+    assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath(PREFERRED_VERSION)));
+  }
 
-    @Test
-    public void givenPreferredVersionNotAvailableLocallyWhenThenVersionIsDownloadedAndPathIsReturned() throws Exception {
-        when(localBinaryVersions.listExisting()).thenReturn(versions(A_VERSION, ANOTHER_VERSION));
-        when(binaryRemoteSource.fetchPreferredVersion()).thenReturn(Optional.of(PREFERRED_VERSION));
-        when(binaryDownloader.downloadBinary(PREFERRED_VERSION)).thenReturn(Optional.of(new BinaryVersion(PREFERRED_VERSION)));
-        assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath(PREFERRED_VERSION)));
-    }
+  @Test
+  public void givenPreferredVersionNotAvailableLocallyWhenThenVersionIsDownloadedAndPathIsReturned()
+      throws Exception {
+    when(localBinaryVersions.listExisting()).thenReturn(versions(A_VERSION, ANOTHER_VERSION));
+    when(binaryRemoteSource.fetchPreferredVersion()).thenReturn(Optional.of(PREFERRED_VERSION));
+    when(binaryDownloader.downloadBinary(PREFERRED_VERSION))
+        .thenReturn(Optional.of(new BinaryVersion(PREFERRED_VERSION)));
+    assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath(PREFERRED_VERSION)));
+  }
 
-    @Test
-    public void givenFailedToFetchPreferredVersionWhenFetchBinaryThenReturnsLatestLocalVersion() throws Exception {
-        when(localBinaryVersions.listExisting()).thenReturn(aVersions());
-        when(binaryRemoteSource.fetchPreferredVersion()).thenReturn(Optional.empty());
-        assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath(LATEST_VERSION)));
-    }
+  @Test
+  public void givenFailedToFetchPreferredVersionWhenFetchBinaryThenReturnsLatestLocalVersion()
+      throws Exception {
+    when(localBinaryVersions.listExisting()).thenReturn(aVersions());
+    when(binaryRemoteSource.fetchPreferredVersion()).thenReturn(Optional.empty());
+    assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath(LATEST_VERSION)));
+  }
 
-    @Test
-    public void givenFailedToFetchPreferredVersionAndNoLocalVersionWhenFetchBinaryThenExceptionRaised() throws Exception {
-        when(localBinaryVersions.listExisting()).thenReturn(emptyList());
-        when(binaryRemoteSource.fetchPreferredVersion()).thenReturn(Optional.empty());
-        assertThrows(NoValidBinaryToRunException.class, binaryVersionFetcher::fetchBinary);
-    }
+  @Test
+  public void
+      givenFailedToFetchPreferredVersionAndNoLocalVersionWhenFetchBinaryThenExceptionRaised()
+          throws Exception {
+    when(localBinaryVersions.listExisting()).thenReturn(emptyList());
+    when(binaryRemoteSource.fetchPreferredVersion()).thenReturn(Optional.empty());
+    assertThrows(NoValidBinaryToRunException.class, binaryVersionFetcher::fetchBinary);
+  }
 }

--- a/src/test/java/com/tabnine/binary/BootstrapperSupportTests.java
+++ b/src/test/java/com/tabnine/binary/BootstrapperSupportTests.java
@@ -1,19 +1,5 @@
 package com.tabnine.binary;
 
-import com.tabnine.binary.fetch.*;
-import com.tabnine.general.StaticConfig;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.prefs.BackingStoreException;
-import java.util.prefs.Preferences;
-
 import static com.tabnine.general.StaticConfig.versionFullPath;
 import static com.tabnine.testUtils.TestData.PREFERRED_VERSION;
 import static com.tabnine.testUtils.TestData.aVersions;
@@ -21,75 +7,92 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
+import com.tabnine.binary.fetch.*;
+import com.tabnine.general.StaticConfig;
+import java.util.List;
+import java.util.Optional;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 @ExtendWith(MockitoExtension.class)
 public class BootstrapperSupportTests {
-    @Mock
-    private LocalBinaryVersions localBinaryVersions;
-    @Mock
-    private BinaryRemoteSource binaryRemoteSource;
-    @Mock
-    private BundleDownloader bundleDownloader;
+  @Mock private LocalBinaryVersions localBinaryVersions;
+  @Mock private BinaryRemoteSource binaryRemoteSource;
+  @Mock private BundleDownloader bundleDownloader;
 
-    @InjectMocks
-    private BinaryVersionFetcher binaryVersionFetcher;
+  @InjectMocks private BinaryVersionFetcher binaryVersionFetcher;
 
-    @BeforeEach
-    public void setUp() throws BackingStoreException {
-        Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
-        preferences.clear();
-    }
+  @BeforeEach
+  public void setUp() throws BackingStoreException {
+    Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
+    preferences.clear();
+  }
 
-    @Test
-    public void testWhenBootstrapperVersionIsNotLocalItWillDownloadIt() throws Exception {
-        when(binaryRemoteSource.fetchPreferredVersion(StaticConfig.getTabNineBundleVersionUrl())).thenReturn(Optional.of("9.9.9"));
-        when(bundleDownloader.downloadAndExtractBundle("9.9.9")).thenReturn(Optional.of(new BinaryVersion("9.9.9")));
-        assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("9.9.9")));
-    }
+  @Test
+  public void testWhenBootstrapperVersionIsNotLocalItWillDownloadIt() throws Exception {
+    when(binaryRemoteSource.fetchPreferredVersion(StaticConfig.getTabNineBundleVersionUrl()))
+        .thenReturn(Optional.of("9.9.9"));
+    when(bundleDownloader.downloadAndExtractBundle("9.9.9"))
+        .thenReturn(Optional.of(new BinaryVersion("9.9.9")));
+    assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("9.9.9")));
+  }
 
-    @Test
-    public void testWhenBootstrapperVersionExistsItWillUseIt() throws Exception {
-        Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
-        preferences.put(BootstrapperSupport.BOOTSTRAPPED_VERSION_KEY, "8.8.8");
-        List<BinaryVersion> binaryVersions = aVersions();
-        binaryVersions.add(new BinaryVersion("8.8.8"));
-        when(localBinaryVersions.listExisting()).thenReturn(binaryVersions);
-        assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("8.8.8")));
-    }
+  @Test
+  public void testWhenBootstrapperVersionExistsItWillUseIt() throws Exception {
+    Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
+    preferences.put(BootstrapperSupport.BOOTSTRAPPED_VERSION_KEY, "8.8.8");
+    List<BinaryVersion> binaryVersions = aVersions();
+    binaryVersions.add(new BinaryVersion("8.8.8"));
+    when(localBinaryVersions.listExisting()).thenReturn(binaryVersions);
+    assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("8.8.8")));
+  }
 
-    @Test
-    public void testWhenActiveVersionExistsItWillUseIt() throws Exception {
-        Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
-        preferences.put(BootstrapperSupport.BOOTSTRAPPED_VERSION_KEY, "8.8.8");
-        when(localBinaryVersions.activeVersion()).thenReturn(Optional.of(new BinaryVersion("7.8.9")));
-        assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("7.8.9")));
-    }
+  @Test
+  public void testWhenActiveVersionExistsItWillUseIt() throws Exception {
+    Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
+    preferences.put(BootstrapperSupport.BOOTSTRAPPED_VERSION_KEY, "8.8.8");
+    when(localBinaryVersions.activeVersion()).thenReturn(Optional.of(new BinaryVersion("7.8.9")));
+    assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("7.8.9")));
+  }
 
-    @Test
-    public void testWhenGreaterVersionThanPreferedBootstrapperVersionExistsItWillBeUsedInstead() throws Exception {
-        Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
-        preferences.put(BootstrapperSupport.BOOTSTRAPPED_VERSION_KEY, "5.5.5");
-        List<BinaryVersion> binaryVersions = aVersions();
-        binaryVersions.add(new BinaryVersion("55.55.55"));
-        when(localBinaryVersions.listExisting()).thenReturn(binaryVersions);
-        assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("55.55.55")));
-    }
+  @Test
+  public void testWhenGreaterVersionThanPreferedBootstrapperVersionExistsItWillBeUsedInstead()
+      throws Exception {
+    Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
+    preferences.put(BootstrapperSupport.BOOTSTRAPPED_VERSION_KEY, "5.5.5");
+    List<BinaryVersion> binaryVersions = aVersions();
+    binaryVersions.add(new BinaryVersion("55.55.55"));
+    when(localBinaryVersions.listExisting()).thenReturn(binaryVersions);
+    assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("55.55.55")));
+  }
 
-    @Test
-    public void testWhenBootstrappedVersionDidNotExistLocallyTheBootstrapperWillDownloadAgain() throws Exception {
-        Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
-        preferences.put(BootstrapperSupport.BOOTSTRAPPED_VERSION_KEY, "6.6.6");
-        when(localBinaryVersions.listExisting()).thenReturn(aVersions());
-        when(binaryRemoteSource.fetchPreferredVersion(StaticConfig.getTabNineBundleVersionUrl())).thenReturn(Optional.of("66.66.66"));
-        when(bundleDownloader.downloadAndExtractBundle("66.66.66")).thenReturn(Optional.of(new BinaryVersion("66.66.66")));
-        assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("66.66.66")));
-    }
+  @Test
+  public void testWhenBootstrappedVersionDidNotExistLocallyTheBootstrapperWillDownloadAgain()
+      throws Exception {
+    Preferences preferences = Preferences.userNodeForPackage(BootstrapperSupport.class);
+    preferences.put(BootstrapperSupport.BOOTSTRAPPED_VERSION_KEY, "6.6.6");
+    when(localBinaryVersions.listExisting()).thenReturn(aVersions());
+    when(binaryRemoteSource.fetchPreferredVersion(StaticConfig.getTabNineBundleVersionUrl()))
+        .thenReturn(Optional.of("66.66.66"));
+    when(bundleDownloader.downloadAndExtractBundle("66.66.66"))
+        .thenReturn(Optional.of(new BinaryVersion("66.66.66")));
+    assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath("66.66.66")));
+  }
 
-    @Test
-    public void testWhenBootstrappedVersionFailedToDownloadWillFallbackToLocalVersion() throws Exception {
-        when(localBinaryVersions.listExisting()).thenReturn(aVersions());
-        when(binaryRemoteSource.fetchPreferredVersion(StaticConfig.getTabNineBundleVersionUrl())).thenReturn(Optional.of("7.7.7"));
-        when(binaryRemoteSource.fetchPreferredVersion()).thenReturn(Optional.of(PREFERRED_VERSION));
-        when(bundleDownloader.downloadAndExtractBundle("7.7.7")).thenReturn(Optional.empty());
-        assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath(PREFERRED_VERSION)));
-    }
+  @Test
+  public void testWhenBootstrappedVersionFailedToDownloadWillFallbackToLocalVersion()
+      throws Exception {
+    when(localBinaryVersions.listExisting()).thenReturn(aVersions());
+    when(binaryRemoteSource.fetchPreferredVersion(StaticConfig.getTabNineBundleVersionUrl()))
+        .thenReturn(Optional.of("7.7.7"));
+    when(binaryRemoteSource.fetchPreferredVersion()).thenReturn(Optional.of(PREFERRED_VERSION));
+    when(bundleDownloader.downloadAndExtractBundle("7.7.7")).thenReturn(Optional.empty());
+    assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath(PREFERRED_VERSION)));
+  }
 }

--- a/src/test/java/com/tabnine/binary/BootstrapperSupportTests.java
+++ b/src/test/java/com/tabnine/binary/BootstrapperSupportTests.java
@@ -5,8 +5,10 @@ import static com.tabnine.testUtils.TestData.PREFERRED_VERSION;
 import static com.tabnine.testUtils.TestData.aVersions;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import com.tabnine.binary.exceptions.InvalidVersionPathException;
 import com.tabnine.binary.fetch.*;
 import com.tabnine.general.StaticConfig;
 import java.util.List;
@@ -94,5 +96,10 @@ public class BootstrapperSupportTests {
     when(binaryRemoteSource.fetchPreferredVersion()).thenReturn(Optional.of(PREFERRED_VERSION));
     when(bundleDownloader.downloadAndExtractBundle("7.7.7")).thenReturn(Optional.empty());
     assertThat(binaryVersionFetcher.fetchBinary(), equalTo(versionFullPath(PREFERRED_VERSION)));
+  }
+
+  @Test
+  public void whenVersionIsInvalidThenVersionFullPathFails() {
+    assertThrows(InvalidVersionPathException.class, () -> versionFullPath("not a semver version"));
   }
 }

--- a/src/test/java/com/tabnine/binary/fetch/BinaryDownloaderTests.java
+++ b/src/test/java/com/tabnine/binary/fetch/BinaryDownloaderTests.java
@@ -1,22 +1,5 @@
 package com.tabnine.binary.fetch;
 
-import com.tabnine.testUtils.WireMockExtension;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Optional;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.tabnine.general.StaticConfig.*;
 import static com.tabnine.testUtils.TabnineMatchers.fileContentEquals;
@@ -29,70 +12,90 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
+import com.tabnine.testUtils.WireMockExtension;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 @ExtendWith(WireMockExtension.class)
 @ExtendWith(MockitoExtension.class)
 public class BinaryDownloaderTests {
-    @TempDir
-    public Path temporaryFolder;
-    @Mock
-    private TempBinaryValidator tempBinaryValidator;
-    @Spy
-    private GeneralDownloader downloader = new GeneralDownloader();
-    @InjectMocks
-    private BinaryDownloader binaryDownloader;
+  @TempDir public Path temporaryFolder;
+  @Mock private TempBinaryValidator tempBinaryValidator;
+  @Spy private GeneralDownloader downloader = new GeneralDownloader();
+  @InjectMocks private BinaryDownloader binaryDownloader;
 
-    private String originalHome = System.getProperty(USER_HOME_PATH_PROPERTY);
+  private String originalHome = System.getProperty(USER_HOME_PATH_PROPERTY);
 
-    @BeforeEach
-    public void setUp() {
-        System.setProperty(USER_HOME_PATH_PROPERTY, temporaryFolder.toString());
-        System.setProperty(REMOTE_BASE_URL_PROPERTY, format("http://localhost:%d", WireMockExtension.WIREMOCK_EXTENSION_DEFAULT_PORT));
+  @BeforeEach
+  public void setUp() {
+    System.setProperty(USER_HOME_PATH_PROPERTY, temporaryFolder.toString());
+    System.setProperty(
+        REMOTE_BASE_URL_PROPERTY,
+        format("http://localhost:%d", WireMockExtension.WIREMOCK_EXTENSION_DEFAULT_PORT));
 
-        Paths.get(temporaryFolder.toFile().toString(), TABNINE_FOLDER_NAME).toFile().mkdirs();
+    Paths.get(temporaryFolder.toFile().toString(), TABNINE_FOLDER_NAME).toFile().mkdirs();
+  }
 
-    }
+  @AfterEach
+  public void tearDown() throws Exception {
+    System.setProperty(USER_HOME_PATH_PROPERTY, originalHome);
+  }
 
-    @AfterEach
-    public void tearDown() throws Exception {
-        System.setProperty(USER_HOME_PATH_PROPERTY, originalHome);
-    }
+  @Test
+  public void whenDownloadingBinarySuccessfullyThenItsContentIsWrittenSuccessfullyToTemporaryFile()
+      throws Exception {
+    stubFor(
+        get(urlEqualTo(String.join("/", "", A_VERSION, TARGET_NAME, EXECUTABLE_NAME)))
+            .willReturn(
+                aResponse().withHeader("Content-Type", "text/plain").withBody(A_BINARY_CONTENT)));
 
-    @Test
-    public void whenDownloadingBinarySuccessfullyThenItsContentIsWrittenSuccessfullyToTemporaryFile() throws Exception {
-        stubFor(get(urlEqualTo(String.join("/", "", A_VERSION, TARGET_NAME, EXECUTABLE_NAME)))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "text/plain")
-                        .withBody(A_BINARY_CONTENT)));
+    binaryDownloader.downloadBinary(A_VERSION);
 
-        binaryDownloader.downloadBinary(A_VERSION);
+    File[] files = Paths.get(versionFullPath(A_VERSION)).getParent().toFile().listFiles();
+    assertThat(files, arrayWithSize(1));
+    assertThat(files, arrayContaining(fileContentEquals(A_BINARY_CONTENT)));
+  }
 
-        File[] files = Paths.get(versionFullPath(A_VERSION)).getParent().toFile().listFiles();
-        assertThat(files, arrayWithSize(1));
-        assertThat(files, arrayContaining(fileContentEquals(A_BINARY_CONTENT)));
-    }
+  @Test
+  public void whenDownloadingBinarySuccessfullyThenValidatorCalledWithIt() throws Exception {
+    stubFor(
+        get(urlEqualTo(String.join("/", "", A_VERSION, TARGET_NAME, EXECUTABLE_NAME)))
+            .willReturn(
+                aResponse().withHeader("Content-Type", "text/plain").withBody(A_BINARY_CONTENT)));
 
-    @Test
-    public void whenDownloadingBinarySuccessfullyThenValidatorCalledWithIt() throws Exception {
-        stubFor(get(urlEqualTo(String.join("/", "", A_VERSION, TARGET_NAME, EXECUTABLE_NAME)))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "text/plain")
-                        .withBody(A_BINARY_CONTENT)));
+    binaryDownloader.downloadBinary(A_VERSION);
 
-        binaryDownloader.downloadBinary(A_VERSION);
+    verify(tempBinaryValidator)
+        .validateAndRename(
+            pathStartsWith(versionFullPath(A_VERSION) + ".download"),
+            eq(Paths.get(versionFullPath(A_VERSION))));
+  }
 
-        verify(tempBinaryValidator).validateAndRename(pathStartsWith(versionFullPath(A_VERSION) + ".download"), eq(Paths.get(versionFullPath(A_VERSION))));
-    }
+  @Test
+  public void givenServerResultInErrorWhenDownloadingBinaryThenFailedToDownloadExceptionThrown()
+      throws Exception {
+    stubFor(
+        get(urlEqualTo(String.join("/", "", A_VERSION, TARGET_NAME, EXECUTABLE_NAME)))
+            .willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR)));
 
-    @Test
-    public void givenServerResultInErrorWhenDownloadingBinaryThenFailedToDownloadExceptionThrown() throws Exception {
-        stubFor(get(urlEqualTo(String.join("/", "", A_VERSION, TARGET_NAME, EXECUTABLE_NAME)))
-                .willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR)));
+    assertThat(binaryDownloader.downloadBinary(A_VERSION), Matchers.equalTo(Optional.empty()));
+  }
 
-        assertThat(binaryDownloader.downloadBinary(A_VERSION), Matchers.equalTo(Optional.empty()));
-    }
-
-    @Test
-    public void givenNoServerResultWhenDownloadingBinaryThenFailedToDownloadExceptionThrown() throws Exception {
-        assertThat(binaryDownloader.downloadBinary(A_VERSION), Matchers.equalTo(Optional.empty()));
-    }
+  @Test
+  public void givenNoServerResultWhenDownloadingBinaryThenFailedToDownloadExceptionThrown()
+      throws Exception {
+    assertThat(binaryDownloader.downloadBinary(A_VERSION), Matchers.equalTo(Optional.empty()));
+  }
 }

--- a/src/test/java/com/tabnine/binary/fetch/BinaryRemoteSourceTests.java
+++ b/src/test/java/com/tabnine/binary/fetch/BinaryRemoteSourceTests.java
@@ -1,16 +1,5 @@
 package com.tabnine.binary.fetch;
 
-import com.tabnine.binary.exceptions.FailedToDownloadException;
-import com.tabnine.testUtils.WireMockExtension;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.tabnine.general.StaticConfig.*;
 import static com.tabnine.testUtils.TabnineMatchers.emptyOptional;
@@ -20,82 +9,108 @@ import static com.tabnine.testUtils.WireMockExtension.WIREMOCK_EXTENSION_DEFAULT
 import static java.lang.String.format;
 import static org.junit.Assert.assertThat;
 
+import com.tabnine.binary.exceptions.FailedToDownloadException;
+import com.tabnine.testUtils.WireMockExtension;
+import java.util.Optional;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 @ExtendWith(WireMockExtension.class)
 @ExtendWith(MockitoExtension.class)
 public class BinaryRemoteSourceTests {
-    @InjectMocks
-    private BinaryRemoteSource binaryRemoteSource;
+  @InjectMocks private BinaryRemoteSource binaryRemoteSource;
 
-    @BeforeEach
-    public void setUp() {
-        System.setProperty(REMOTE_VERSION_URL_PROPERTY, format("http://localhost:%d/", WIREMOCK_EXTENSION_DEFAULT_PORT));
-        System.setProperty(REMOTE_BETA_VERSION_URL_PROPERTY, format("http://localhost:%d/", WIREMOCK_EXTENSION_DEFAULT_PORT));
-    }
+  @BeforeEach
+  public void setUp() {
+    System.setProperty(
+        REMOTE_VERSION_URL_PROPERTY,
+        format("http://localhost:%d/", WIREMOCK_EXTENSION_DEFAULT_PORT));
+    System.setProperty(
+        REMOTE_BETA_VERSION_URL_PROPERTY,
+        format("http://localhost:%d/", WIREMOCK_EXTENSION_DEFAULT_PORT));
+  }
 
-    @Test
-    public void givenServerResponseWhenVersionRequestedThenItIsReturnProperly() throws FailedToDownloadException {
-        stubFor(get(urlEqualTo("/"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "text/plain")
-                        .withBody(PREFERRED_VERSION)));
+  @Test
+  public void givenServerResponseWhenVersionRequestedThenItIsReturnProperly()
+      throws FailedToDownloadException {
+    stubFor(
+        get(urlEqualTo("/"))
+            .willReturn(
+                aResponse().withHeader("Content-Type", "text/plain").withBody(PREFERRED_VERSION)));
 
-        assertThat(binaryRemoteSource.fetchPreferredVersion(), Matchers.equalTo(Optional.of(PREFERRED_VERSION)));
-    }
+    assertThat(
+        binaryRemoteSource.fetchPreferredVersion(),
+        Matchers.equalTo(Optional.of(PREFERRED_VERSION)));
+  }
 
-    @Test
-    public void givenNoServerToRespondWhenVersionRequestedThenFailedToDownloadExceptionThrown() throws FailedToDownloadException {
-        System.setProperty(REMOTE_VERSION_URL_PROPERTY, NONE_EXISTING_SERVICE);
+  @Test
+  public void givenNoServerToRespondWhenVersionRequestedThenFailedToDownloadExceptionThrown()
+      throws FailedToDownloadException {
+    System.setProperty(REMOTE_VERSION_URL_PROPERTY, NONE_EXISTING_SERVICE);
 
-        assertThat(binaryRemoteSource.fetchPreferredVersion(), emptyOptional());
-    }
+    assertThat(binaryRemoteSource.fetchPreferredVersion(), emptyOptional());
+  }
 
-    @Test
-    public void givenServerResponseLateWhenVersionRequestedThenFailedToDownloadExceptionThrown() throws FailedToDownloadException {
-        stubFor(get(urlEqualTo("/"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "text/plain")
-                        .withFixedDelay(REMOTE_CONNECTION_TIMEOUT + EPSILON)
-                        .withBody(PREFERRED_VERSION)));
+  @Test
+  public void givenServerResponseLateWhenVersionRequestedThenFailedToDownloadExceptionThrown()
+      throws FailedToDownloadException {
+    stubFor(
+        get(urlEqualTo("/"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "text/plain")
+                    .withFixedDelay(REMOTE_CONNECTION_TIMEOUT + EPSILON)
+                    .withBody(PREFERRED_VERSION)));
 
-        assertThat(binaryRemoteSource.fetchPreferredVersion(), emptyOptional());
-    }
+    assertThat(binaryRemoteSource.fetchPreferredVersion(), emptyOptional());
+  }
 
-    @Test
-    public void givenServerResponseWhenBetaVersionRequestedAndIsAvailableLocallyThenItIsReturned() throws Exception {
-        stubFor(get(urlEqualTo("/"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "text/plain")
-                        .withBody(BETA_VERSION)));
+  @Test
+  public void givenServerResponseWhenBetaVersionRequestedAndIsAvailableLocallyThenItIsReturned()
+      throws Exception {
+    stubFor(
+        get(urlEqualTo("/"))
+            .willReturn(
+                aResponse().withHeader("Content-Type", "text/plain").withBody(BETA_VERSION)));
 
-        assertThat(binaryRemoteSource.existingLocalBetaVersion(versionsWithBeta()),
-                versionMatch(BETA_VERSION));
-    }
+    assertThat(
+        binaryRemoteSource.existingLocalBetaVersion(versionsWithBeta()),
+        versionMatch(BETA_VERSION));
+  }
 
-    @Test
-    public void givenServerResponseWhenBetaVersionRequestedAndIsNotAvailableLocallyThenNullReturned() throws Exception {
-        stubFor(get(urlEqualTo("/"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "text/plain")
-                        .withBody(BETA_VERSION)));
+  @Test
+  public void givenServerResponseWhenBetaVersionRequestedAndIsNotAvailableLocallyThenNullReturned()
+      throws Exception {
+    stubFor(
+        get(urlEqualTo("/"))
+            .willReturn(
+                aResponse().withHeader("Content-Type", "text/plain").withBody(BETA_VERSION)));
 
-        assertThat(binaryRemoteSource.existingLocalBetaVersion(aVersions()), emptyOptional());
-    }
+    assertThat(binaryRemoteSource.existingLocalBetaVersion(aVersions()), emptyOptional());
+  }
 
-    @Test
-    public void givenNoServerToRespondToVersionRequestWhenVersionRequestedThenNullReturned() throws Exception {
-        System.setProperty(REMOTE_VERSION_URL_PROPERTY, NONE_EXISTING_SERVICE);
+  @Test
+  public void givenNoServerToRespondToVersionRequestWhenVersionRequestedThenNullReturned()
+      throws Exception {
+    System.setProperty(REMOTE_VERSION_URL_PROPERTY, NONE_EXISTING_SERVICE);
 
-        assertThat(binaryRemoteSource.existingLocalBetaVersion(aVersions()), emptyOptional());
-    }
+    assertThat(binaryRemoteSource.existingLocalBetaVersion(aVersions()), emptyOptional());
+  }
 
-    @Test
-    public void givenServerResponseLateWhenBetaVersionRequestedThenNullReturned() throws Exception {
-        stubFor(get(urlEqualTo("/"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "text/plain")
-                        .withFixedDelay(REMOTE_CONNECTION_TIMEOUT + EPSILON)
-                        .withBody(BETA_VERSION)));
+  @Test
+  public void givenServerResponseLateWhenBetaVersionRequestedThenNullReturned() throws Exception {
+    stubFor(
+        get(urlEqualTo("/"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "text/plain")
+                    .withFixedDelay(REMOTE_CONNECTION_TIMEOUT + EPSILON)
+                    .withBody(BETA_VERSION)));
 
-        assertThat(binaryRemoteSource.existingLocalBetaVersion(aVersions()), emptyOptional());
-    }
+    assertThat(binaryRemoteSource.existingLocalBetaVersion(aVersions()), emptyOptional());
+  }
 }

--- a/src/test/java/com/tabnine/binary/fetch/BinaryValidatorTests.java
+++ b/src/test/java/com/tabnine/binary/fetch/BinaryValidatorTests.java
@@ -1,31 +1,30 @@
 package com.tabnine.binary.fetch;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 @ExtendWith(MockitoExtension.class)
 public class BinaryValidatorTests {
-    @InjectMocks
-    private BinaryValidator binaryValidator;
+  @InjectMocks private BinaryValidator binaryValidator;
 
-    @Test
-    public void givenABinaryThatReturnsAResultWhenValidatingThenBinaryIsValid() throws Exception {
-        assertThat(binaryValidator.isWorking("echo"), is(true));
-    }
+  @Test
+  public void givenABinaryThatReturnsAResultWhenValidatingThenBinaryIsValid() throws Exception {
+    assertThat(binaryValidator.isWorking("echo"), is(true));
+  }
 
-    @Test
-    public void givenABinaryThatDoesNotReturnAResultWhenValidatingThenBinaryIsNotValid() throws Exception {
-        assertThat(binaryValidator.isWorking("exit"), is(false));
-    }
+  @Test
+  public void givenABinaryThatDoesNotReturnAResultWhenValidatingThenBinaryIsNotValid()
+      throws Exception {
+    assertThat(binaryValidator.isWorking("exit"), is(false));
+  }
 
-    @Test
-    public void givenABinaryThatDoesNotExistWhenValidatingThenBinaryIsNotValid() throws Exception {
-        assertThat(binaryValidator.isWorking("/test/test123"), is(false));
-    }
-
+  @Test
+  public void givenABinaryThatDoesNotExistWhenValidatingThenBinaryIsNotValid() throws Exception {
+    assertThat(binaryValidator.isWorking("/test/test123"), is(false));
+  }
 }

--- a/src/test/java/com/tabnine/binary/fetch/TempBinaryValidatorTests.java
+++ b/src/test/java/com/tabnine/binary/fetch/TempBinaryValidatorTests.java
@@ -1,18 +1,5 @@
 package com.tabnine.binary.fetch;
 
-import com.tabnine.binary.exceptions.FailedToDownloadException;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import static com.tabnine.general.StaticConfig.BINARY_MINIMUM_REASONABLE_SIZE;
 import static com.tabnine.testUtils.TabnineMatchers.fileContentEquals;
 import static com.tabnine.testUtils.TestData.EPSILON;
@@ -21,66 +8,87 @@ import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
+import com.tabnine.binary.exceptions.FailedToDownloadException;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 @ExtendWith(MockitoExtension.class)
 public class TempBinaryValidatorTests {
-    @TempDir
-    public Path temporaryFolder;
-    @Mock
-    private BinaryValidator binaryValidator;
-    @InjectMocks
-    private TempBinaryValidator tempBinaryValidator;
+  @TempDir public Path temporaryFolder;
+  @Mock private BinaryValidator binaryValidator;
+  @InjectMocks private TempBinaryValidator tempBinaryValidator;
 
-    @Test
-    public void givenTempBinaryNotExistsWhenValidatedThenFailedToDownloadExceptionThrown() throws Exception {
-        assertThrows(FailedToDownloadException.class, () -> tempBinaryValidator.validateAndRename(aTempFile(), aDestinationFile()));
+  @Test
+  public void givenTempBinaryNotExistsWhenValidatedThenFailedToDownloadExceptionThrown()
+      throws Exception {
+    assertThrows(
+        FailedToDownloadException.class,
+        () -> tempBinaryValidator.validateAndRename(aTempFile(), aDestinationFile()));
+  }
+
+  @Test
+  public void
+      givenTempBinaryWithContentSmallerThanThresholdWhenValidatedThenFailedToDownloadExceptionThrown()
+          throws Exception {
+    Files.write(aTempFile(), binaryContentSized(BINARY_MINIMUM_REASONABLE_SIZE - EPSILON));
+
+    assertThrows(
+        FailedToDownloadException.class,
+        () -> tempBinaryValidator.validateAndRename(aTempFile(), aDestinationFile()));
+  }
+
+  @Test
+  public void givenTempBinaryNoWorkingWhenValidatedThenFailedToDownloadExceptionThrown()
+      throws Exception {
+    Files.write(aTempFile(), binaryContentSized(BINARY_MINIMUM_REASONABLE_SIZE + EPSILON));
+    when(binaryValidator.isWorking(aTempFile().toString())).thenReturn(false);
+
+    assertThrows(
+        FailedToDownloadException.class,
+        () -> tempBinaryValidator.validateAndRename(aTempFile(), aDestinationFile()));
+  }
+
+  @Test
+  public void givenValidTempBinaryWhenValidatedThenItIsMovedToDestination() throws Exception {
+    Files.write(aTempFile(), binaryContentSized(BINARY_MINIMUM_REASONABLE_SIZE + EPSILON));
+    when(binaryValidator.isWorking(aTempFile().toString())).thenReturn(true);
+
+    tempBinaryValidator.validateAndRename(aTempFile(), aDestinationFile());
+
+    assertThat(
+        aDestinationFile().toFile(),
+        fileContentEquals(binaryContentSized(BINARY_MINIMUM_REASONABLE_SIZE + EPSILON)));
+  }
+
+  @Test
+  public void whenTempBinaryValidatedThenItIsSetAsExecutable() throws Exception {
+    Path mockedTempDestination = mock(Path.class);
+    File mockedTempFile = mock(File.class);
+    when(mockedTempDestination.toFile()).thenReturn(mockedTempFile);
+    when(mockedTempFile.exists()).thenReturn(true);
+    when(mockedTempFile.length()).thenReturn((long) (BINARY_MINIMUM_REASONABLE_SIZE + EPSILON));
+
+    try {
+      tempBinaryValidator.validateAndRename(mockedTempDestination, aDestinationFile());
+    } catch (Exception ignored) {
     }
 
-    @Test
-    public void givenTempBinaryWithContentSmallerThanThresholdWhenValidatedThenFailedToDownloadExceptionThrown() throws Exception {
-        Files.write(aTempFile(), binaryContentSized(BINARY_MINIMUM_REASONABLE_SIZE - EPSILON));
+    verify(mockedTempFile).setExecutable(true);
+  }
 
-        assertThrows(FailedToDownloadException.class, () -> tempBinaryValidator.validateAndRename(aTempFile(), aDestinationFile()));
-    }
+  private Path aDestinationFile() {
+    return Paths.get(temporaryFolder.toString(), "destinationfile");
+  }
 
-    @Test
-    public void givenTempBinaryNoWorkingWhenValidatedThenFailedToDownloadExceptionThrown() throws Exception {
-        Files.write(aTempFile(), binaryContentSized(BINARY_MINIMUM_REASONABLE_SIZE + EPSILON));
-        when(binaryValidator.isWorking(aTempFile().toString())).thenReturn(false);
-
-        assertThrows(FailedToDownloadException.class, () -> tempBinaryValidator.validateAndRename(aTempFile(), aDestinationFile()));
-    }
-
-    @Test
-    public void givenValidTempBinaryWhenValidatedThenItIsMovedToDestination() throws Exception {
-        Files.write(aTempFile(), binaryContentSized(BINARY_MINIMUM_REASONABLE_SIZE + EPSILON));
-        when(binaryValidator.isWorking(aTempFile().toString())).thenReturn(true);
-
-        tempBinaryValidator.validateAndRename(aTempFile(), aDestinationFile());
-
-        assertThat(aDestinationFile().toFile(), fileContentEquals(binaryContentSized(BINARY_MINIMUM_REASONABLE_SIZE + EPSILON)));
-    }
-
-    @Test
-    public void whenTempBinaryValidatedThenItIsSetAsExecutable() throws Exception {
-        Path mockedTempDestination = mock(Path.class);
-        File mockedTempFile = mock(File.class);
-        when(mockedTempDestination.toFile()).thenReturn(mockedTempFile);
-        when(mockedTempFile.exists()).thenReturn(true);
-        when(mockedTempFile.length()).thenReturn((long) (BINARY_MINIMUM_REASONABLE_SIZE + EPSILON));
-
-        try {
-            tempBinaryValidator.validateAndRename(mockedTempDestination, aDestinationFile());
-        } catch (Exception ignored) {
-        }
-
-        verify(mockedTempFile).setExecutable(true);
-    }
-
-    private Path aDestinationFile() {
-        return Paths.get(temporaryFolder.toString(), "destinationfile");
-    }
-
-    private Path aTempFile() {
-        return Paths.get(temporaryFolder.toString(), "tempfile");
-    }
+  private Path aTempFile() {
+    return Paths.get(temporaryFolder.toString(), "tempfile");
+  }
 }

--- a/src/test/java/com/tabnine/integration/BinaryBadResultsIntegrationTests.java
+++ b/src/test/java/com/tabnine/integration/BinaryBadResultsIntegrationTests.java
@@ -1,15 +1,5 @@
 package com.tabnine.integration;
 
-import com.intellij.codeInsight.lookup.LookupElement;
-import com.tabnine.binary.exceptions.TabNineDeadException;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.mockito.stubbing.Answer;
-
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import static com.tabnine.general.StaticConfig.ILLEGAL_RESPONSE_THRESHOLD;
 import static com.tabnine.general.StaticConfig.sleepUponFailure;
 import static com.tabnine.testUtils.TabnineMatchers.lookupBuilder;
@@ -17,111 +7,129 @@ import static com.tabnine.testUtils.TabnineMatchers.lookupElement;
 import static com.tabnine.testUtils.TestData.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.tabnine.binary.exceptions.TabNineDeadException;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
 
 public class BinaryBadResultsIntegrationTests extends MockedBinaryCompletionTestCase {
 
-    @Before
-    public void beforeEach() {
-        myFixture.completeBasic(); //make sure all singletons are inited
-        clearInvocations(binaryProcessGatewayProviderMock);
+  @Before
+  public void beforeEach() {
+    myFixture.completeBasic(); // make sure all singletons are inited
+    clearInvocations(binaryProcessGatewayProviderMock);
+  }
+
+  @Test
+  public void givenACompletionWhenIOExceptionWasThrownThenBinaryIsRestarted() throws Exception {
+    when(binaryProcessGatewayMock.readRawResponse()).thenThrow(new IOException());
+
+    LookupElement[] actual = myFixture.completeBasic();
+
+    assertThat(actual, is(nullValue()));
+    verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
+  }
+
+  @Test
+  public void givenBinaryProcessFailsAtSomeSortThenOldProcessIsDestoryed() throws Exception {
+    when(binaryProcessGatewayMock.readRawResponse()).thenThrow(new IOException());
+
+    myFixture.completeBasic();
+
+    verify(binaryProcessGatewayMock).destroy();
+  }
+
+  @Test
+  public void givenACompletionWhenBufferedReaderIsFinishedThenBinaryIsRestarted() throws Exception {
+    when(binaryProcessGatewayMock.readRawResponse()).thenThrow(new TabNineDeadException());
+
+    LookupElement[] actual = myFixture.completeBasic();
+
+    assertThat(actual, is(nullValue()));
+    verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
+  }
+
+  @Test
+  public void givenACompletionWhenBinaryReturnNonsenseThenNoResultReturned() throws Exception {
+    when(binaryProcessGatewayMock.readRawResponse()).thenReturn(INVALID_RESULT);
+
+    LookupElement[] actual = myFixture.completeBasic();
+
+    assertThat(actual, is(nullValue()));
+  }
+
+  @Test
+  public void givenConsecutiveCompletionsWhenBinaryReturnNonsenseThenBinaryIsRestarted()
+      throws Exception {
+    when(binaryProcessGatewayMock.readRawResponse()).thenReturn(INVALID_RESULT);
+
+    for (int i = 0; i < ILLEGAL_RESPONSE_THRESHOLD + OVERFLOW; i++) {
+      myFixture.completeBasic();
     }
 
-    @Test
-    public void givenACompletionWhenIOExceptionWasThrownThenBinaryIsRestarted() throws Exception {
-        when(binaryProcessGatewayMock.readRawResponse()).thenThrow(new IOException());
+    verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
+  }
 
-        LookupElement[] actual = myFixture.completeBasic();
+  @Test
+  public void givenConsecutiveCompletionsWhenBinaryReturnNullThenBinaryIsRestarted()
+      throws Exception {
+    when(binaryProcessGatewayMock.readRawResponse()).thenReturn(NULL_RESULT);
 
-        assertThat(actual, is(nullValue()));
-        verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
+    for (int i = 0; i < ILLEGAL_RESPONSE_THRESHOLD + OVERFLOW; i++) {
+      myFixture.completeBasic();
     }
 
-    @Test
-    public void givenBinaryProcessFailsAtSomeSortThenOldProcessIsDestoryed() throws Exception {
-        when(binaryProcessGatewayMock.readRawResponse()).thenThrow(new IOException());
+    verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
+  }
 
-        myFixture.completeBasic();
+  @Ignore(
+      "This test works, but only when ran alone, as it is tied to the startup mechanism which fires only for the 1st test in the suite.")
+  @Test
+  public void
+      givenBinaryIsFailingOnStartThenExtensionWillTryAgainAfterAWhileAndPredictionsWillNull()
+          throws Exception {
+    when(binaryProcessGatewayMock.readRawResponse()).thenReturn(A_PREDICTION_RESULT);
+    doThrow(new IOException()).when(binaryProcessGatewayMock).init(any());
 
-        verify(binaryProcessGatewayMock).destroy();
-    }
+    assertThat(myFixture.completeBasic(), is(nullValue()));
 
-    @Test
-    public void givenACompletionWhenBufferedReaderIsFinishedThenBinaryIsRestarted() throws Exception {
-        when(binaryProcessGatewayMock.readRawResponse()).thenThrow(new TabNineDeadException());
+    sleepUponFailure(1);
 
-        LookupElement[] actual = myFixture.completeBasic();
+    verify(binaryProcessGatewayMock, times(2)).init(any());
+  }
 
-        assertThat(actual, is(nullValue()));
-        verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
-    }
+  @Test
+  public void givenBinaryIsRestartedWhenNextCompletionFiresThenResponseIsValid() throws Exception {
+    AtomicBoolean first = new AtomicBoolean(true);
+    when(binaryProcessGatewayMock.readRawResponse())
+        .thenAnswer(
+            (Answer<String>)
+                invocation -> {
+                  if (first.get()) {
+                    first.set(false);
+                    throw new TabNineDeadException();
+                  }
 
-    @Test
-    public void givenACompletionWhenBinaryReturnNonsenseThenNoResultReturned() throws Exception {
-        when(binaryProcessGatewayMock.readRawResponse()).thenReturn(INVALID_RESULT);
+                  return A_PREDICTION_RESULT;
+                });
 
-        LookupElement[] actual = myFixture.completeBasic();
+    LookupElement[] actual = myFixture.completeBasic();
 
-        assertThat(actual, is(nullValue()));
-    }
+    assertThat(actual, is(nullValue()));
+    verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
 
-    @Test
-    public void givenConsecutiveCompletionsWhenBinaryReturnNonsenseThenBinaryIsRestarted() throws Exception {
-        when(binaryProcessGatewayMock.readRawResponse()).thenReturn(INVALID_RESULT);
-
-        for (int i = 0; i < ILLEGAL_RESPONSE_THRESHOLD + OVERFLOW; i++) {
-            myFixture.completeBasic();
-        }
-
-        verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
-    }
-
-    @Test
-    public void givenConsecutiveCompletionsWhenBinaryReturnNullThenBinaryIsRestarted() throws Exception {
-        when(binaryProcessGatewayMock.readRawResponse()).thenReturn(NULL_RESULT);
-
-        for (int i = 0; i < ILLEGAL_RESPONSE_THRESHOLD + OVERFLOW; i++) {
-            myFixture.completeBasic();
-        }
-
-        verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
-    }
-
-    @Ignore("This test works, but only when ran alone, as it is tied to the startup mechanism which fires only for the 1st test in the suite.")
-    @Test
-    public void givenBinaryIsFailingOnStartThenExtensionWillTryAgainAfterAWhileAndPredictionsWillNull() throws Exception {
-        when(binaryProcessGatewayMock.readRawResponse()).thenReturn(A_PREDICTION_RESULT);
-        doThrow(new IOException()).when(binaryProcessGatewayMock).init(any());
-
-        assertThat(myFixture.completeBasic(), is(nullValue()));
-
-        sleepUponFailure(1);
-
-        verify(binaryProcessGatewayMock, times(2)).init(any());
-    }
-
-    @Test
-    public void givenBinaryIsRestartedWhenNextCompletionFiresThenResponseIsValid() throws Exception {
-        AtomicBoolean first = new AtomicBoolean(true);
-        when(binaryProcessGatewayMock.readRawResponse()).thenAnswer((Answer<String>) invocation -> {
-            if (first.get()) {
-                first.set(false);
-                throw new TabNineDeadException();
-            }
-
-            return A_PREDICTION_RESULT;
-        });
-
-        LookupElement[] actual = myFixture.completeBasic();
-
-        assertThat(actual, is(nullValue()));
-        verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
-
-        assertThat(myFixture.completeBasic(), array(
-                lookupBuilder("hello"),
-                lookupElement("return result"),
-                lookupElement("return result;")
-        ));
-    }
+    assertThat(
+        myFixture.completeBasic(),
+        array(
+            lookupBuilder("hello"),
+            lookupElement("return result"),
+            lookupElement("return result;")));
+  }
 }

--- a/src/test/java/com/tabnine/integration/MockedBinaryCompletionTestCase.java
+++ b/src/test/java/com/tabnine/integration/MockedBinaryCompletionTestCase.java
@@ -1,5 +1,11 @@
 package com.tabnine.integration;
 
+import static com.tabnine.testUtils.TestData.A_TEST_TXT_FILE;
+import static com.tabnine.testUtils.TestData.SOME_CONTENT;
+import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupEvent;
 import com.intellij.codeInsight.lookup.LookupManager;
@@ -16,71 +22,73 @@ import org.junit.After;
 import org.junit.BeforeClass;
 import org.mockito.Mockito;
 
-import static com.tabnine.testUtils.TestData.A_TEST_TXT_FILE;
-import static com.tabnine.testUtils.TestData.SOME_CONTENT;
-import static java.util.Collections.singletonList;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+public abstract class MockedBinaryCompletionTestCase
+    extends LightPlatformCodeInsightFixture4TestCase {
+  protected static BinaryProcessGateway binaryProcessGatewayMock =
+      Mockito.mock(BinaryProcessGateway.class);
+  protected static BinaryRun binaryRunMock = Mockito.mock(BinaryRun.class);
+  protected static BinaryProcessGatewayProvider binaryProcessGatewayProviderMock =
+      Mockito.mock(BinaryProcessGatewayProvider.class);
 
-public abstract class MockedBinaryCompletionTestCase extends LightPlatformCodeInsightFixture4TestCase {
-    protected static BinaryProcessGateway binaryProcessGatewayMock = Mockito.mock(BinaryProcessGateway.class);
-    protected static BinaryRun binaryRunMock = Mockito.mock(BinaryRun.class);
-    protected static BinaryProcessGatewayProvider binaryProcessGatewayProviderMock = Mockito.mock(BinaryProcessGatewayProvider.class);
+  @BeforeClass
+  public static void setUpClass() {
+    DependencyContainer.setTesting(
+        binaryRunMock,
+        binaryProcessGatewayProviderMock,
+        new BinaryProcessRequesterPollerCappedImpl(0, 0, 0));
+  }
 
-    @BeforeClass
-    public static void setUpClass() {
-        DependencyContainer.setTesting(binaryRunMock, binaryProcessGatewayProviderMock, new BinaryProcessRequesterPollerCappedImpl(0, 0, 0));
+  @After
+  public void postFixtureSetup() throws Exception {
+    Mockito.reset(binaryProcessGatewayMock, binaryRunMock, binaryProcessGatewayProviderMock);
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    preFixtureSetup();
+    super.setUp();
+    myFixture.configureByText(A_TEST_TXT_FILE, SOME_CONTENT);
+  }
+
+  public void preFixtureSetup() throws Exception {
+    when(binaryProcessGatewayMock.isDead()).thenReturn(false);
+    when(binaryProcessGatewayProviderMock.generateBinaryProcessGateway())
+        .thenReturn(binaryProcessGatewayMock);
+    when(binaryRunMock.generateRunCommand(any())).thenReturn(singletonList(TestData.A_COMMAND));
+    when(binaryProcessGatewayMock.isDead()).thenReturn(false);
+    when(binaryProcessGatewayProviderMock.generateBinaryProcessGateway())
+        .thenReturn(binaryProcessGatewayMock);
+    when(binaryRunMock.generateRunCommand(any())).thenReturn(singletonList(TestData.A_COMMAND));
+  }
+
+  protected void selectItem(LookupElement item) {
+    try {
+      Thread.sleep(100);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
     }
+    selectItem(item, (char) 0);
+  }
 
-    @After
-    public void postFixtureSetup() throws Exception {
-        Mockito.reset(binaryProcessGatewayMock, binaryRunMock, binaryProcessGatewayProviderMock);
+  protected void selectItem(@NotNull LookupElement item, final char completionChar) {
+    final LookupImpl lookup = getLookup();
+    lookup.setCurrentItem(item);
+    if (LookupEvent.isSpecialCompletionChar(completionChar)) {
+      lookup.finishLookup(completionChar);
+    } else {
+      type(completionChar);
     }
+  }
 
-    @Override
-    protected void setUp() throws Exception {
-        preFixtureSetup();
-        super.setUp();
-        myFixture.configureByText(A_TEST_TXT_FILE, SOME_CONTENT);
-    }
+  protected LookupImpl getLookup() {
+    return (LookupImpl) LookupManager.getInstance(getProject()).getActiveLookup();
+  }
 
-    public void preFixtureSetup() throws Exception {
-        when(binaryProcessGatewayMock.isDead()).thenReturn(false);
-        when(binaryProcessGatewayProviderMock.generateBinaryProcessGateway()).thenReturn(binaryProcessGatewayMock);
-        when(binaryRunMock.generateRunCommand(any())).thenReturn(singletonList(TestData.A_COMMAND));
-        when(binaryProcessGatewayMock.isDead()).thenReturn(false);
-        when(binaryProcessGatewayProviderMock.generateBinaryProcessGateway()).thenReturn(binaryProcessGatewayMock);
-        when(binaryRunMock.generateRunCommand(any())).thenReturn(singletonList(TestData.A_COMMAND));
-    }
+  protected void type(char c) {
+    myFixture.type(c);
+  }
 
-    protected void selectItem(LookupElement item) {
-        try {
-            Thread.sleep(100);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        selectItem(item, (char) 0);
-    }
-
-    protected void selectItem(@NotNull LookupElement item, final char completionChar) {
-        final LookupImpl lookup = getLookup();
-        lookup.setCurrentItem(item);
-        if (LookupEvent.isSpecialCompletionChar(completionChar)) {
-            lookup.finishLookup(completionChar);
-        } else {
-            type(completionChar);
-        }
-    }
-
-    protected LookupImpl getLookup() {
-        return (LookupImpl) LookupManager.getInstance(getProject()).getActiveLookup();
-    }
-
-    protected void type(char c) {
-        myFixture.type(c);
-    }
-
-    protected void type(String s) {
-        myFixture.type(s);
-    }
+  protected void type(String s) {
+    myFixture.type(s);
+  }
 }

--- a/src/test/java/com/tabnine/integration/PredictionBehaviourIntegrationTests.java
+++ b/src/test/java/com/tabnine/integration/PredictionBehaviourIntegrationTests.java
@@ -1,10 +1,5 @@
 package com.tabnine.integration;
 
-import org.junit.Test;
-
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Stream;
-
 import static com.tabnine.testUtils.BadResultsUtils.enoughBadResultsToCauseADeath;
 import static com.tabnine.testUtils.BadResultsUtils.overThresholdBadResultsWithAGoodResultInBetween;
 import static com.tabnine.testUtils.TabnineMatchers.lookupBuilder;
@@ -15,52 +10,70 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+import org.junit.Test;
+
 public class PredictionBehaviourIntegrationTests extends MockedBinaryCompletionTestCase {
-    @Test
-    public void givenAFileWhenCompletionFiredThenRequestIsWrittenToBinaryProcessInputCorrectly() throws Exception {
-        when(binaryProcessGatewayMock.readRawResponse()).thenReturn(A_PREDICTION_RESULT);
+  @Test
+  public void givenAFileWhenCompletionFiredThenRequestIsWrittenToBinaryProcessInputCorrectly()
+      throws Exception {
+    when(binaryProcessGatewayMock.readRawResponse()).thenReturn(A_PREDICTION_RESULT);
 
-        myFixture.completeBasic();
+    myFixture.completeBasic();
 
-        verify(binaryProcessGatewayMock).writeRequest(A_REQUEST_TO_TABNINE_BINARY);
+    verify(binaryProcessGatewayMock).writeRequest(A_REQUEST_TO_TABNINE_BINARY);
+  }
+
+  @Test
+  public void givenAFileWhenCompletionFiredThenResponseFromBinaryParsedCorrectlyToResults()
+      throws Exception {
+    when(binaryProcessGatewayMock.readRawResponse()).thenReturn(A_PREDICTION_RESULT);
+
+    assertThat(
+        myFixture.completeBasic(),
+        array(
+            lookupBuilder("hello"),
+            lookupElement("return result"),
+            lookupElement("return result;")));
+  }
+
+  @Test
+  public void givenInvalidCompletionsThatAreNotConsecutiveThanPluginIsNotDead() throws Exception {
+    String[] enoughResultsToCauseDeathIfWerentForGoodResultBetweenEndingWithAGoodResult =
+        Stream.concat(
+                overThresholdBadResultsWithAGoodResultInBetween(), Stream.of(A_PREDICTION_RESULT))
+            .toArray(String[]::new);
+    when(binaryProcessGatewayMock.readRawResponse())
+        .thenReturn(
+            INVALID_RESULT,
+            enoughResultsToCauseDeathIfWerentForGoodResultBetweenEndingWithAGoodResult);
+
+    for (int i = 0;
+        i < enoughResultsToCauseDeathIfWerentForGoodResultBetweenEndingWithAGoodResult.length;
+        i++) {
+      myFixture.completeBasic();
     }
 
-    @Test
-    public void givenAFileWhenCompletionFiredThenResponseFromBinaryParsedCorrectlyToResults() throws Exception {
-        when(binaryProcessGatewayMock.readRawResponse()).thenReturn(A_PREDICTION_RESULT);
+    assertThat(
+        myFixture.completeBasic(),
+        array(
+            lookupBuilder("hello"),
+            lookupElement("return result"),
+            lookupElement("return result;")));
+  }
 
-        assertThat(myFixture.completeBasic(), array(
-                lookupBuilder("hello"),
-                lookupElement("return result"),
-                lookupElement("return result;")
-        ));
-    }
+  @Test
+  public void givenMoreConsecutiveInvalidCompletionsThanThresholdThenPluginDies() throws Exception {
+    String[] badResults = enoughBadResultsToCauseADeath().toArray(String[]::new);
+    when(binaryProcessGatewayMock.readRawResponse()).thenReturn(INVALID_RESULT, badResults);
 
-    @Test
-    public void givenInvalidCompletionsThatAreNotConsecutiveThanPluginIsNotDead() throws Exception {
-        String[] enoughResultsToCauseDeathIfWerentForGoodResultBetweenEndingWithAGoodResult = Stream.concat(overThresholdBadResultsWithAGoodResultInBetween(), Stream.of(A_PREDICTION_RESULT)).toArray(String[]::new);
-        when(binaryProcessGatewayMock.readRawResponse()).thenReturn(INVALID_RESULT, enoughResultsToCauseDeathIfWerentForGoodResultBetweenEndingWithAGoodResult);
-
-        for (int i = 0; i < enoughResultsToCauseDeathIfWerentForGoodResultBetweenEndingWithAGoodResult.length; i++) {
+    assertThrows(
+        ExecutionException.class,
+        () -> {
+          for (int i = 0; i < badResults.length; i++) {
             myFixture.completeBasic();
-        }
-
-        assertThat(myFixture.completeBasic(), array(
-                lookupBuilder("hello"),
-                lookupElement("return result"),
-                lookupElement("return result;")
-        ));
-    }
-
-    @Test
-    public void givenMoreConsecutiveInvalidCompletionsThanThresholdThenPluginDies() throws Exception {
-        String[] badResults = enoughBadResultsToCauseADeath().toArray(String[]::new);
-        when(binaryProcessGatewayMock.readRawResponse()).thenReturn(INVALID_RESULT, badResults);
-
-        assertThrows(ExecutionException.class, () -> {
-            for (int i = 0; i < badResults.length; i++) {
-                myFixture.completeBasic();
-            }
+          }
         });
-    }
+  }
 }

--- a/src/test/java/com/tabnine/integration/PredictionTimeoutIntegrationTests.java
+++ b/src/test/java/com/tabnine/integration/PredictionTimeoutIntegrationTests.java
@@ -1,15 +1,5 @@
 package com.tabnine.integration;
 
-import com.intellij.codeInsight.lookup.LookupElement;
-import com.tabnine.binary.*;
-import com.tabnine.binary.exceptions.TabNineDeadException;
-import org.junit.Test;
-import org.mockito.stubbing.Answer;
-
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import static com.tabnine.general.StaticConfig.COMPLETION_TIME_THRESHOLD;
 import static com.tabnine.general.StaticConfig.CONSECUTIVE_TIMEOUTS_THRESHOLD;
 import static com.tabnine.testUtils.TabnineMatchers.lookupBuilder;
@@ -19,186 +9,213 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.tabnine.binary.*;
+import com.tabnine.binary.exceptions.TabNineDeadException;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
 public class PredictionTimeoutIntegrationTests extends MockedBinaryCompletionTestCase {
-    @Test
-    public void givenAFileWhenCompletionFiredAndResponseTakeMoreThanThresholdThenResponseIsNulled() throws Exception {
-        when(binaryProcessGatewayMock.readRawResponse()).thenAnswer(invocation -> {
-            Thread.sleep(COMPLETION_TIME_THRESHOLD + OVERFLOW);
+  @Test
+  public void givenAFileWhenCompletionFiredAndResponseTakeMoreThanThresholdThenResponseIsNulled()
+      throws Exception {
+    when(binaryProcessGatewayMock.readRawResponse())
+        .thenAnswer(
+            invocation -> {
+              Thread.sleep(COMPLETION_TIME_THRESHOLD + OVERFLOW);
 
-            return A_PREDICTION_RESULT;
-        });
+              return A_PREDICTION_RESULT;
+            });
 
-        LookupElement[] actual = myFixture.completeBasic();
+    LookupElement[] actual = myFixture.completeBasic();
 
-        assertThat(actual, is(nullValue()));
-    }
+    assertThat(actual, is(nullValue()));
+  }
 
-    @Test
-    public void givenAFileWhenCompletionFiredAndResponseTakeMoreThanThresholdThenResponseIsNulledAndThePrecidingResponseGoThrough() throws Exception {
-        AtomicBoolean first = new AtomicBoolean(true);
-        when(binaryProcessGatewayMock.readRawResponse()).thenAnswer(invocation -> {
-            if (first.get()) {
+  @Test
+  public void
+      givenAFileWhenCompletionFiredAndResponseTakeMoreThanThresholdThenResponseIsNulledAndThePrecidingResponseGoThrough()
+          throws Exception {
+    AtomicBoolean first = new AtomicBoolean(true);
+    when(binaryProcessGatewayMock.readRawResponse())
+        .thenAnswer(
+            invocation -> {
+              if (first.get()) {
                 first.set(false);
                 Thread.sleep(COMPLETION_TIME_THRESHOLD + OVERFLOW);
-            }
+              }
 
-            return A_PREDICTION_RESULT;
-        });
+              return A_PREDICTION_RESULT;
+            });
 
-        LookupElement[] actual = myFixture.completeBasic();
+    LookupElement[] actual = myFixture.completeBasic();
 
-        assertThat(actual, is(nullValue()));
+    assertThat(actual, is(nullValue()));
 
-        assertThat(myFixture.completeBasic(), array(
-                lookupBuilder("hello"),
-                lookupElement("return result"),
-                lookupElement("return result;")
-        ));
-    }
+    assertThat(
+        myFixture.completeBasic(),
+        array(
+            lookupBuilder("hello"),
+            lookupElement("return result"),
+            lookupElement("return result;")));
+  }
 
-    @Test
-    public void givenPreviousTimedOutCompletionWhenCompletionThenPreviousResultIsIgnoredAndCurrentIsReturned() throws Exception {
-        AtomicInteger index = new AtomicInteger();
-        when(binaryProcessGatewayMock.readRawResponse()).then((invocation) -> {
-            if (index.getAndIncrement() == 0) {
+  @Test
+  public void
+      givenPreviousTimedOutCompletionWhenCompletionThenPreviousResultIsIgnoredAndCurrentIsReturned()
+          throws Exception {
+    AtomicInteger index = new AtomicInteger();
+    when(binaryProcessGatewayMock.readRawResponse())
+        .then(
+            (invocation) -> {
+              if (index.getAndIncrement() == 0) {
                 Thread.sleep(COMPLETION_TIME_THRESHOLD + EPSILON);
 
                 return A_PREDICTION_RESULT;
-            }
+              }
 
-            Thread.sleep(EPSILON);
-            return SECOND_PREDICTION_RESULT;
-        });
+              Thread.sleep(EPSILON);
+              return SECOND_PREDICTION_RESULT;
+            });
 
+    assertThat(myFixture.completeBasic(), nullValue());
+    assertThat(myFixture.completeBasic(), array(lookupBuilder("hello"), lookupElement("test")));
+  }
+
+  @Test
+  public void
+      givenConsecutivesTimeOutsCompletionWhenCompletionThenPreviousResultIsIgnoredAndCurrentIsReturned()
+          throws Exception {
+    AtomicInteger index = new AtomicInteger();
+    when(binaryProcessGatewayMock.readRawResponse())
+        .then(
+            (invocation) -> {
+              if (index.getAndIncrement() < CONSECUTIVE_TIMEOUTS_THRESHOLD) {
+                Thread.sleep(COMPLETION_TIME_THRESHOLD + EPSILON);
+
+                return A_PREDICTION_RESULT;
+              }
+
+              Thread.sleep(EPSILON);
+              return SECOND_PREDICTION_RESULT;
+            });
+
+    for (int i = 0; i < CONSECUTIVE_TIMEOUTS_THRESHOLD; i++) {
+      assertThat(myFixture.completeBasic(), nullValue());
+    }
+
+    verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
+    assertThat(myFixture.completeBasic(), array(lookupBuilder("hello"), lookupElement("test")));
+  }
+
+  @Test
+  public void givenCompletionTimeOutsButNotConsecutiveWhenCompletionThenRestartIsNotHappening()
+      throws Exception {
+    AtomicInteger index = new AtomicInteger();
+    when(binaryProcessGatewayMock.readRawResponse())
+        .then(
+            (invocation) -> {
+              int currentIndex = index.getAndIncrement();
+
+              if (currentIndex == INDEX_OF_SOME_VALID_RESULT_BETWEEN_TIMEOUTS) {
+                return A_PREDICTION_RESULT;
+              }
+
+              if (currentIndex < CONSECUTIVE_TIMEOUTS_THRESHOLD + OVERFLOW) {
+                Thread.sleep(COMPLETION_TIME_THRESHOLD + EPSILON);
+
+                return A_PREDICTION_RESULT;
+              }
+
+              Thread.sleep(EPSILON);
+              return SECOND_PREDICTION_RESULT;
+            });
+
+    for (int i = 0; i < CONSECUTIVE_TIMEOUTS_THRESHOLD + OVERFLOW; i++) {
+      if (i != INDEX_OF_SOME_VALID_RESULT_BETWEEN_TIMEOUTS) {
         assertThat(myFixture.completeBasic(), nullValue());
-        assertThat(myFixture.completeBasic(), array(
-                lookupBuilder("hello"),
-                lookupElement("test")
-        ));
+      } else {
+        myFixture.completeBasic();
+      }
     }
 
-    @Test
-    public void givenConsecutivesTimeOutsCompletionWhenCompletionThenPreviousResultIsIgnoredAndCurrentIsReturned() throws Exception {
-        AtomicInteger index = new AtomicInteger();
-        when(binaryProcessGatewayMock.readRawResponse()).then((invocation) -> {
-            if (index.getAndIncrement() < CONSECUTIVE_TIMEOUTS_THRESHOLD) {
-                Thread.sleep(COMPLETION_TIME_THRESHOLD + EPSILON);
+    assertThat(myFixture.completeBasic(), array(lookupBuilder("hello"), lookupElement("test")));
+    verify(binaryProcessGatewayProviderMock, never()).generateBinaryProcessGateway();
+  }
 
-                return A_PREDICTION_RESULT;
-            }
+  @Test
+  public void givenLateComingFailingRequestsWhenCompletionThenRestartIsHappeningOnlyOnce()
+      throws Exception {
+    AtomicInteger index = new AtomicInteger();
+    when(binaryProcessGatewayMock.readRawResponse())
+        .then(
+            (invocation) -> {
+              int currentIndex = index.getAndIncrement();
 
-            Thread.sleep(EPSILON);
-            return SECOND_PREDICTION_RESULT;
-        });
-
-        for (int i = 0; i < CONSECUTIVE_TIMEOUTS_THRESHOLD; i++) {
-            assertThat(myFixture.completeBasic(), nullValue());
-        }
-
-        verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
-        assertThat(myFixture.completeBasic(), array(
-                lookupBuilder("hello"),
-                lookupElement("test")
-        ));
-    }
-
-    @Test
-    public void givenCompletionTimeOutsButNotConsecutiveWhenCompletionThenRestartIsNotHappening() throws Exception {
-        AtomicInteger index = new AtomicInteger();
-        when(binaryProcessGatewayMock.readRawResponse()).then((invocation) -> {
-            int currentIndex = index.getAndIncrement();
-
-            if (currentIndex == INDEX_OF_SOME_VALID_RESULT_BETWEEN_TIMEOUTS) {
-                return A_PREDICTION_RESULT;
-            }
-
-            if (currentIndex < CONSECUTIVE_TIMEOUTS_THRESHOLD + OVERFLOW) {
-                Thread.sleep(COMPLETION_TIME_THRESHOLD + EPSILON);
-
-                return A_PREDICTION_RESULT;
-            }
-
-            Thread.sleep(EPSILON);
-            return SECOND_PREDICTION_RESULT;
-        });
-
-        for (int i = 0; i < CONSECUTIVE_TIMEOUTS_THRESHOLD + OVERFLOW; i++) {
-            if (i != INDEX_OF_SOME_VALID_RESULT_BETWEEN_TIMEOUTS) {
-                assertThat(myFixture.completeBasic(), nullValue());
-            } else {
-                myFixture.completeBasic();
-            }
-        }
-
-        assertThat(myFixture.completeBasic(), array(
-                lookupBuilder("hello"),
-                lookupElement("test")
-        ));
-        verify(binaryProcessGatewayProviderMock, never()).generateBinaryProcessGateway();
-    }
-
-    @Test
-    public void givenLateComingFailingRequestsWhenCompletionThenRestartIsHappeningOnlyOnce() throws Exception {
-        AtomicInteger index = new AtomicInteger();
-        when(binaryProcessGatewayMock.readRawResponse()).then((invocation) -> {
-            int currentIndex = index.getAndIncrement();
-
-            if (currentIndex == 0) {
+              if (currentIndex == 0) {
                 Thread.sleep(2 * COMPLETION_TIME_THRESHOLD);
 
                 throw new IOException();
-            }
+              }
 
-            Thread.sleep(EPSILON);
+              Thread.sleep(EPSILON);
 
-            throw new IOException();
-        });
+              throw new IOException();
+            });
 
-        assertThat(myFixture.completeBasic(), nullValue());
-        assertThat(myFixture.completeBasic(), nullValue());
+    assertThat(myFixture.completeBasic(), nullValue());
+    assertThat(myFixture.completeBasic(), nullValue());
 
-        Thread.sleep(3 * COMPLETION_TIME_THRESHOLD);
-        verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
+    Thread.sleep(3 * COMPLETION_TIME_THRESHOLD);
+    verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
+  }
+
+  @Test
+  public void pollerTimeoutExceptionThrown() throws Exception {
+    BinaryProcessRequesterPollerCappedImpl binaryProcessRequesterPollerCapped =
+        new BinaryProcessRequesterPollerCappedImpl(5, 10, 10);
+    when(binaryProcessGatewayMock.readRawResponse()).thenThrow(new TabNineDeadException());
+    boolean timeoutCalled = false;
+    try {
+      binaryProcessRequesterPollerCapped.pollUntilReady(binaryProcessGatewayMock);
+    } catch (TabNineDeadException e) {
+      timeoutCalled = true;
     }
+    assertTrue(timeoutCalled);
+  }
 
-    @Test
-    public void pollerTimeoutExceptionThrown() throws Exception {
-        BinaryProcessRequesterPollerCappedImpl binaryProcessRequesterPollerCapped = new BinaryProcessRequesterPollerCappedImpl(5, 10, 10);
-        when(binaryProcessGatewayMock.readRawResponse()).thenThrow(new TabNineDeadException());
-        boolean timeoutCalled = false;
-        try {
-            binaryProcessRequesterPollerCapped.pollUntilReady(binaryProcessGatewayMock);
-        } catch (TabNineDeadException e) {
-            timeoutCalled = true;
-        }
-        assertTrue(timeoutCalled);
+  @Test
+  public void pollerHandlesTimeoutSuccesfully() throws Exception {
+    BinaryProcessRequesterPollerCappedImpl binaryProcessRequesterPollerCapped =
+        new BinaryProcessRequesterPollerCappedImpl(5, 10, 19);
+    boolean timeoutCalled = false;
+
+    final int[] pollCount = {0};
+    when(binaryProcessGatewayMock.readRawResponse())
+        .thenAnswer(
+            (Answer<String>)
+                invocation -> {
+                  pollCount[0] = pollCount[0] + 1;
+                  int count = pollCount[0];
+                  if (count == 4) {
+                    return SET_STATE_RESPONSE;
+                  }
+                  try {
+                    Thread.sleep(20);
+                  } catch (InterruptedException ignored) {
+
+                  }
+                  return null;
+                });
+    try {
+      binaryProcessRequesterPollerCapped.pollUntilReady(binaryProcessGatewayMock);
+    } catch (TabNineDeadException e) {
+      timeoutCalled = true;
     }
-
-    @Test
-    public void pollerHandlesTimeoutSuccesfully() throws Exception {
-        BinaryProcessRequesterPollerCappedImpl binaryProcessRequesterPollerCapped = new BinaryProcessRequesterPollerCappedImpl(5, 10, 19);
-        boolean timeoutCalled = false;
-
-        final int[] pollCount = {0};
-        when(binaryProcessGatewayMock.readRawResponse()).thenAnswer((Answer<String>) invocation -> {
-            pollCount[0] = pollCount[0] + 1;
-            int count = pollCount[0];
-            if (count == 4) {
-                return SET_STATE_RESPONSE;
-            }
-            try {
-                Thread.sleep(20);
-            } catch (InterruptedException ignored) {
-
-            }
-            return null;
-        });
-        try {
-            binaryProcessRequesterPollerCapped.pollUntilReady(binaryProcessGatewayMock);
-        } catch (TabNineDeadException e) {
-            timeoutCalled = true;
-        }
-        assertFalse(timeoutCalled);
-        assertEquals(4, pollCount[0]);
-    }
+    assertFalse(timeoutCalled);
+    assertEquals(4, pollCount[0]);
+  }
 }

--- a/src/test/java/com/tabnine/integration/SelectionBehaviourIntegrationTests.java
+++ b/src/test/java/com/tabnine/integration/SelectionBehaviourIntegrationTests.java
@@ -1,49 +1,54 @@
 package com.tabnine.integration;
 
-import com.intellij.codeInsight.lookup.LookupElement;
-import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
-
 import static com.tabnine.testUtils.TestData.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import com.intellij.codeInsight.lookup.LookupElement;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
 public class SelectionBehaviourIntegrationTests extends MockedBinaryCompletionTestCase {
-    @Test
-    public void givenTabNineCompletionWhenSelectedThenSetStateIsWrittenToBinary() throws Exception {
-        when(binaryProcessGatewayMock.readRawResponse()).thenReturn(A_PREDICTION_RESULT, SET_STATE_RESPONSE);
+  @Test
+  public void givenTabNineCompletionWhenSelectedThenSetStateIsWrittenToBinary() throws Exception {
+    when(binaryProcessGatewayMock.readRawResponse())
+        .thenReturn(A_PREDICTION_RESULT, SET_STATE_RESPONSE);
 
-        LookupElement[] lookupElements = myFixture.completeBasic();
-        selectItem(lookupElements[1]);
+    LookupElement[] lookupElements = myFixture.completeBasic();
+    selectItem(lookupElements[1]);
 
-        verify(binaryProcessGatewayMock).writeRequest(SET_STATE_REQUEST);
-    }
+    verify(binaryProcessGatewayMock).writeRequest(SET_STATE_REQUEST);
+  }
 
-    @Test
-    public void givenAFileWithNoExtensionWhenSelectedThenSetStateExtensionIsUndefined() throws Exception {
-        myFixture.configureByText(A_FILE_WITH_NO_EXTENSION, SOME_CONTENT);
-        when(binaryProcessGatewayMock.readRawResponse()).thenReturn(A_PREDICTION_RESULT, SET_STATE_RESPONSE);
+  @Test
+  public void givenAFileWithNoExtensionWhenSelectedThenSetStateExtensionIsUndefined()
+      throws Exception {
+    myFixture.configureByText(A_FILE_WITH_NO_EXTENSION, SOME_CONTENT);
+    when(binaryProcessGatewayMock.readRawResponse())
+        .thenReturn(A_PREDICTION_RESULT, SET_STATE_RESPONSE);
 
-        LookupElement[] lookupElements = myFixture.completeBasic();
-        selectItem(lookupElements[1]);
+    LookupElement[] lookupElements = myFixture.completeBasic();
+    selectItem(lookupElements[1]);
 
-        verify(binaryProcessGatewayMock).writeRequest(NO_EXTENSION_STATE_REQUEST);
-    }
+    verify(binaryProcessGatewayMock).writeRequest(NO_EXTENSION_STATE_REQUEST);
+  }
 
-    @Test
-    public void givenTabNineCompletionWhenNotSelectedThenNotCounted() throws Exception {
-        when(binaryProcessGatewayMock.readRawResponse()).thenReturn(A_PREDICTION_RESULT, SET_STATE_RESPONSE);
+  @Test
+  public void givenTabNineCompletionWhenNotSelectedThenNotCounted() throws Exception {
+    when(binaryProcessGatewayMock.readRawResponse())
+        .thenReturn(A_PREDICTION_RESULT, SET_STATE_RESPONSE);
 
-        LookupElement[] lookupElements = myFixture.completeBasic();
-        selectItem(new LookupElement() {
-            @NotNull
-            @Override
-            public String getLookupString() {
-                return "yay";
-            }
+    LookupElement[] lookupElements = myFixture.completeBasic();
+    selectItem(
+        new LookupElement() {
+          @NotNull
+          @Override
+          public String getLookupString() {
+            return "yay";
+          }
         });
 
-        // At most once because there is a completion request...
-        verify(binaryProcessGatewayMock, atMostOnce()).writeRequest(any());
-    }
+    // At most once because there is a completion request...
+    verify(binaryProcessGatewayMock, atMostOnce()).writeRequest(any());
+  }
 }

--- a/src/test/java/com/tabnine/plugin/InlineCompletionTests.java
+++ b/src/test/java/com/tabnine/plugin/InlineCompletionTests.java
@@ -1,5 +1,8 @@
 package com.tabnine.plugin;
 
+import static com.tabnine.testUtils.TestData.THIRD_PREDICTION_RESULT;
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,132 +14,130 @@ import com.tabnine.inline.CompletionPreview;
 import com.tabnine.inline.ShowNextInlineCompletionAction;
 import com.tabnine.inline.ShowPreviousInlineCompletionAction;
 import com.tabnine.integration.MockedBinaryCompletionTestCase;
-import com.tabnine.prediction.TabNineCompletion;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import java.util.Properties;
-
-import static com.tabnine.testUtils.TestData.THIRD_PREDICTION_RESULT;
-import static org.mockito.Mockito.when;
-
 public class InlineCompletionTests extends MockedBinaryCompletionTestCase {
-    private static final ObjectMapper mapper = createObjectMapper();
-    private static MockedStatic<SuggestionsMode> suggestionsModeMock;
+  private static final ObjectMapper mapper = createObjectMapper();
+  private static MockedStatic<SuggestionsMode> suggestionsModeMock;
 
-    @Before
-    public void init() {
-        suggestionsModeMock = Mockito.mockStatic(SuggestionsMode.class);
-    }
+  @Before
+  public void init() {
+    suggestionsModeMock = Mockito.mockStatic(SuggestionsMode.class);
+  }
 
-    @After
-    public void clear() {
-        suggestionsModeMock.close();
-    }
+  @After
+  public void clear() {
+    suggestionsModeMock.close();
+  }
 
-    private void configureInlineTest(SuggestionsMode suggestionsMode, String oldPrefix) throws Exception {
-        String value = setOldPrefixFor(THIRD_PREDICTION_RESULT, oldPrefix);
-        when(binaryProcessGatewayMock.readRawResponse()).thenReturn(value);
-        suggestionsModeMock.when(SuggestionsMode::getSuggestionMode).thenReturn(suggestionsMode);
-    }
+  private void configureInlineTest(SuggestionsMode suggestionsMode, String oldPrefix)
+      throws Exception {
+    String value = setOldPrefixFor(THIRD_PREDICTION_RESULT, oldPrefix);
+    when(binaryProcessGatewayMock.readRawResponse()).thenReturn(value);
+    suggestionsModeMock.when(SuggestionsMode::getSuggestionMode).thenReturn(suggestionsMode);
+  }
 
-    private String setOldPrefixFor(String completionMock, String oldPrefix) throws JsonProcessingException {
-        AutocompleteResponse autocompleteResponse = mapper.readValue(completionMock, AutocompleteResponse.class);
-        autocompleteResponse.old_prefix = oldPrefix;
-        return mapper.writeValueAsString(autocompleteResponse);
-    }
+  private String setOldPrefixFor(String completionMock, String oldPrefix)
+      throws JsonProcessingException {
+    AutocompleteResponse autocompleteResponse =
+        mapper.readValue(completionMock, AutocompleteResponse.class);
+    autocompleteResponse.old_prefix = oldPrefix;
+    return mapper.writeValueAsString(autocompleteResponse);
+  }
 
-    private static ObjectMapper createObjectMapper() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        // it fails on `docs` fields which is not presented in `AutocompleteResponse`, but that's (serialization works in production).
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        return objectMapper;
-    }
+  private static ObjectMapper createObjectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    // it fails on `docs` fields which is not presented in `AutocompleteResponse`, but that's
+    // (serialization works in production).
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    return objectMapper;
+  }
 
-    @Test
-    public void showInlineCompletion() throws Exception {
-        configureInlineTest(SuggestionsMode.INLINE, "t");
+  @Test
+  public void showInlineCompletion() throws Exception {
+    configureInlineTest(SuggestionsMode.INLINE, "t");
 
-        type("\nt");
-        assertEquals(
-                "Incorrect inline completion",
-                "emp",
-                CompletionPreview.getPreviewText(myFixture.getEditor()));
-    }
+    type("\nt");
+    assertEquals(
+        "Incorrect inline completion",
+        "emp",
+        CompletionPreview.getPreviewText(myFixture.getEditor()));
+  }
 
-    @Test
-    public void noInlineCompletionWhenAutocompleteSuggestionMode() throws Exception {
-        configureInlineTest(SuggestionsMode.AUTOCOMPLETE, "t");
+  @Test
+  public void noInlineCompletionWhenAutocompleteSuggestionMode() throws Exception {
+    configureInlineTest(SuggestionsMode.AUTOCOMPLETE, "t");
 
-        type("\nt");
-        assertNull(CompletionPreview.getPreviewText(myFixture.getEditor()));
-    }
+    type("\nt");
+    assertNull(CompletionPreview.getPreviewText(myFixture.getEditor()));
+  }
 
-    @Test
-    public void showSecondSuggestionWhenExecutingNextInlineAction() throws Exception {
-        configureInlineTest(SuggestionsMode.INLINE, "te");
+  @Test
+  public void showSecondSuggestionWhenExecutingNextInlineAction() throws Exception {
+    configureInlineTest(SuggestionsMode.INLINE, "te");
 
-        type("\nte");
-        myFixture.performEditorAction(ShowNextInlineCompletionAction.ACTION_ID);
-        assertEquals(
-                "Incorrect next inline completion",
-                "mporary",
-                CompletionPreview.getPreviewText(myFixture.getEditor()));
-    }
+    type("\nte");
+    myFixture.performEditorAction(ShowNextInlineCompletionAction.ACTION_ID);
+    assertEquals(
+        "Incorrect next inline completion",
+        "mporary",
+        CompletionPreview.getPreviewText(myFixture.getEditor()));
+  }
 
-    @Test
-    public void showLastSuggestionWhenExecutingPrevInlineAction() throws Exception {
-        configureInlineTest(SuggestionsMode.INLINE, "te");
+  @Test
+  public void showLastSuggestionWhenExecutingPrevInlineAction() throws Exception {
+    configureInlineTest(SuggestionsMode.INLINE, "te");
 
-        type("\nte");
-        myFixture.performEditorAction(ShowPreviousInlineCompletionAction.ACTION_ID);
-        assertEquals(
-                "Incorrect previous inline completion",
-                "mporary file",
-                CompletionPreview.getPreviewText(myFixture.getEditor()));
-    }
+    type("\nte");
+    myFixture.performEditorAction(ShowPreviousInlineCompletionAction.ACTION_ID);
+    assertEquals(
+        "Incorrect previous inline completion",
+        "mporary file",
+        CompletionPreview.getPreviewText(myFixture.getEditor()));
+  }
 
-    @Test
-    public void showFirstSuggestionWhenExecutingNextAndThenPrevInlineActions() throws Exception {
-        configureInlineTest(SuggestionsMode.INLINE, "te");
+  @Test
+  public void showFirstSuggestionWhenExecutingNextAndThenPrevInlineActions() throws Exception {
+    configureInlineTest(SuggestionsMode.INLINE, "te");
 
-        type("\nte");
-        myFixture.performEditorAction(ShowNextInlineCompletionAction.ACTION_ID);
-        myFixture.performEditorAction(ShowPreviousInlineCompletionAction.ACTION_ID);
-        assertEquals(
-                "Incorrect next inline completion",
-                "mp",
-                CompletionPreview.getPreviewText(myFixture.getEditor()));
-    }
+    type("\nte");
+    myFixture.performEditorAction(ShowNextInlineCompletionAction.ACTION_ID);
+    myFixture.performEditorAction(ShowPreviousInlineCompletionAction.ACTION_ID);
+    assertEquals(
+        "Incorrect next inline completion",
+        "mp",
+        CompletionPreview.getPreviewText(myFixture.getEditor()));
+  }
 
-    @Test
-    public void acceptInlineCompletion() throws Exception {
-        configureInlineTest(SuggestionsMode.INLINE, "t");
+  @Test
+  public void acceptInlineCompletion() throws Exception {
+    configureInlineTest(SuggestionsMode.INLINE, "t");
 
-        type("\nt");
-        myFixture.performEditorAction(AcceptInlineCompletionAction.ACTION_ID);
-        myFixture.checkResult("hello\ntemp\nhello");
-    }
+    type("\nt");
+    myFixture.performEditorAction(AcceptInlineCompletionAction.ACTION_ID);
+    myFixture.checkResult("hello\ntemp\nhello");
+  }
 
-    @Test
-    public void dontShowPreviewForAutoFillingChars() throws Exception {
-        configureInlineTest(SuggestionsMode.INLINE, "[");
+  @Test
+  public void dontShowPreviewForAutoFillingChars() throws Exception {
+    configureInlineTest(SuggestionsMode.INLINE, "[");
 
-        type("\n");
-        type("[");
-        // only test the auto-filled char, so dispose the preview before the last character
-        ObjectUtils.doIfNotNull(myFixture.getEditor(), editor -> {
-            CompletionPreview.disposeIfExists(editor);
-            return null;
+    type("\n");
+    type("[");
+    // only test the auto-filled char, so dispose the preview before the last character
+    ObjectUtils.doIfNotNull(
+        myFixture.getEditor(),
+        editor -> {
+          CompletionPreview.disposeIfExists(editor);
+          return null;
         });
 
-        type("]");
-        assertNull(
-                "Should not have shown preview",
-                CompletionPreview.getPreviewText(myFixture.getEditor())
-        );
-    }
+    type("]");
+    assertNull(
+        "Should not have shown preview", CompletionPreview.getPreviewText(myFixture.getEditor()));
+  }
 }

--- a/src/test/java/com/tabnine/testUtils/BadResultsUtils.java
+++ b/src/test/java/com/tabnine/testUtils/BadResultsUtils.java
@@ -1,38 +1,38 @@
 package com.tabnine.testUtils;
 
-import org.jetbrains.annotations.NotNull;
-
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
 import static com.tabnine.general.StaticConfig.CONSECUTIVE_RESTART_THRESHOLD;
 import static com.tabnine.general.StaticConfig.ILLEGAL_RESPONSE_THRESHOLD;
 import static com.tabnine.testUtils.TestData.*;
 
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+
 public class BadResultsUtils {
-    @NotNull
-    public static Stream<String> overThresholdBadResultsWithAGoodResultInBetween() {
-        Stream<String> results = Stream.concat(enoughBadResultsToCauseARestart(), Stream.of(A_PREDICTION_RESULT));
+  @NotNull
+  public static Stream<String> overThresholdBadResultsWithAGoodResultInBetween() {
+    Stream<String> results =
+        Stream.concat(enoughBadResultsToCauseARestart(), Stream.of(A_PREDICTION_RESULT));
 
-        for (int i = 0; i < CONSECUTIVE_RESTART_THRESHOLD; i++) {
-            results = Stream.concat(results, enoughBadResultsToCauseARestart());
-        }
-
-        return results;
+    for (int i = 0; i < CONSECUTIVE_RESTART_THRESHOLD; i++) {
+      results = Stream.concat(results, enoughBadResultsToCauseARestart());
     }
 
-    @NotNull
-    public static Stream<String> enoughBadResultsToCauseADeath() {
-        Stream<String> results = enoughBadResultsToCauseARestart();
+    return results;
+  }
 
-        for (int i = 0; i < CONSECUTIVE_RESTART_THRESHOLD; i++) {
-            results = Stream.concat(results, enoughBadResultsToCauseARestart());
-        }
+  @NotNull
+  public static Stream<String> enoughBadResultsToCauseADeath() {
+    Stream<String> results = enoughBadResultsToCauseARestart();
 
-        return results;
+    for (int i = 0; i < CONSECUTIVE_RESTART_THRESHOLD; i++) {
+      results = Stream.concat(results, enoughBadResultsToCauseARestart());
     }
 
-    private static Stream<String> enoughBadResultsToCauseARestart() {
-        return IntStream.range(0, ILLEGAL_RESPONSE_THRESHOLD + OVERFLOW).mapToObj(i -> INVALID_RESULT);
-    }
+    return results;
+  }
+
+  private static Stream<String> enoughBadResultsToCauseARestart() {
+    return IntStream.range(0, ILLEGAL_RESPONSE_THRESHOLD + OVERFLOW).mapToObj(i -> INVALID_RESULT);
+  }
 }

--- a/src/test/java/com/tabnine/testUtils/TabnineMatchers.java
+++ b/src/test/java/com/tabnine/testUtils/TabnineMatchers.java
@@ -1,15 +1,10 @@
 package com.tabnine.testUtils;
 
+import static org.mockito.ArgumentMatchers.argThat;
+
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.tabnine.binary.fetch.BinaryVersion;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
-import org.jetbrains.annotations.NotNull;
-
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -17,105 +12,115 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-
-import static org.mockito.ArgumentMatchers.argThat;
+import javax.annotation.Nonnull;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.jetbrains.annotations.NotNull;
 
 public class TabnineMatchers {
-    public static Matcher<LookupElement> lookupElement(String suffix) {
-        return new BaseMatcher<LookupElement>() {
-            @Override
-            public boolean matches(Object o) {
-                LookupElement lookupElement = (LookupElement) o;
+  public static Matcher<LookupElement> lookupElement(String suffix) {
+    return new BaseMatcher<LookupElement>() {
+      @Override
+      public boolean matches(Object o) {
+        LookupElement lookupElement = (LookupElement) o;
 
-                return lookupElement.getLookupString().equals(suffix);
-            }
+        return lookupElement.getLookupString().equals(suffix);
+      }
 
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("LookupElement's string: ").appendValue(suffix);
-            }
-        };
-    }
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("LookupElement's string: ").appendValue(suffix);
+      }
+    };
+  }
 
-    public static Matcher<LookupElement> lookupBuilder(String hello) {
-        return new BaseMatcher<LookupElement>() {
-            @Override
-            public boolean matches(Object o) {
-                LookupElementBuilder lookupElement = (LookupElementBuilder) o;
+  public static Matcher<LookupElement> lookupBuilder(String hello) {
+    return new BaseMatcher<LookupElement>() {
+      @Override
+      public boolean matches(Object o) {
+        LookupElementBuilder lookupElement = (LookupElementBuilder) o;
 
-                return lookupElement.getObject().equals(hello) && lookupElement.getLookupString().equals(hello);
-            }
+        return lookupElement.getObject().equals(hello)
+            && lookupElement.getLookupString().equals(hello);
+      }
 
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("LookupElementBuilder's object and lookupString: ").appendValue(hello);
-            }
-        };
-    }
+      @Override
+      public void describeTo(Description description) {
+        description
+            .appendText("LookupElementBuilder's object and lookupString: ")
+            .appendValue(hello);
+      }
+    };
+  }
 
-    public static <T> Matcher<List<T>> hasItemInPosition(int position, Matcher<T> value) {
-        return new BaseMatcher<List<T>>() {
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("item in position ").appendValue(position).appendText(" ")
-                        .appendDescriptionOf(value);
-            }
+  public static <T> Matcher<List<T>> hasItemInPosition(int position, Matcher<T> value) {
+    return new BaseMatcher<List<T>>() {
+      @Override
+      public void describeTo(Description description) {
+        description
+            .appendText("item in position ")
+            .appendValue(position)
+            .appendText(" ")
+            .appendDescriptionOf(value);
+      }
 
-            @Override
-            public boolean matches(Object o) {
-                if (!(o instanceof List)) {
-                    return false;
-                }
+      @Override
+      public boolean matches(Object o) {
+        if (!(o instanceof List)) {
+          return false;
+        }
 
-                return value.matches(((List) o).get(position));
-            }
-        };
-    }
+        return value.matches(((List) o).get(position));
+      }
+    };
+  }
 
-    public static Matcher<File> fileContentEquals(byte[] content) {
-        return new BaseMatcher<File>() {
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("file content is ").appendValue(content);
-            }
+  public static Matcher<File> fileContentEquals(byte[] content) {
+    return new BaseMatcher<File>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("file content is ").appendValue(content);
+      }
 
-            @Override
-            public boolean matches(Object o) {
-                try {
-                    return Arrays.equals(Files.readAllBytes(((File) o).toPath()), content);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        };
-    }
+      @Override
+      public boolean matches(Object o) {
+        try {
+          return Arrays.equals(Files.readAllBytes(((File) o).toPath()), content);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+  }
 
-    public static Path pathStartsWith(String s) {
-        return argThat(argument -> argument.toString().startsWith(s));
-    }
+  public static Path pathStartsWith(String s) {
+    return argThat(argument -> argument.toString().startsWith(s));
+  }
 
-    public static <T> Matcher<Optional<T>> emptyOptional() {
-        return Matchers.equalTo(Optional.empty());
-    }
+  public static <T> Matcher<Optional<T>> emptyOptional() {
+    return Matchers.equalTo(Optional.empty());
+  }
 
-    @NotNull
-    public static Matcher<Optional<BinaryVersion>> versionMatch(@Nonnull String version) {
-        return new BaseMatcher<Optional<BinaryVersion>>() {
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("value ").appendValue(version);
-            }
+  @NotNull
+  public static Matcher<Optional<BinaryVersion>> versionMatch(@Nonnull String version) {
+    return new BaseMatcher<Optional<BinaryVersion>>() {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("value ").appendValue(version);
+      }
 
-            @Override
-            public boolean matches(Object o) {
-                if (!(o instanceof Optional)) {
-                    return false;
-                }
+      @Override
+      public boolean matches(Object o) {
+        if (!(o instanceof Optional)) {
+          return false;
+        }
 
-                Optional<BinaryVersion> binaryVersions = (Optional<BinaryVersion>) o;
+        Optional<BinaryVersion> binaryVersions = (Optional<BinaryVersion>) o;
 
-                return binaryVersions.get().getVersion().equals(version);
-            }
-        };
-    }
+        return binaryVersions.get().getVersion().equals(version);
+      }
+    };
+  }
 }

--- a/src/test/java/com/tabnine/testUtils/TestData.java
+++ b/src/test/java/com/tabnine/testUtils/TestData.java
@@ -1,64 +1,79 @@
 package com.tabnine.testUtils;
 
-import com.tabnine.binary.fetch.BinaryVersion;
-
-import java.util.List;
-import java.util.stream.Stream;
-
 import static com.tabnine.general.StaticConfig.BINARY_PROTOCOL_VERSION;
 import static java.util.stream.Collectors.toList;
 
+import com.tabnine.binary.fetch.BinaryVersion;
+import java.util.List;
+import java.util.stream.Stream;
+
 public class TestData {
-    public static final String A_REQUEST_TO_TABNINE_BINARY = "{\"request\":{\"Autocomplete\":{\"before\":\"hello\",\"after\":\"\\nhello\",\"filename\":\"/src/test.txt\",\"region_includes_beginning\":true,\"region_includes_end\":true,\"max_num_results\":5,\"offset\":5,\"line\":0,\"character\":5}},\"version\":\"" + BINARY_PROTOCOL_VERSION + "\"}\n";
-    public static final String A_TEST_TXT_FILE = "test.txt";
-    public static final String A_FILE_WITH_NO_EXTENSION = "file_with_no_extension";
-    public static final String SOME_CONTENT = "hello<caret>\nhello";
-    public static final String A_PREDICTION_RESULT = "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"return result\",\"old_suffix\":\"\\\\n\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"11%\"},{\"new_prefix\":\"return result;\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 7%\"}],\"user_message\":[],\"docs\":[]}";
-    public static final String SECOND_PREDICTION_RESULT = "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"test\",\"old_suffix\":\"\\\\n\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"11%\"}],\"user_message\":[],\"docs\":[]}";
-    public static final String THIRD_PREDICTION_RESULT =
-            "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"temp\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"21%\"},{\"new_prefix\":\"temporary\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 17%\"},{\"new_prefix\":\"temporary file\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 13%\"}],\"user_message\":[],\"docs\":[]}";
-    public static final String MULTI_LINE_PREDICTION_RESULT =
-            "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"temp\ntemp2\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"21%\"},{\"new_prefix\":\"temporary\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 17%\"},{\"new_prefix\":\"temporary file\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 13%\"}],\"user_message\":[],\"docs\":[]}";
+  public static final String A_REQUEST_TO_TABNINE_BINARY =
+      "{\"request\":{\"Autocomplete\":{\"before\":\"hello\",\"after\":\"\\nhello\",\"filename\":\"/src/test.txt\",\"region_includes_beginning\":true,\"region_includes_end\":true,\"max_num_results\":5,\"offset\":5,\"line\":0,\"character\":5}},\"version\":\""
+          + BINARY_PROTOCOL_VERSION
+          + "\"}\n";
+  public static final String A_TEST_TXT_FILE = "test.txt";
+  public static final String A_FILE_WITH_NO_EXTENSION = "file_with_no_extension";
+  public static final String SOME_CONTENT = "hello<caret>\nhello";
+  public static final String A_PREDICTION_RESULT =
+      "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"return result\",\"old_suffix\":\"\\\\n\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"11%\"},{\"new_prefix\":\"return result;\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 7%\"}],\"user_message\":[],\"docs\":[]}";
+  public static final String SECOND_PREDICTION_RESULT =
+      "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"test\",\"old_suffix\":\"\\\\n\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"11%\"}],\"user_message\":[],\"docs\":[]}";
+  public static final String THIRD_PREDICTION_RESULT =
+      "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"temp\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"21%\"},{\"new_prefix\":\"temporary\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 17%\"},{\"new_prefix\":\"temporary file\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 13%\"}],\"user_message\":[],\"docs\":[]}";
+  public static final String MULTI_LINE_PREDICTION_RESULT =
+      "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"temp\ntemp2\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"21%\"},{\"new_prefix\":\"temporary\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 17%\"},{\"new_prefix\":\"temporary file\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 13%\"}],\"user_message\":[],\"docs\":[]}";
 
-    public static final int OVERFLOW = 1;
-    public static final String INVALID_RESULT = "Nonsense";
+  public static final int OVERFLOW = 1;
+  public static final String INVALID_RESULT = "Nonsense";
 
-    public static final String A_NON_EXISTING_BINARY_PATH = "test/kaki/pipi";
-    public static final String ANOTHER_VERSION = "1.0.0";
-    public static final String A_VERSION = "0.0.1";
-    public static final String PREFERRED_VERSION = "2.3.1";
-    public static final String PRELATEST_VERSION = "2.20.100";
-    public static final String LATEST_VERSION = "2.30.0";
-    public static final String BETA_VERSION = "3.0.0";
+  public static final String A_NON_EXISTING_BINARY_PATH = "test/kaki/pipi";
+  public static final String ANOTHER_VERSION = "1.0.0";
+  public static final String A_VERSION = "0.0.1";
+  public static final String PREFERRED_VERSION = "2.3.1";
+  public static final String PRELATEST_VERSION = "2.20.100";
+  public static final String LATEST_VERSION = "2.30.0";
+  public static final String BETA_VERSION = "3.0.0";
 
-    public static final int INTERNAL_SERVER_ERROR = 500;
-    public static final byte[] A_BINARY_CONTENT = "A_BINARY_CONTENT".getBytes();
+  public static final int INTERNAL_SERVER_ERROR = 500;
+  public static final byte[] A_BINARY_CONTENT = "A_BINARY_CONTENT".getBytes();
 
-    public static final int EPSILON = 1;
-    public static final String NONE_EXISTING_SERVICE = "http://localhost:10101/";
+  public static final int EPSILON = 1;
+  public static final String NONE_EXISTING_SERVICE = "http://localhost:10101/";
 
-    public static final String SET_STATE_REQUEST =
-            "{\"request\":{\"SetState\":{\"state_type\":{\"Selection\":{\"language\":\"txt\",\"length\":13,\"origin\":\"LOCAL\",\"net_length\":13,\"strength\":\"11%\",\"index\":1,\"line_prefix_length\":5,\"line_net_prefix_length\":5,\"line_suffix_length\":0,\"num_of_suggestions\":2,\"num_of_vanilla_suggestions\":0,\"num_of_deep_local_suggestions\":2,\"num_of_deep_cloud_suggestions\":0,\"num_of_lsp_suggestions\":0,\"suggestions\":[{\"length\":13,\"strength\":\"11%\",\"origin\":\"LOCAL\"},{\"length\":14,\"strength\":\" 7%\",\"origin\":\"LOCAL\"}]}}}},\"version\":\"" + BINARY_PROTOCOL_VERSION + "\"}\n";
-    public static final String NO_EXTENSION_STATE_REQUEST =
-            "{\"request\":{\"SetState\":{\"state_type\":{\"Selection\":{\"language\":\"undefined\",\"length\":13,\"origin\":\"LOCAL\",\"net_length\":13,\"strength\":\"11%\",\"index\":1,\"line_prefix_length\":5,\"line_net_prefix_length\":5,\"line_suffix_length\":0,\"num_of_suggestions\":2,\"num_of_vanilla_suggestions\":0,\"num_of_deep_local_suggestions\":2,\"num_of_deep_cloud_suggestions\":0,\"num_of_lsp_suggestions\":0,\"suggestions\":[{\"length\":13,\"strength\":\"11%\",\"origin\":\"LOCAL\"},{\"length\":14,\"strength\":\" 7%\",\"origin\":\"LOCAL\"}]}}}},\"version\":\"" + BINARY_PROTOCOL_VERSION + "\"}\n";
-    public static final String SET_STATE_RESPONSE = "{\"result\":\"Done\"}";
-    public static final String NULL_RESULT = "null";
-    public static final int INDEX_OF_SOME_VALID_RESULT_BETWEEN_TIMEOUTS = 2;
-    public static final String A_COMMAND = "testing";
+  public static final String SET_STATE_REQUEST =
+      "{\"request\":{\"SetState\":{\"state_type\":{\"Selection\":{\"language\":\"txt\",\"length\":13,\"origin\":\"LOCAL\",\"net_length\":13,\"strength\":\"11%\",\"index\":1,\"line_prefix_length\":5,\"line_net_prefix_length\":5,\"line_suffix_length\":0,\"num_of_suggestions\":2,\"num_of_vanilla_suggestions\":0,\"num_of_deep_local_suggestions\":2,\"num_of_deep_cloud_suggestions\":0,\"num_of_lsp_suggestions\":0,\"suggestions\":[{\"length\":13,\"strength\":\"11%\",\"origin\":\"LOCAL\"},{\"length\":14,\"strength\":\" 7%\",\"origin\":\"LOCAL\"}]}}}},\"version\":\""
+          + BINARY_PROTOCOL_VERSION
+          + "\"}\n";
+  public static final String NO_EXTENSION_STATE_REQUEST =
+      "{\"request\":{\"SetState\":{\"state_type\":{\"Selection\":{\"language\":\"undefined\",\"length\":13,\"origin\":\"LOCAL\",\"net_length\":13,\"strength\":\"11%\",\"index\":1,\"line_prefix_length\":5,\"line_net_prefix_length\":5,\"line_suffix_length\":0,\"num_of_suggestions\":2,\"num_of_vanilla_suggestions\":0,\"num_of_deep_local_suggestions\":2,\"num_of_deep_cloud_suggestions\":0,\"num_of_lsp_suggestions\":0,\"suggestions\":[{\"length\":13,\"strength\":\"11%\",\"origin\":\"LOCAL\"},{\"length\":14,\"strength\":\" 7%\",\"origin\":\"LOCAL\"}]}}}},\"version\":\""
+          + BINARY_PROTOCOL_VERSION
+          + "\"}\n";
+  public static final String SET_STATE_RESPONSE = "{\"result\":\"Done\"}";
+  public static final String NULL_RESULT = "null";
+  public static final int INDEX_OF_SOME_VALID_RESULT_BETWEEN_TIMEOUTS = 2;
+  public static final String A_COMMAND = "testing";
 
-    public static byte[] binaryContentSized(int size) {
-        return new byte[size];
-    }
+  public static byte[] binaryContentSized(int size) {
+    return new byte[size];
+  }
 
-    public static List<BinaryVersion> versions(String... versions) {
-        return Stream.of(versions).map(BinaryVersion::new).collect(toList());
-    }
+  public static List<BinaryVersion> versions(String... versions) {
+    return Stream.of(versions).map(BinaryVersion::new).collect(toList());
+  }
 
-    public static List<BinaryVersion> versionsWithBeta() {
-        return versions(BETA_VERSION, LATEST_VERSION, PRELATEST_VERSION, PREFERRED_VERSION, ANOTHER_VERSION, A_VERSION);
-    }
+  public static List<BinaryVersion> versionsWithBeta() {
+    return versions(
+        BETA_VERSION,
+        LATEST_VERSION,
+        PRELATEST_VERSION,
+        PREFERRED_VERSION,
+        ANOTHER_VERSION,
+        A_VERSION);
+  }
 
-    public static List<BinaryVersion> aVersions() {
-        return versions(LATEST_VERSION, PRELATEST_VERSION, PREFERRED_VERSION, ANOTHER_VERSION, A_VERSION);
-    }
+  public static List<BinaryVersion> aVersions() {
+    return versions(
+        LATEST_VERSION, PRELATEST_VERSION, PREFERRED_VERSION, ANOTHER_VERSION, A_VERSION);
+  }
 }

--- a/src/test/java/com/tabnine/testUtils/WireMockExtension.java
+++ b/src/test/java/com/tabnine/testUtils/WireMockExtension.java
@@ -8,35 +8,36 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * To have multiple instances, use it like so:
- * <pre>
- * {@code
+ *
+ * <pre>{@code
  * @RegisterExtension
  * public WireMockExtension mockServer1 = new WireMockExtension(8081);
  *
  * @RegisterExtension
  * public WireMockExtension mockServer2 = new WireMockExtension(8082);
- * }
- * </pre>
+ * }</pre>
  */
-public class WireMockExtension extends WireMockServer implements BeforeEachCallback, AfterEachCallback {
-    public static final int WIREMOCK_EXTENSION_DEFAULT_PORT = WireMockConfiguration.options().portNumber();
+public class WireMockExtension extends WireMockServer
+    implements BeforeEachCallback, AfterEachCallback {
+  public static final int WIREMOCK_EXTENSION_DEFAULT_PORT =
+      WireMockConfiguration.options().portNumber();
 
-    public WireMockExtension() {
-        super(WIREMOCK_EXTENSION_DEFAULT_PORT);
-    }
+  public WireMockExtension() {
+    super(WIREMOCK_EXTENSION_DEFAULT_PORT);
+  }
 
-    public WireMockExtension(int port) {
-        super(port);
-    }
+  public WireMockExtension(int port) {
+    super(port);
+  }
 
-    @Override
-    public void beforeEach(ExtensionContext context) {
-        this.start();
-    }
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    this.start();
+  }
 
-    @Override
-    public void afterEach(ExtensionContext context) throws Exception {
-        this.stop();
-        this.resetAll();
-    }
+  @Override
+  public void afterEach(ExtensionContext context) throws Exception {
+    this.stop();
+    this.resetAll();
+  }
 }


### PR DESCRIPTION
I formatted all the Java code using google-java-format (link below), and added a job to the ci that checks both Java and Kotlin formatting on every push.

Relevant changes: 
- `ci.yml` - (renamed from `compatibilty-stable.yml` and) added the format check job
- `build.gradle` - added the google-java-format plugin

### Instructions
- To run the formatter locally: 
  - Java: `./gradlew goJF`
  - Kotlin: `./gradlew ktlintFormat`
- To check formatting locally: 
  - Java: `./gradlew verGJF --warning-mode all`
  - Kotlin: `./gradlew ktlintCheck `
- To use the formatter on IJ: Install the [google-java-format](https://plugins.jetbrains.com/plugin/8527-google-java-format/) plugin, and follow the instructions [here](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides) - it should replace the default `Format Code` action.