### PR TITLE
uninstall fix - stop time check on the newer version zip

### DIFF
--- a/src/main/java/com/tabnine/UninstallListener.kt
+++ b/src/main/java/com/tabnine/UninstallListener.kt
@@ -78,6 +78,7 @@ class UninstallListener(
                     match.value.substring(TABNINE_JAR_NAME.length, match.value.length - JAR_SUFFIX.length)
                 SemVer.parseFromText(fileVersion)
             }?.let { semver ->
+                Logger.getInstance(javaClass).info("Successfully parsed file version from the zip file: $semver ==> Comparing it to current version: $version")
                 semver > version
             } ?: false
 }

--- a/src/main/java/com/tabnine/general/PluginsZipReader.kt
+++ b/src/main/java/com/tabnine/general/PluginsZipReader.kt
@@ -1,6 +1,8 @@
 package com.tabnine.general
 
 import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.diagnostic.Logger
+import com.tabnine.UninstallListener
 import java.io.File
 import java.util.zip.ZipFile
 
@@ -10,8 +12,13 @@ data class TabnineZipFile(val contentFilenames: List<String>, val creationTimeMi
 
 fun readTempTabninePluginZip(): TabnineZipFile? {
     try {
-        val file = File(PathManager.getPluginTempPath(), TABNINE_ZIP_FILE)
-        if (!file.exists()) return null
+        val pluginTempPath = PathManager.getPluginTempPath()
+        Logger.getInstance(UninstallListener::class.java).info("Looking for $TABNINE_ZIP_FILE in: $pluginTempPath")
+        val file = File(pluginTempPath, TABNINE_ZIP_FILE)
+        if (!file.exists()) {
+            Logger.getInstance(UninstallListener::class.java).warn("Could not find $TABNINE_ZIP_FILE in $pluginTempPath")
+            return null
+        }
 
         val contentFilenames = ZipFile(file).use { zip ->
             zip.entries().toList().map { it.name }

--- a/src/test/kotlin/integration/uninstall/UninstallListenerTest.kt
+++ b/src/test/kotlin/integration/uninstall/UninstallListenerTest.kt
@@ -101,14 +101,4 @@ class UninstallListenerTest {
 
         driver.verifyUninstallReporterFallback()
     }
-
-    @Test
-    fun shouldFireUninstallRequestWhenNewerZipIsStale() {
-        driver.mockExistingPluginZipFiles(listOf("TabNine-0.0.1.zip"), stale = true)
-        driver.mockUninstallResponse()
-
-        uninstallListener.uninstall(PluginDescriptorMock("0.0.0"))
-
-        driver.verifyUninstallRequestFired()
-    }
 }


### PR DESCRIPTION
Since the latest alpha release caused FP uninstall events internally (@boaz-codota and @amircodota) - 
And since this code has been manually and automatically tested pretty thoroughly -
My current suspicion is that the "stale" check I added causes the FP.
IJ downloads the new plugin version when it decides to check for updates, which is not necessarily related to when the users wants to update.

Note that without the "stale" check, there could be TN now - users who had the new plugin version downloaded and decided to uninstall will not fire an uninstall event. 