### PR TITLE
change AppSettingsState component name to avoid collisions

### DIFF
--- a/src/main/java/com/tabnine/userSettings/AppSettingsState.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsState.kt
@@ -18,7 +18,7 @@ val settingsDefaultColor = GraphicsUtils.niceContrastColor.rgb
  * The [State] and [Storage] annotations define the name of the data and the file name where
  * these persistent application settings are stored.
  */
-@State(name = "org.intellij.sdk.settings.AppSettingsState", storages = [Storage("TabnineSettings.xml")])
+@State(name = "com.tabnine.userSettings.AppSettingsState", storages = [Storage("TabnineSettings.xml")])
 class AppSettingsState : PersistentStateComponent<AppSettingsState?> {
     var useDefaultColor: Boolean = false
     var logFilePath: String = ""


### PR DESCRIPTION
the previous name was one taken from a general example somewhere on the internet - so if any other random plugin copied the same example we'll have collisions.
### Note
This is a breaking change, i.e user settings will be reset to default.
We only have the log file path & inline color there, so i dont think its too much trouble, but worth mentioning.