### PR TITLE
fix invalid range exception

### DIFF
--- a/src/main/java/com/tabnine/inline/CompletionUtils.kt
+++ b/src/main/java/com/tabnine/inline/CompletionUtils.kt
@@ -11,7 +11,6 @@ object CompletionUtils {
 
     @JvmStatic
     fun isValidDocumentChange(editor: Editor, document: Document, newOffset: Int, previousOffset: Int): Boolean {
-
         if (newOffset < 0 || previousOffset > newOffset) return false
 
         val addedText = document.getText(TextRange(previousOffset, newOffset))

--- a/src/main/java/com/tabnine/inline/CompletionUtils.kt
+++ b/src/main/java/com/tabnine/inline/CompletionUtils.kt
@@ -11,6 +11,8 @@ object CompletionUtils {
 
     @JvmStatic
     fun isValidDocumentChange(editor: Editor, document: Document, newOffset: Int, previousOffset: Int): Boolean {
+        if (newOffset < 0 || newOffset > previousOffset) return false
+
         val addedText = document.getText(TextRange(previousOffset, newOffset))
         return (
             isValidMidlinePosition(document, newOffset) &&

--- a/src/main/java/com/tabnine/inline/CompletionUtils.kt
+++ b/src/main/java/com/tabnine/inline/CompletionUtils.kt
@@ -11,7 +11,8 @@ object CompletionUtils {
 
     @JvmStatic
     fun isValidDocumentChange(editor: Editor, document: Document, newOffset: Int, previousOffset: Int): Boolean {
-        if (newOffset < 0 || newOffset > previousOffset) return false
+
+        if (newOffset < 0 || previousOffset > newOffset) return false
 
         val addedText = document.getText(TextRange(previousOffset, newOffset))
         return (


### PR DESCRIPTION
After Updating my alpha plugin from @yairco1990 's last pr (#398), my IDE started to get significantly slower, and I saw this error message occur several times:
```
2022-10-25 00:47:07,401 [ 496260] SEVERE - #c.i.o.a.i.FlushQueue - Invalid range specified: (1089, 976)
....
```
![image](https://user-images.githubusercontent.com/67855609/197639022-bceda71e-fb5e-420c-b400-6ea68384043f.png)

The conditions I added are matching the assertion being done at the `TextRange.java` class: 
```java
private static boolean isProperRange(int startOffset, int endOffset) {
    return startOffset <= endOffset && startOffset >= 0;
  }
```