### PR TITLE
fix snippet shown event

### DIFF
--- a/src/main/java/com/tabnine/binary/requests/notifications/shown/SnippetShownRequest.kt
+++ b/src/main/java/com/tabnine/binary/requests/notifications/shown/SnippetShownRequest.kt
@@ -5,7 +5,7 @@ import com.tabnine.binary.requests.autocomplete.SnippetContext
 import com.tabnine.binary.requests.selection.SetStateBinaryResponse
 import com.tabnine.general.StaticConfig
 
-data class SnippetShownRequest(var filename: String, var snippetContext: SnippetContext) : BinaryRequest<SetStateBinaryResponse> {
+data class SnippetShownRequest(var filename: String, var snippet_context: SnippetContext) : BinaryRequest<SetStateBinaryResponse> {
     override fun response(): Class<SetStateBinaryResponse> {
         return SetStateBinaryResponse::class.java
     }


### PR DESCRIPTION
the context field was being sent with camelCase, while the binary expected snake_case.
this, combined with the relevant binary PR created the situation where no snippet related fields where added to the event 