### PR TITLE
remove debouncer from inline

### DIFF
--- a/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
+++ b/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
@@ -45,18 +45,6 @@ public class TabnineDocumentListener implements DocumentListener {
       return;
     }
 
-    if (ApplicationManager.getApplication().isUnitTestMode()) {
-      documentChangedDebounced(event, eventNewText);
-    } else {
-      alarm.cancelAllRequests();
-      // Give enough time to cancel previous requests in cases where the document listener is called
-      // too often
-      // (e.g. on newline+indents, auto-filling pairs etc.).
-      alarm.addRequest(() -> documentChangedDebounced(event, eventNewText), MINIMAL_DELAY_MILLIS);
-    }
-  }
-
-  private void documentChangedDebounced(@NotNull DocumentEvent event, String eventNewText) {
     Document document = event.getDocument();
 
     if (ObjectUtils.doIfCast(document, DocumentEx.class, DocumentEx::isInBulkUpdate)

--- a/src/main/java/com/tabnine/inline/listeners/InlineCaretListener.kt
+++ b/src/main/java/com/tabnine/inline/listeners/InlineCaretListener.kt
@@ -3,6 +3,7 @@ package com.tabnine.inline.listeners
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.CaretListener
+import com.intellij.openapi.util.TextRange
 import com.tabnine.inline.CompletionPreview
 
 class InlineCaretListener : CaretListener {
@@ -11,7 +12,20 @@ class InlineCaretListener : CaretListener {
             return
         }
         CompletionPreview.findCompletionPreview(event.editor)?.let { preview ->
-            if (preview.isCurrentlyDisplayingInlays) preview.clear()
+            if (preview.isCurrentlyDisplayingInlays && !changeIsASingleCharacterTyping(event)) preview.clear()
         }
     }
+}
+
+private fun changeIsASingleCharacterTyping(event: CaretEvent): Boolean {
+    val editor = event.editor
+    val lineDiff = event.newPosition.line - event.oldPosition.line
+    val charDiff = event.newPosition.column - event.oldPosition.column
+    if (lineDiff != 0 || charDiff != 1) {
+        return false
+    }
+    val textInsideChangedRange: String = editor.getDocument().getText(
+        TextRange(event.oldPosition.column, event.newPosition.column)
+    )
+    return !textInsideChangedRange.trim().isEmpty()
 }

--- a/src/main/java/com/tabnine/inline/listeners/InlineKeyListener.kt
+++ b/src/main/java/com/tabnine/inline/listeners/InlineKeyListener.kt
@@ -11,12 +11,7 @@ class InlineKeyListener(private val editor: Editor) : KeyAdapter() {
         if (!preview.isCurrentlyDisplayingInlays) return
 
         val key = event.keyCode
-        // do not interfere with inline shortcuts
-        if (key == KeyEvent.VK_ALT ||
-            key == KeyEvent.VK_OPEN_BRACKET ||
-            key == KeyEvent.VK_CLOSE_BRACKET ||
-            key == KeyEvent.VK_TAB
-        ) return
-        preview.clear()
+        if (key == KeyEvent.VK_BACK_SPACE || key == KeyEvent.VK_DELETE)
+            preview.clear()
     }
 }


### PR DESCRIPTION
- removed the debouncer from all relevant places - the `TabnineDocumentListener` and `CompletionPreview`
- changed key listener to only clear preview on delete / backspace
- changed caret listener to only clear if the change is not a single char typing change 