### PR TITLE
fix snippets tabs

### DIFF
--- a/src/main/java/com/tabnine/inline/render/BlockElementRenderer.kt
+++ b/src/main/java/com/tabnine/inline/render/BlockElementRenderer.kt
@@ -34,9 +34,12 @@ class BlockElementRenderer(
         color = color ?: GraphicsUtils.color
         g.color = color
         g.font = GraphicsUtils.getFont(editor, deprecated)
+        val tabSpaces = " ".repeat(tabSize(editor))
+
         blockText.withIndex().forEach { (i, line) ->
+            val lineWithSpaces = line.replace("\t", tabSpaces)
             g.drawString(
-                line,
+                lineWithSpaces,
                 0,
                 targetRegion.y + i * editor.lineHeight + editor.ascent
             )

--- a/src/main/java/com/tabnine/inline/render/GraphicsUtils.kt
+++ b/src/main/java/com/tabnine/inline/render/GraphicsUtils.kt
@@ -2,6 +2,8 @@ package com.tabnine.inline.render
 
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.EditorFontType
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings
 import com.intellij.ui.JBColor
 import com.tabnine.userSettings.AppSettingsState
 import java.awt.Color
@@ -53,4 +55,12 @@ object GraphicsUtils {
                 (color.blue * color.blue * 0.068)
         )
     }
+}
+
+fun tabSize(editor: Editor): Int {
+    val commonCodeStyleSettings = editor.project
+        ?.let { PsiDocumentManager.getInstance(it).getPsiFile(editor.document) }
+        ?.let { CommonCodeStyleSettings(it.language) }
+
+    return commonCodeStyleSettings?.indentOptions?.TAB_SIZE ?: editor.settings.getTabSize(editor.project)
 }


### PR DESCRIPTION
### What?
When showing inline completions, replacing `\t`s with the appropriate amount of spaces.

### Why?
It happens to be the case that `Graphics.drawString` counts `\t` as 0 length - you can also check that `FontMetrics.stringWidth` returns 0 for `\t`.

Before:
![image](https://user-images.githubusercontent.com/67855609/165810905-774f4201-7b6c-4172-831a-6a239964704d.png)

After:
![image](https://user-images.githubusercontent.com/67855609/165810980-5604036c-f8a9-47b2-949b-df7d45d46e8d.png)
