### PR TITLE
Dev2 1835 - do not modify the old suffix in case multiline suggestions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,5 @@ jobs:
         uses: snyk/actions/gradle-jdk11@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high

--- a/src/main/java/com/tabnine/inline/CompletionPreview.java
+++ b/src/main/java/com/tabnine/inline/CompletionPreview.java
@@ -1,5 +1,7 @@
 package com.tabnine.inline;
 
+import static com.tabnine.inline.CompletionPreviewUtilsKt.*;
+
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Caret;
@@ -24,8 +26,6 @@ import com.tabnine.selections.SelectionUtil;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import static com.tabnine.inline.CompletionPreviewUtilsKt.*;
 
 public class CompletionPreview implements Disposable {
   private static final Key<CompletionPreview> INLINE_COMPLETION_PREVIEW =

--- a/src/main/java/com/tabnine/inline/CompletionPreview.java
+++ b/src/main/java/com/tabnine/inline/CompletionPreview.java
@@ -1,7 +1,5 @@
 package com.tabnine.inline;
 
-import static com.tabnine.inline.CompletionPreviewUtilsKt.hadSuffix;
-
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Caret;
@@ -26,6 +24,8 @@ import com.tabnine.selections.SelectionUtil;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import static com.tabnine.inline.CompletionPreviewUtilsKt.*;
 
 public class CompletionPreview implements Disposable {
   private static final Key<CompletionPreview> INLINE_COMPLETION_PREVIEW =
@@ -146,7 +146,7 @@ public class CompletionPreview implements Disposable {
     int startOffset = cursorOffset - completion.oldPrefix.length();
     int endOffset = cursorOffset + suffix.length();
 
-    if (hadSuffix(completion)) {
+    if (shouldRemoveSuffixIfSingleLine(completion)) {
       editor.getDocument().deleteString(cursorOffset, cursorOffset + completion.oldSuffix.length());
     }
 

--- a/src/main/java/com/tabnine/inline/CompletionPreview.java
+++ b/src/main/java/com/tabnine/inline/CompletionPreview.java
@@ -146,7 +146,7 @@ public class CompletionPreview implements Disposable {
     int startOffset = cursorOffset - completion.oldPrefix.length();
     int endOffset = cursorOffset + suffix.length();
 
-    if (shouldRemoveSuffixIfSingleLine(completion)) {
+    if (shouldRemoveSuffix(completion)) {
       editor.getDocument().deleteString(cursorOffset, cursorOffset + completion.oldSuffix.length());
     }
 

--- a/src/main/java/com/tabnine/inline/CompletionPreviewUtils.kt
+++ b/src/main/java/com/tabnine/inline/CompletionPreviewUtils.kt
@@ -9,6 +9,6 @@ fun hadSuffix(currentCompletion: TabNineCompletion): Boolean {
 fun isSingleLine(currentCompletion: TabNineCompletion): Boolean {
     return !currentCompletion.getSuffix().trim()?.contains("\n") ?: true
 }
-fun shouldRemoveSuffixIfSingleLine(currentCompletion: TabNineCompletion): Boolean {
+fun shouldRemoveSuffix(currentCompletion: TabNineCompletion): Boolean {
     return hadSuffix(currentCompletion) && isSingleLine(currentCompletion)
 }

--- a/src/main/java/com/tabnine/inline/CompletionPreviewUtils.kt
+++ b/src/main/java/com/tabnine/inline/CompletionPreviewUtils.kt
@@ -5,3 +5,10 @@ import com.tabnine.prediction.TabNineCompletion
 fun hadSuffix(currentCompletion: TabNineCompletion): Boolean {
     return currentCompletion.oldSuffix?.trim()?.isNotEmpty() ?: false
 }
+
+fun isSingleLine(currentCompletion: TabNineCompletion): Boolean {
+    return !currentCompletion.getSuffix().trim()?.contains("\n") ?: true
+}
+fun shouldRemoveSuffixIfSingleLine(currentCompletion: TabNineCompletion): Boolean {
+    return hadSuffix(currentCompletion) && isSingleLine(currentCompletion)
+}

--- a/src/test/java/com/tabnine/plugin/InlineCompletionTests.java
+++ b/src/test/java/com/tabnine/plugin/InlineCompletionTests.java
@@ -13,12 +13,14 @@ import com.tabnine.inline.EscapeHandler;
 import com.tabnine.inline.ShowNextTabnineInlineCompletionAction;
 import com.tabnine.inline.ShowPreviousTabnineInlineCompletionAction;
 import java.awt.datatransfer.StringSelection;
+
+import com.tabnine.testUtils.TestData;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class InlineCompletionTests extends MockedBinaryCompletionTestCase {
 
+public class InlineCompletionTests extends MockedBinaryCompletionTestCase {
   @Before
   public void init() {
     Mockito.when(suggestionsModeServiceMock.getSuggestionMode()).thenReturn(SuggestionsMode.INLINE);
@@ -27,6 +29,10 @@ public class InlineCompletionTests extends MockedBinaryCompletionTestCase {
   private void mockCompletionResponseWithPrefix(String oldPrefix) throws Exception {
     when(binaryProcessGatewayMock.readRawResponse())
         .thenReturn(setOldPrefixFor(THIRD_PREDICTION_RESULT, oldPrefix));
+  }
+  private void mockCompletionResponse(String responce) throws Exception {
+    when(binaryProcessGatewayMock.readRawResponse())
+            .thenReturn(setOldPrefixFor(responce, "t"));
   }
 
   @Test
@@ -115,6 +121,16 @@ public class InlineCompletionTests extends MockedBinaryCompletionTestCase {
     myFixture.performEditorAction(AcceptTabnineInlineCompletionAction.ACTION_ID);
 
     myFixture.checkResult("hello\ntemp\nhello");
+  }
+
+  @Test
+  public void shouldNotRemoveTheOldSuffixInMultiline() throws Exception {
+    mockCompletionResponse(TestData.MULTI_LINE_SNIPPET_PREDICTION_RESULT);
+    type("\nt");
+
+    myFixture.performEditorAction(AcceptTabnineInlineCompletionAction.ACTION_ID);
+
+    myFixture.checkResult("hello\ntemp\ntemp2\nhello");
   }
 
   @Test

--- a/src/test/java/com/tabnine/plugin/InlineCompletionTests.java
+++ b/src/test/java/com/tabnine/plugin/InlineCompletionTests.java
@@ -12,13 +12,11 @@ import com.tabnine.inline.AcceptTabnineInlineCompletionAction;
 import com.tabnine.inline.EscapeHandler;
 import com.tabnine.inline.ShowNextTabnineInlineCompletionAction;
 import com.tabnine.inline.ShowPreviousTabnineInlineCompletionAction;
-import java.awt.datatransfer.StringSelection;
-
 import com.tabnine.testUtils.TestData;
+import java.awt.datatransfer.StringSelection;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-
 
 public class InlineCompletionTests extends MockedBinaryCompletionTestCase {
   @Before
@@ -30,9 +28,9 @@ public class InlineCompletionTests extends MockedBinaryCompletionTestCase {
     when(binaryProcessGatewayMock.readRawResponse())
         .thenReturn(setOldPrefixFor(THIRD_PREDICTION_RESULT, oldPrefix));
   }
+
   private void mockCompletionResponse(String responce) throws Exception {
-    when(binaryProcessGatewayMock.readRawResponse())
-            .thenReturn(setOldPrefixFor(responce, "t"));
+    when(binaryProcessGatewayMock.readRawResponse()).thenReturn(setOldPrefixFor(responce, "t"));
   }
 
   @Test

--- a/src/test/java/com/tabnine/testUtils/TestData.java
+++ b/src/test/java/com/tabnine/testUtils/TestData.java
@@ -22,7 +22,7 @@ public class TestData {
   public static final String THIRD_PREDICTION_RESULT =
       "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"temp\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"21%\"},{\"new_prefix\":\"temporary\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 17%\"},{\"new_prefix\":\"temporary file\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 13%\"}],\"user_message\":[],\"docs\":[]}";
   public static final String MULTI_LINE_SNIPPET_PREDICTION_RESULT =
-      "{\"old_prefix\":\"\",\"results\":[{\"completion_kind\":\"Snippet\",\"new_prefix\":\"temp\\ntemp2\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"21%\"},{\"new_prefix\":\"temporary\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 17%\"},{\"new_prefix\":\"temporary file\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 13%\"}],\"user_message\":[],\"docs\":[]}";
+      "{\"old_prefix\":\"\",\"results\":[{\"completion_kind\":\"Snippet\",\"new_prefix\":\"temp\\ntemp2\",\"old_suffix\":\"hello\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"21%\"},{\"new_prefix\":\"temporary\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 17%\"},{\"new_prefix\":\"temporary file\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 13%\"}],\"user_message\":[],\"docs\":[]}";
 
   public static final int OVERFLOW = 1;
   public static final String INVALID_RESULT = "Nonsense";


### PR DESCRIPTION
**problem:**  
Tabnine returns the  `old_suffix`  to be replaced by the new_prefix (current suggestion)
for now, this logic is relevant only in single-line suggestions.

**example:** 
 in the case of `console("H<caret>")`  and `new_prefix :ello")` Tabnine will return  `old_suffix: ")` to be replaced by the `new_prefix`

**notes:**
 - this logic s not relevant to multiline suggestions because it is already handled [here](https://github.com/codota/triton-cloud-frontend/blob/a8997be6f66c7312567b819068e0f05db798afdb/app/suggestion_processing/postprocessors/overlap.py#L18)
 - we have the same workaround in vscode as well https://github.com/codota/tabnine-vscode/blob/c0a9a7d5a19e4a9ef23579ce8688d216d1aab439/src/provideInlineCompletionItems.ts#L87
 - this logic is calculated [here](https://github.com/codota/acpl-paid/blob/13bfa7ffde61209300ac7167505c211727b93995/tabnine/server/src/postprocess.rs#L166)
and because it is used by the Ycmd mode, for now, I've decided to handle it on the plugin level, moving forward  we should consider removing it from the binary


