### PR TITLE
make postprocess work for non-empty lines

### DIFF
--- a/src/main/java/com/tabnine/binary/requests/autocomplete/CompletionPostprocess.kt
+++ b/src/main/java/com/tabnine/binary/requests/autocomplete/CompletionPostprocess.kt
@@ -4,9 +4,8 @@ import com.tabnine.general.CompletionKind
 
 fun postprocess(request: AutocompleteRequest, result: AutocompleteResponse, tabSize: Int) {
     val resultsSubset = result.results.filter { it.completion_kind == CompletionKind.Snippet }
-    if (resultsSubset.isEmpty()) {
-        return
-    }
+    if (resultsSubset.isEmpty()) return
+
     val tabsInSpaces = " ".repeat(tabSize)
     resultsSubset.forEach { it.new_prefix = it.new_prefix.replace("\t", tabsInSpaces) }
 
@@ -28,11 +27,8 @@ fun lastLineIndentation(value: String, tabsInSpaces: String): Int? {
     if (lastLineStartIndex == -1) return null
 
     val lastLine = value.substring(lastLineStartIndex + 1).replace("\t", tabsInSpaces)
-    if (lastLine.isBlank()) {
-        return lastLine.length
-    }
 
-    return null
+    return lastLine.length - lastLine.trimStart().length
 }
 
 /**

--- a/src/test/java/com/tabnine/plugin/completionPostProcess/Mixed.kt
+++ b/src/test/java/com/tabnine/plugin/completionPostProcess/Mixed.kt
@@ -5,6 +5,14 @@ import org.junit.Test
 
 class Mixed {
     @Test
+    fun shouldReindentAndTrimCorrectlyWhereLastLineHasText() {
+        val request = request("def a():\n  i")
+        val response = snippetResponse("if x > 2:\n\t  return x\n\t.return None\ndef b():\n  return 3")
+        postprocess(request, response, TAB_SIZE)
+
+        assertNewPrefix(response, "if x > 2:\n    return x\n  .return None")
+    }
+    @Test
     fun shouldReindentAndTrimCorrectlyWhereIndentationIsReseeding() {
         val request = request("def a():\n  ")
         val response = snippetResponse("if x > 2:\n\t  return x\n\t.return None\ndef b():\n  return 3")

--- a/src/test/java/com/tabnine/plugin/completionPostProcess/Spaces.kt
+++ b/src/test/java/com/tabnine/plugin/completionPostProcess/Spaces.kt
@@ -5,6 +5,14 @@ import org.junit.Test
 
 class Spaces {
     @Test
+    fun shouldReindentAndTrimCorrectlyWhereLastLineHasText() {
+        val request = request("def a():\n  i")
+        val response = snippetResponse("if x > 2:\n    return x\n  .return None\ndef b():\n  return 3")
+        postprocess(request, response, TAB_SIZE)
+
+        assertNewPrefix(response, "if x > 2:\n    return x\n  .return None")
+    }
+    @Test
     fun shouldTrimCorrectlyWhereIndentationIsReseeding() {
         val request = request("def a():\n  ")
         val response = snippetResponse("if x > 2:\n    return x\n  .return None\ndef b():\n  return 3")

--- a/src/test/java/com/tabnine/plugin/completionPostProcess/Tabs.kt
+++ b/src/test/java/com/tabnine/plugin/completionPostProcess/Tabs.kt
@@ -5,6 +5,14 @@ import org.junit.Test
 
 class Tabs {
     @Test
+    fun shouldReindentAndTrimCorrectlyWhereLastLineHasText() {
+        val request = request("def a():\n\ti")
+        val response = snippetResponse("if x > 2:\n\t\treturn x\n\t.return None\ndef b():\n\treturn 3")
+        postprocess(request, response, TAB_SIZE)
+
+        assertNewPrefix(response, "if x > 2:\n    return x\n  .return None")
+    }
+    @Test
     fun shouldReindentAndTrimCorrectlyWhereIndentationIsReseeding() {
         val request = request("def a():\n\t")
         val response = snippetResponse("if x > 2:\n\t\treturn x\n\t.return None\ndef b():\n\treturn 3")


### PR DESCRIPTION
### The Bug
Where the last line is empty, the trimming is done correctly:
![image](https://user-images.githubusercontent.com/67855609/169288065-7844d6e1-65cb-4c39-b2b3-7e8ca6b2e187.png)

But where you start writing a prefix which matches the snippet, the `postprocess` function is skipping the trimming part:
![image](https://user-images.githubusercontent.com/67855609/169288349-6818bea6-e167-4ba9-a209-051321b5d42e.png)

### Solution
Calculate the indentation regardless of any subsequent text in the last line, there's no need to guard this function with the `if (lastLine.isBlank())`.