### PR TITLE
change rendering mode reporting

### DIFF
--- a/src/main/java/com/tabnine/binary/requests/selection/SelectionRequest.java
+++ b/src/main/java/com/tabnine/binary/requests/selection/SelectionRequest.java
@@ -2,7 +2,7 @@ package com.tabnine.binary.requests.selection;
 
 import com.google.gson.annotations.SerializedName;
 import com.tabnine.binary.requests.autocomplete.SnippetContext;
-import com.tabnine.capabilities.SuggestionsMode;
+import com.tabnine.capabilities.RenderingMode;
 import com.tabnine.general.CompletionKind;
 import com.tabnine.general.CompletionOrigin;
 import java.util.List;
@@ -57,5 +57,5 @@ public class SelectionRequest {
 
   @Nullable
   @SerializedName(value = "suggestion_rendering_mode")
-  public SuggestionsMode suggestionRenderingMode;
+  public RenderingMode suggestionRenderingMode;
 }

--- a/src/main/java/com/tabnine/capabilities/RenderingMode.java
+++ b/src/main/java/com/tabnine/capabilities/RenderingMode.java
@@ -1,0 +1,14 @@
+package com.tabnine.capabilities;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Used to mark which rendering option was actually used by the UI for - to be sent in the selection
+ * report
+ */
+public enum RenderingMode {
+  @SerializedName(value = "Inline")
+  INLINE,
+  @SerializedName(value = "Popup")
+  AUTOCOMPLETE,
+}

--- a/src/main/java/com/tabnine/capabilities/SuggestionsMode.java
+++ b/src/main/java/com/tabnine/capabilities/SuggestionsMode.java
@@ -1,9 +1,7 @@
 package com.tabnine.capabilities;
 
-import com.google.gson.annotations.SerializedName;
-
+/** This is being crated according to the Capabilities from the binary */
 public enum SuggestionsMode {
-  @SerializedName(value = "Inline")
   INLINE {
     @Override
     public boolean isInlineEnabled() {
@@ -15,7 +13,6 @@ public enum SuggestionsMode {
       return false;
     }
   },
-  @SerializedName(value = "Popup")
   AUTOCOMPLETE {
     @Override
     public boolean isInlineEnabled() {
@@ -27,7 +24,6 @@ public enum SuggestionsMode {
       return true;
     }
   },
-  @SerializedName(value = "Hybrid")
   HYBRID {
     @Override
     public boolean isInlineEnabled() {

--- a/src/main/java/com/tabnine/general/DependencyContainer.java
+++ b/src/main/java/com/tabnine/general/DependencyContainer.java
@@ -38,10 +38,7 @@ public class DependencyContainer {
   public static CompletionPreviewListener instanceOfCompletionPreviewListener() {
     final BinaryRequestFacade binaryRequestFacade = instanceOfBinaryRequestFacade();
     return new CompletionPreviewListener(
-        binaryRequestFacade,
-        new StatusBarUpdater(binaryRequestFacade),
-        new HoverUpdater(),
-        instanceOfSuggestionsModeService());
+        binaryRequestFacade, new StatusBarUpdater(binaryRequestFacade), new HoverUpdater());
   }
 
   public static BinaryRequestFacade instanceOfBinaryRequestFacade() {

--- a/src/main/java/com/tabnine/inline/CompletionPreview.java
+++ b/src/main/java/com/tabnine/inline/CompletionPreview.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.util.Key;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.refactoring.rename.inplace.InplaceRefactoring;
+import com.tabnine.capabilities.RenderingMode;
 import com.tabnine.general.DependencyContainer;
 import com.tabnine.inline.listeners.InlineCaretListener;
 import com.tabnine.inline.listeners.InlineFocusListener;
@@ -157,6 +158,7 @@ public class CompletionPreview implements Disposable {
         this.editor,
         completion,
         file.getName(),
+        RenderingMode.INLINE,
         (selection -> {
           selection.index = currentIndex;
           SelectionUtil.addSuggestionsCount(selection, completions);

--- a/src/main/java/com/tabnine/selections/CompletionPreviewListener.java
+++ b/src/main/java/com/tabnine/selections/CompletionPreviewListener.java
@@ -4,7 +4,7 @@ import com.intellij.openapi.editor.Editor;
 import com.tabnine.binary.BinaryRequestFacade;
 import com.tabnine.binary.requests.selection.SelectionRequest;
 import com.tabnine.binary.requests.selection.SetStateBinaryRequest;
-import com.tabnine.capabilities.SuggestionsModeService;
+import com.tabnine.capabilities.RenderingMode;
 import com.tabnine.hover.HoverUpdater;
 import com.tabnine.prediction.TabNineCompletion;
 import com.tabnine.statusBar.StatusBarUpdater;
@@ -14,23 +14,21 @@ public class CompletionPreviewListener {
   private final BinaryRequestFacade binaryRequestFacade;
   private final StatusBarUpdater statusBarUpdater;
   private final HoverUpdater hoverUpdater;
-  private final SuggestionsModeService suggestionsModeService;
 
   public CompletionPreviewListener(
       BinaryRequestFacade binaryRequestFacade,
       StatusBarUpdater statusBarUpdater,
-      HoverUpdater hoverUpdater,
-      SuggestionsModeService suggestionsModeService) {
+      HoverUpdater hoverUpdater) {
     this.binaryRequestFacade = binaryRequestFacade;
     this.statusBarUpdater = statusBarUpdater;
     this.hoverUpdater = hoverUpdater;
-    this.suggestionsModeService = suggestionsModeService;
   }
 
   public void executeSelection(
       Editor editor,
       TabNineCompletion completion,
       String filename,
+      RenderingMode renderingMode,
       Consumer<SelectionRequest> extendSelectionRequest) {
     SelectionRequest selection = new SelectionRequest();
 
@@ -45,7 +43,7 @@ public class CompletionPreviewListener {
     selection.strength = SelectionUtil.getStrength(completion);
     selection.completionKind = completion.completionKind;
     selection.snippetContext = completion.snippet_context;
-    selection.suggestionRenderingMode = suggestionsModeService.getSuggestionMode();
+    selection.suggestionRenderingMode = renderingMode;
     extendSelectionRequest.accept(selection);
 
     binaryRequestFacade.executeRequest(new SetStateBinaryRequest(selection));

--- a/src/main/java/com/tabnine/selections/TabNineLookupListener.java
+++ b/src/main/java/com/tabnine/selections/TabNineLookupListener.java
@@ -8,6 +8,7 @@ import com.intellij.codeInsight.lookup.impl.LookupImpl;
 import com.tabnine.binary.BinaryRequestFacade;
 import com.tabnine.binary.requests.selection.SelectionRequest;
 import com.tabnine.binary.requests.selection.SetStateBinaryRequest;
+import com.tabnine.capabilities.RenderingMode;
 import com.tabnine.capabilities.SuggestionsModeService;
 import com.tabnine.prediction.TabNineCompletion;
 import com.tabnine.statusBar.StatusBarUpdater;
@@ -76,7 +77,7 @@ public class TabNineLookupListener implements LookupListener {
       selection.strength = SelectionUtil.getStrength(item);
       selection.completionKind = item.completionKind;
       selection.snippetContext = item.snippet_context;
-      selection.suggestionRenderingMode = suggestionsModeService.getSuggestionMode();
+      selection.suggestionRenderingMode = RenderingMode.AUTOCOMPLETE;
       SelectionUtil.addSuggestionsCount(selection, suggestions);
 
       binaryRequestFacade.executeRequest(new SetStateBinaryRequest(selection));


### PR DESCRIPTION
Until now it reported the rendering mode determined by the binary, but this is not what we're looking for with this report - we want to know per selection how it was **actually** rendered - so sending "hybrid" doesn't say anything.

I created another enum which represents the actual rendering that took affect, and separated it from the "suggestions mode" which the binary determines.