### PR TITLE
fix postprocess - catch brackets

### DIFF
--- a/src/main/java/com/tabnine/binary/requests/autocomplete/CompletionPostprocess.kt
+++ b/src/main/java/com/tabnine/binary/requests/autocomplete/CompletionPostprocess.kt
@@ -37,7 +37,7 @@ fun lastLineIndentation(value: String, tabsInSpaces: String): Int? {
  */
 fun constructRegex(indentation: Int): Regex {
     val upperLimit = indentation - 1
-    return Regex("""^ {0,$upperLimit}[\w\n]+""", RegexOption.MULTILINE)
+    return Regex("""^ {0,$upperLimit}[^\s\n]+""", RegexOption.MULTILINE)
 }
 
 /**

--- a/src/test/java/com/tabnine/plugin/completionPostProcess/Mixed.kt
+++ b/src/test/java/com/tabnine/plugin/completionPostProcess/Mixed.kt
@@ -66,4 +66,16 @@ class Mixed {
 
         assertNewPrefix(response, newPrefix)
     }
+
+    @Test
+    fun bracketsFixture() {
+        val request = request("fn a() {\n\t")
+        val response = snippetResponse("if a {\n  \treturn true\n  }\n\treturn false\n\t}\n}")
+        postprocess(request, response, TAB_SIZE)
+
+        assertNewPrefix(
+            response,
+            "if a {\n    return true\n  }\n  return false\n  }"
+        )
+    }
 }

--- a/src/test/java/com/tabnine/plugin/completionPostProcess/Spaces.kt
+++ b/src/test/java/com/tabnine/plugin/completionPostProcess/Spaces.kt
@@ -66,4 +66,16 @@ class Spaces {
 
         assertNewPrefix(response, newPrefix)
     }
+
+    @Test
+    fun bracketsFixture() {
+        val request = request("fn a() {\n  ")
+        val response = snippetResponse("if a {\n    return true\n  }\n  return false\n  }\n}")
+        postprocess(request, response, TAB_SIZE)
+
+        assertNewPrefix(
+            response,
+            "if a {\n    return true\n  }\n  return false\n  }"
+        )
+    }
 }

--- a/src/test/java/com/tabnine/plugin/completionPostProcess/Tabs.kt
+++ b/src/test/java/com/tabnine/plugin/completionPostProcess/Tabs.kt
@@ -67,4 +67,16 @@ class Tabs {
 
         assertNewPrefix(response, newPrefix)
     }
+
+    @Test
+    fun bracketsFixture() {
+        val request = request("fn a() {\n\t")
+        val response = snippetResponse("if a {\n\t\treturn true\n\t}\n\treturn false\n\t}\n}")
+        postprocess(request, response, TAB_SIZE)
+
+        assertNewPrefix(
+            response,
+            "if a {\n    return true\n  }\n  return false\n  }"
+        )
+    }
 }


### PR DESCRIPTION
The regex didn't catch `}` and such, only alpha-numeric chars.
I replaced the `\w` with `^\s` ("not whitespace") to catch all these cases