### PR TITLE
DEV2-1681 - "Getting started" improvements

### DIFF
--- a/src/main/java/com/tabnine/binary/fetch/BootstrapperSupport.java
+++ b/src/main/java/com/tabnine/binary/fetch/BootstrapperSupport.java
@@ -2,8 +2,8 @@ package com.tabnine.binary.fetch;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.util.text.SemVer;
-import com.tabnine.general.GettingStartedManagerKt;
 import com.tabnine.general.StaticConfig;
+import com.tabnine.lifecycle.PluginInstalledNotifier;
 import java.util.Optional;
 import java.util.prefs.Preferences;
 
@@ -19,10 +19,7 @@ public class BootstrapperSupport {
     if (localBootstrapVersion.isPresent()) {
       return localBootstrapVersion;
     }
-    if (ApplicationManager.getApplication() != null
-        && !ApplicationManager.getApplication().isUnitTestMode()) {
-      GettingStartedManagerKt.handleFirstTimePreview();
-    }
+    notifyPluginInstalled();
     return downloadRemoteVersion(binaryRemoteSource, bundleDownloader);
   }
 
@@ -63,5 +60,17 @@ public class BootstrapperSupport {
         .fetchPreferredVersion(StaticConfig.getTabNineBundleVersionUrl())
         .flatMap(bundleDownloader::downloadAndExtractBundle)
         .map(BootstrapperSupport::savePreferredBootstrapVersion);
+  }
+
+  private static void notifyPluginInstalled() {
+    if (ApplicationManager.getApplication() != null) {
+      ApplicationManager.getApplication()
+          .invokeLater(
+              () ->
+                  ApplicationManager.getApplication()
+                      .getMessageBus()
+                      .syncPublisher(PluginInstalledNotifier.PLUGIN_INSTALLED_TOPIC)
+                      .onPluginInstalled());
+    }
   }
 }

--- a/src/main/java/com/tabnine/binary/requests/statusBar/StatusBarInteractionRequest.java
+++ b/src/main/java/com/tabnine/binary/requests/statusBar/StatusBarInteractionRequest.java
@@ -7,7 +7,7 @@ import com.tabnine.binary.BinaryRequest;
 import com.tabnine.binary.requests.selection.SetStateBinaryResponse;
 import org.jetbrains.annotations.NotNull;
 
-public class ConfigOpenedFromStatusBarRequest implements BinaryRequest<SetStateBinaryResponse> {
+public class StatusBarInteractionRequest implements BinaryRequest<SetStateBinaryResponse> {
   @Override
   public Class<SetStateBinaryResponse> response() {
     return SetStateBinaryResponse.class;

--- a/src/main/java/com/tabnine/general/BrowserUtilsService.kt
+++ b/src/main/java/com/tabnine/general/BrowserUtilsService.kt
@@ -1,0 +1,73 @@
+package com.tabnine.general
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
+import com.intellij.openapi.fileEditor.impl.HTMLEditorProvider
+import com.intellij.openapi.project.Project
+import com.tabnine.binary.exceptions.NotSupportedByIDEVersion
+import java.lang.reflect.Method
+import javax.swing.SwingConstants
+
+class BrowserUtilsService {
+    companion object {
+        @JvmStatic
+        val instance: BrowserUtilsService
+            get() = ServiceManager.getService(BrowserUtilsService::class.java)
+    }
+
+    fun openPageOnFocusedProject(pageTitle: String, pageUrl: String) {
+        val focusedProject = getFocusedProject()
+        if (focusedProject.isPresent) {
+            openUrlOnSplitWindow(focusedProject.get(), pageTitle, pageUrl)
+        } else {
+            openUrlOnBrowser(pageUrl)
+        }
+    }
+
+    fun openUrlOnSplitWindow(project: Project, pageTitle: String, url: String) {
+        try {
+            val openEditorMethod = getOpenEditorMethod()
+            val fileEditorManagerEx = FileEditorManagerEx.getInstanceEx(project)
+            // this causes the current focused file to be displayed twice - in the old and in the new editor
+            fileEditorManagerEx.createSplitter(
+                SwingConstants.VERTICAL, fileEditorManagerEx.currentWindow
+            )
+            // save the current focused file, as we want to close it after the web page is loaded
+            val currentFocusedFile = fileEditorManagerEx.currentWindow?.selectedFile
+            // the focus moves to the web page
+            openEditorMethod.invoke(
+                null,
+                project,
+                pageTitle,
+                url,
+                null
+            )
+            // close the duplicated file in the new editor and set the web page to be the single tab
+            if (currentFocusedFile != null) {
+                fileEditorManagerEx.currentWindow?.closeFile(currentFocusedFile)
+            }
+        } catch (e: NotSupportedByIDEVersion) {
+            openUrlOnBrowser(url)
+        }
+    }
+
+    fun openUrlOnBrowser(url: String) {
+        BrowserUtil.browse(url)
+    }
+
+    @Throws(NotSupportedByIDEVersion::class)
+    private fun getOpenEditorMethod(): Method {
+        return try {
+            HTMLEditorProvider::class.java.getMethod(
+                "openEditor",
+                Project::class.java,
+                String::class.java,
+                String::class.java,
+                String::class.java
+            )
+        } catch (e: Exception) {
+            throw NotSupportedByIDEVersion()
+        }
+    }
+}

--- a/src/main/java/com/tabnine/general/GettingStartedManager.kt
+++ b/src/main/java/com/tabnine/general/GettingStartedManager.kt
@@ -1,99 +1,69 @@
 package com.tabnine.general
 
-import com.intellij.ide.BrowserUtil
 import com.intellij.ide.util.PropertiesComponent
-import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
-import com.intellij.openapi.fileEditor.impl.HTMLEditorProvider
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.PreloadingActivity
+import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.ProjectManager
-import com.tabnine.binary.exceptions.NotSupportedByIDEVersion
 import com.tabnine.general.Utils.executeUIThreadWithDelay
-import java.lang.reflect.Method
-import java.util.Arrays
+import com.tabnine.lifecycle.PluginInstalledNotifier
 import java.util.concurrent.TimeUnit
-import javax.swing.SwingConstants
 
 const val PAGE_TITLE = "Tabnine - Getting Started"
 const val PAGE_URL = "https://www.tabnine.com/getting-started/intellij?origin=ide"
 const val IS_GETTING_STARTED_OPENED_KEY = "is-getting-started-opened"
 const val AFTER_PROJECT_OPENED_DELAY_SECONDS = 15L
 
-fun handleFirstTimePreview() {
-    if (!isPageShown()) {
+class GettingStartedManager : PreloadingActivity(), Disposable {
+    private val browserUtilsService = BrowserUtilsService.instance
+
+    companion object {
+        @JvmStatic
+        val instance = GettingStartedManager()
+    }
+
+    override fun preload(indicator: ProgressIndicator) {
+        registerForPluginInstalled()
+    }
+
+    private fun registerForPluginInstalled() {
+        ApplicationManager.getApplication()
+            .messageBus
+            .connect(this)
+            .subscribe(
+                PluginInstalledNotifier.PLUGIN_INSTALLED_TOPIC,
+                PluginInstalledNotifier {
+                    handleFirstTimePreview()
+                }
+            )
+    }
+
+    private fun handleFirstTimePreview() {
         executeUIThreadWithDelay(
-            { openPageOnAllProjects() },
+            {
+                if (!isPageShown()) {
+                    browserUtilsService.openPageOnFocusedProject(PAGE_TITLE, PAGE_URL)
+                    markPageAsShown()
+                }
+            },
             AFTER_PROJECT_OPENED_DELAY_SECONDS,
             TimeUnit.SECONDS
         )
     }
-}
-
-fun openPageOnProject(project: Project) {
-    try {
-        val openEditorMethod = getOpenEditorMethod()
-        val fileEditorManagerEx = FileEditorManagerEx.getInstanceEx(project)
-        // this causes the current focused file to be displayed twice - in the old and in the new editor
-        fileEditorManagerEx.createSplitter(
-            SwingConstants.VERTICAL, fileEditorManagerEx.currentWindow
-        )
-        // save the current focused file, as we want to close it after the web page is loaded
-        val currentFocusedFile = fileEditorManagerEx.currentWindow?.selectedFile
-        // the focus moves to the web page
-        openEditorMethod.invoke(
-            null,
-            project,
-            PAGE_TITLE,
-            PAGE_URL,
-            null
-        )
-        // close the duplicated file in the new editor and set the web page to be the single tab
-        if (currentFocusedFile != null) {
-            fileEditorManagerEx.currentWindow?.closeFile(currentFocusedFile)
-        }
-    } catch (e: NotSupportedByIDEVersion) {
-        BrowserUtil.browse(PAGE_URL)
-    }
-    markPageAsShown()
-}
-
-private fun openPageOnAllProjects() {
-    if (isInIdeWebPageSupported()) {
-        Arrays.stream(ProjectManager.getInstance().openProjects)
-            .forEach { openPageOnProject(it) }
-    } else {
-        BrowserUtil.browse(PAGE_URL)
+    fun openPageOnProject(project: Project) {
+        browserUtilsService.openUrlOnSplitWindow(project, PAGE_TITLE, PAGE_URL)
         markPageAsShown()
     }
-}
 
-private fun isInIdeWebPageSupported(): Boolean {
-    return try {
-        getOpenEditorMethod()
-        true
-    } catch (e: NotSupportedByIDEVersion) {
-        false
+    private fun isPageShown(): Boolean {
+        return PropertiesComponent.getInstance().getBoolean(IS_GETTING_STARTED_OPENED_KEY)
     }
-}
 
-@Throws(NotSupportedByIDEVersion::class)
-private fun getOpenEditorMethod(): Method {
-    return try {
-        HTMLEditorProvider::class.java.getMethod(
-            "openEditor",
-            Project::class.java,
-            String::class.java,
-            String::class.java,
-            String::class.java
-        )
-    } catch (e: Exception) {
-        throw NotSupportedByIDEVersion()
+    private fun markPageAsShown() {
+        PropertiesComponent.getInstance().setValue(IS_GETTING_STARTED_OPENED_KEY, true)
     }
-}
 
-private fun isPageShown(): Boolean {
-    return PropertiesComponent.getInstance().getBoolean(IS_GETTING_STARTED_OPENED_KEY)
-}
-
-private fun markPageAsShown() {
-    PropertiesComponent.getInstance().setValue(IS_GETTING_STARTED_OPENED_KEY, true)
+    override fun dispose() {
+    }
 }

--- a/src/main/java/com/tabnine/general/ProjectUtils.kt
+++ b/src/main/java/com/tabnine/general/ProjectUtils.kt
@@ -1,0 +1,15 @@
+package com.tabnine.general
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.wm.WindowManager
+import java.util.Arrays
+import java.util.Optional
+
+fun getFocusedProject(): Optional<Project> {
+    return Arrays.stream(ProjectManager.getInstance().openProjects)
+        .filter() {
+            WindowManager.getInstance().getFrame(it)?.isFocused == true
+        }
+        .findFirst()
+}

--- a/src/main/java/com/tabnine/lifecycle/PluginInstalledNotifier.java
+++ b/src/main/java/com/tabnine/lifecycle/PluginInstalledNotifier.java
@@ -1,0 +1,10 @@
+package com.tabnine.lifecycle;
+
+import com.intellij.util.messages.Topic;
+
+public interface PluginInstalledNotifier {
+  Topic<PluginInstalledNotifier> PLUGIN_INSTALLED_TOPIC =
+      Topic.create("Plugin Installed Notifier", PluginInstalledNotifier.class);
+
+  void onPluginInstalled();
+}

--- a/src/main/java/com/tabnine/statusBar/StatusBarActions.kt
+++ b/src/main/java/com/tabnine/statusBar/StatusBarActions.kt
@@ -6,9 +6,8 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.tabnine.binary.requests.analytics.EventRequest
 import com.tabnine.binary.requests.config.ConfigRequest
-import com.tabnine.binary.requests.statusBar.ConfigOpenedFromStatusBarRequest
 import com.tabnine.general.DependencyContainer
-import com.tabnine.general.openPageOnProject
+import com.tabnine.general.GettingStartedManager
 
 const val OPEN_TABNINE_HUB_TEXT = "Open Tabnine Hub"
 const val GETTING_STARTED_TEXT = "Getting Started Guide"
@@ -33,13 +32,18 @@ object StatusBarActions {
             OPEN_TABNINE_HUB_TEXT
         ) {
             binaryRequestFacade.executeRequest(ConfigRequest())
-            binaryRequestFacade.executeRequest(ConfigOpenedFromStatusBarRequest())
+            binaryRequestFacade.executeRequest(
+                EventRequest(
+                    "Button Click",
+                    mapOf("action_name" to "open_hub", "action_text" to OPEN_TABNINE_HUB_TEXT)
+                )
+            )
         }
     }
 
     private fun createGettingStartedAction(project: Project): DumbAwareAction {
         return DumbAwareAction.create(GETTING_STARTED_TEXT) {
-            openPageOnProject(project)
+            GettingStartedManager.instance.openPageOnProject(project)
             binaryRequestFacade.executeRequest(
                 EventRequest(
                     "Button Click",

--- a/src/main/java/com/tabnine/statusBar/StatusBarPopupListener.java
+++ b/src/main/java/com/tabnine/statusBar/StatusBarPopupListener.java
@@ -1,0 +1,18 @@
+package com.tabnine.statusBar;
+
+import com.intellij.openapi.ui.popup.JBPopupListener;
+import com.intellij.openapi.ui.popup.LightweightWindowEvent;
+import com.tabnine.binary.BinaryRequestFacade;
+import com.tabnine.binary.requests.statusBar.StatusBarInteractionRequest;
+import com.tabnine.general.DependencyContainer;
+import org.jetbrains.annotations.NotNull;
+
+public class StatusBarPopupListener implements JBPopupListener {
+  private final BinaryRequestFacade binaryRequestFacade =
+      DependencyContainer.instanceOfBinaryRequestFacade();
+
+  @Override
+  public void beforeShown(@NotNull LightweightWindowEvent event) {
+    binaryRequestFacade.executeRequest(new StatusBarInteractionRequest());
+  }
+}

--- a/src/main/java/com/tabnine/statusBar/TabnineStatusBarWidget.java
+++ b/src/main/java/com/tabnine/statusBar/TabnineStatusBarWidget.java
@@ -69,15 +69,18 @@ public class TabnineStatusBarWidget extends EditorBasedWidget
   }
 
   public ListPopup createPopup() {
-    return JBPopupFactory.getInstance()
-        .createActionGroupPopup(
-            null,
-            StatusBarActions.buildStatusBarActionsGroup(
-                myStatusBar != null ? myStatusBar.getProject() : null),
-            DataManager.getInstance()
-                .getDataContext(myStatusBar != null ? myStatusBar.getComponent() : null),
-            JBPopupFactory.ActionSelectionAid.SPEEDSEARCH,
-            true);
+    ListPopup popup =
+        JBPopupFactory.getInstance()
+            .createActionGroupPopup(
+                null,
+                StatusBarActions.buildStatusBarActionsGroup(
+                    myStatusBar != null ? myStatusBar.getProject() : null),
+                DataManager.getInstance()
+                    .getDataContext(myStatusBar != null ? myStatusBar.getComponent() : null),
+                JBPopupFactory.ActionSelectionAid.SPEEDSEARCH,
+                true);
+    popup.addListener(new StatusBarPopupListener());
+    return popup;
   }
 
   private StateResponse getStateResponse() {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -110,6 +110,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <preloadingActivity implementation="com.tabnine.Initializer"/>
+        <preloadingActivity implementation="com.tabnine.general.GettingStartedManager"/>
         <postStartupActivity implementation="com.tabnine.Initializer"/>
         <statusBarWidgetProvider implementation="com.tabnine.statusBar.StatusBarProvider"/>
         <statusBarWidgetProvider implementation="com.tabnine.statusBar.StatusBarPromotionProvider"/>
@@ -118,6 +119,7 @@
         <applicationService serviceImplementation="com.tabnine.lifecycle.BinaryStateService"/>
         <applicationService serviceImplementation="com.tabnine.capabilities.CapabilitiesService"/>
         <applicationService serviceImplementation="com.tabnine.lifecycle.LifeCycleHelper"/>
+        <applicationService serviceImplementation="com.tabnine.general.BrowserUtilsService"/>
 
         <actionPromoter implementation="com.tabnine.inline.InlineActionsPromoter"/>
         <editorActionHandler action="EditorEscape" implementationClass="com.tabnine.inline.EscapeHandler" id="previewEscape" order="before hide-hints"/>


### PR DESCRIPTION
- isolate the browser functionality from GettingStartedManager 
- open the getting started page on the focused project
- change the explicit reference to GettingStartedManager to event-based approach
- change user-interaction event to happen on the status bar click
- set a different event for the "open hub" popup button