### PR TITLE
DEV2-1779: - prevent switchable suggestion. - a fix for flickering suggestions. - add debounce value capabilities.

### DIFF
--- a/src/main/java/com/tabnine/binary/requests/notifications/shown/SuggestionShownRequest.kt
+++ b/src/main/java/com/tabnine/binary/requests/notifications/shown/SuggestionShownRequest.kt
@@ -1,0 +1,16 @@
+package com.tabnine.binary.requests.notifications.shown
+
+import com.tabnine.binary.BinaryRequest
+import com.tabnine.binary.requests.EmptyResponse
+import com.tabnine.general.CompletionKind
+import com.tabnine.general.CompletionOrigin
+
+data class SuggestionShownRequest(var origin: CompletionOrigin?, var completion_kind: CompletionKind?, var net_length: Int) : BinaryRequest<EmptyResponse> {
+    override fun response(): Class<EmptyResponse> {
+        return EmptyResponse::class.java
+    }
+
+    override fun serialize(): Any {
+        return mapOf("SuggestionShown" to this)
+    }
+}

--- a/src/main/java/com/tabnine/capabilities/Capability.java
+++ b/src/main/java/com/tabnine/capabilities/Capability.java
@@ -16,4 +16,10 @@ public enum Capability {
   DEBOUNCE_VALUE_300,
   @SerializedName("debounce_value_600")
   DEBOUNCE_VALUE_600,
+  @SerializedName("debounce_value_900")
+  DEBOUNCE_VALUE_900,
+  @SerializedName("debounce_value_1200")
+  DEBOUNCE_VALUE_1200,
+  @SerializedName("debounce_value_1500")
+  DEBOUNCE_VALUE_1500,
 }

--- a/src/main/java/com/tabnine/general/Utils.java
+++ b/src/main/java/com/tabnine/general/Utils.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
@@ -91,8 +92,26 @@ public final class Utils {
     return -1;
   }
 
-  public static void executeUIThreadWithDelay(Runnable runnable, long delay, TimeUnit timeUnit) {
-    AppExecutorUtil.getAppScheduledExecutorService()
-        .schedule(() -> ApplicationManager.getApplication().invokeLater(runnable), delay, timeUnit);
+  public static Future<?> executeUIThreadWithDelay(
+      Runnable runnable, long delay, TimeUnit timeUnit) {
+    return executeNonUIThreadWithDelay(
+        () -> ApplicationManager.getApplication().invokeLater(runnable), delay, timeUnit);
+  }
+
+  public static Future<?> executeNonUIThread(Runnable runnable) {
+    if (ApplicationManager.getApplication().isUnitTestMode()) {
+      runnable.run();
+      return null;
+    }
+    return AppExecutorUtil.getAppExecutorService().submit(runnable);
+  }
+
+  public static Future<?> executeNonUIThreadWithDelay(
+      Runnable runnable, long delay, TimeUnit timeUnit) {
+    if (ApplicationManager.getApplication().isUnitTestMode()) {
+      runnable.run();
+      return null;
+    }
+    return AppExecutorUtil.getAppScheduledExecutorService().schedule(runnable, delay, timeUnit);
   }
 }

--- a/src/main/java/com/tabnine/inline/DebounceUtils.kt
+++ b/src/main/java/com/tabnine/inline/DebounceUtils.kt
@@ -7,7 +7,10 @@ import com.tabnine.userSettings.AppSettingsState
 object DebounceUtils {
     private val DEBOUNCE_CAPABILITIES = arrayListOf(
         Capability.DEBOUNCE_VALUE_300,
-        Capability.DEBOUNCE_VALUE_600
+        Capability.DEBOUNCE_VALUE_600,
+        Capability.DEBOUNCE_VALUE_900,
+        Capability.DEBOUNCE_VALUE_1200,
+        Capability.DEBOUNCE_VALUE_1500,
     )
 
     @JvmStatic
@@ -17,17 +20,20 @@ object DebounceUtils {
 
     @JvmStatic
     fun getDebounceMsFromCapabilities(): Long? {
-        if (CapabilitiesService.getInstance().isCapabilityEnabled(Capability.DEBOUNCE_VALUE_300)) {
-            return 300
-        }
-        if (CapabilitiesService.getInstance().isCapabilityEnabled(Capability.DEBOUNCE_VALUE_600)) {
-            return 600
-        }
+        if (isCapabilityEnabled(Capability.DEBOUNCE_VALUE_300)) return 300
+        if (isCapabilityEnabled(Capability.DEBOUNCE_VALUE_600)) return 600
+        if (isCapabilityEnabled(Capability.DEBOUNCE_VALUE_900)) return 900
+        if (isCapabilityEnabled(Capability.DEBOUNCE_VALUE_1200)) return 1200
+        if (isCapabilityEnabled(Capability.DEBOUNCE_VALUE_1500)) return 1500
         return null
     }
 
     @JvmStatic
     fun isFixedDebounceConfigured(): Boolean {
         return DEBOUNCE_CAPABILITIES.stream().anyMatch(CapabilitiesService.getInstance()::isCapabilityEnabled)
+    }
+
+    private fun isCapabilityEnabled(capability: Capability): Boolean {
+        return CapabilitiesService.getInstance().isCapabilityEnabled(capability)
     }
 }

--- a/src/main/java/com/tabnine/inline/EscapeHandler.java
+++ b/src/main/java/com/tabnine/inline/EscapeHandler.java
@@ -21,6 +21,7 @@ public class EscapeHandler extends EditorActionHandler {
   @Override
   public void doExecute(@NotNull Editor editor, Caret caret, DataContext dataContext) {
     CompletionPreview.clear(editor);
+    InlineCompletionCache.getInstance().clear(editor);
     completionsEventSender.sendCancelSuggestionTrigger();
     if (myOriginalHandler.isEnabled(editor, caret, dataContext)) {
       myOriginalHandler.execute(editor, caret, dataContext);

--- a/src/main/java/com/tabnine/inline/InlineCompletionCache.kt
+++ b/src/main/java/com/tabnine/inline/InlineCompletionCache.kt
@@ -24,8 +24,7 @@ class InlineCompletionCache {
         return completions.stream()
             .filter { completion: TabNineCompletion -> completion.suffix.startsWith(userInput) }
             .map { completion: TabNineCompletion ->
-                TabNineCompletion.createAdjustedCompletion(
-                    completion,
+                completion.createAdjustedCompletion(
                     completion.oldPrefix + userInput,
                     completion.cursorPrefix + userInput
                 )

--- a/src/main/java/com/tabnine/inline/InlineCompletionCache.kt
+++ b/src/main/java/com/tabnine/inline/InlineCompletionCache.kt
@@ -1,0 +1,39 @@
+package com.tabnine.inline
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.Key
+import com.tabnine.prediction.TabNineCompletion
+import java.util.stream.Collectors
+
+class InlineCompletionCache {
+
+    companion object {
+        @JvmStatic
+        val instance = InlineCompletionCache()
+
+        private val INLINE_COMPLETIONS_LAST_RESULT = Key.create<List<TabNineCompletion>>("INLINE_COMPLETIONS_LAST_RESULT")
+    }
+
+    fun store(editor: Editor, completions: List<TabNineCompletion>) {
+        editor.putUserData(INLINE_COMPLETIONS_LAST_RESULT, completions)
+    }
+
+    fun retrieveAdjustedCompletions(editor: Editor, userInput: String): List<TabNineCompletion> {
+        val completions = editor.getUserData(INLINE_COMPLETIONS_LAST_RESULT)
+            ?: return emptyList()
+        return completions.stream()
+            .filter { completion: TabNineCompletion -> completion.suffix.startsWith(userInput) }
+            .map { completion: TabNineCompletion ->
+                TabNineCompletion.createAdjustedCompletion(
+                    completion,
+                    completion.oldPrefix + userInput,
+                    completion.cursorPrefix + userInput
+                )
+            }
+            .collect(Collectors.toList())
+    }
+
+    fun clear(editor: Editor) {
+        editor.putUserData(INLINE_COMPLETIONS_LAST_RESULT, null)
+    }
+}

--- a/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
+++ b/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
@@ -35,20 +35,15 @@ public class TabnineDocumentListener implements BulkAwareDocumentListener {
 
     CompletionPreview.clear(editor);
 
-    ApplicationManager.getApplication()
-        .invokeLater(
-            () -> {
-              int offset =
-                  ApplicationManager.getApplication().isUnitTestMode()
-                      ? event.getOffset() + event.getNewLength()
-                      : editor.getCaretModel().getOffset();
+    int offset = event.getOffset() + event.getNewLength();
 
-              if (shouldIgnoreChange(event, editor, offset)) {
-                return;
-              }
+    if (shouldIgnoreChange(event, editor, offset)) {
+      InlineCompletionCache.getInstance().clear(editor);
+      return;
+    }
 
-              handler.retrieveAndShowCompletion(editor, offset, new DefaultCompletionAdjustment());
-            });
+    handler.retrieveAndShowCompletion(
+        editor, offset, event.getNewFragment().toString(), new DefaultCompletionAdjustment());
   }
 
   private boolean shouldIgnoreChange(DocumentEvent event, Editor editor, int offset) {

--- a/src/main/java/com/tabnine/inline/TabnineInlineLookupListener.kt
+++ b/src/main/java/com/tabnine/inline/TabnineInlineLookupListener.kt
@@ -2,7 +2,6 @@ package com.tabnine.inline
 
 import com.intellij.codeInsight.lookup.LookupEvent
 import com.intellij.codeInsight.lookup.LookupListener
-import com.intellij.openapi.application.ApplicationManager
 import com.tabnine.general.DependencyContainer
 
 class TabnineInlineLookupListener : LookupListener {
@@ -16,6 +15,7 @@ class TabnineInlineLookupListener : LookupListener {
 
         val editor = event.lookup.editor
         CompletionPreview.clear(editor)
+        InlineCompletionCache.instance.clear(editor)
 
         val userPrefix = event.lookup.itemPattern(eventItem)
         val completionInFocus = eventItem.lookupString
@@ -30,14 +30,12 @@ class TabnineInlineLookupListener : LookupListener {
             return
         }
 
-        ApplicationManager.getApplication()
-            .invokeLater {
-                handler.retrieveAndShowCompletion(
-                    editor,
-                    editor.caretModel.offset,
-                    LookAheadCompletionAdjustment(userPrefix, completionInFocus)
-                )
-            }
+        handler.retrieveAndShowCompletion(
+            editor,
+            editor.caretModel.offset,
+            "",
+            LookAheadCompletionAdjustment(userPrefix, completionInFocus)
+        )
     }
 
     override fun lookupCanceled(event: LookupEvent) {

--- a/src/main/java/com/tabnine/inline/listeners/InlineCaretListener.kt
+++ b/src/main/java/com/tabnine/inline/listeners/InlineCaretListener.kt
@@ -6,11 +6,12 @@ import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.CaretListener
 import com.intellij.openapi.util.Disposer
 import com.tabnine.inline.CompletionPreview
+import com.tabnine.inline.InlineCompletionCache
 
 class InlineCaretListener(private val completionPreview: CompletionPreview) : CaretListener, Disposable {
     init {
-        completionPreview.editor.caretModel.addCaretListener(this)
         Disposer.register(completionPreview, this)
+        ApplicationManager.getApplication().invokeLater { completionPreview.editor.caretModel.addCaretListener(this) }
     }
 
     override fun caretPositionChanged(event: CaretEvent) {
@@ -19,6 +20,7 @@ class InlineCaretListener(private val completionPreview: CompletionPreview) : Ca
         }
 
         Disposer.dispose(completionPreview)
+        InlineCompletionCache.instance.clear(event.editor)
     }
 
     override fun dispose() {

--- a/src/main/java/com/tabnine/prediction/TabNineCompletion.java
+++ b/src/main/java/com/tabnine/prediction/TabNineCompletion.java
@@ -56,21 +56,20 @@ public class TabNineCompletion implements Completion {
     this.suggestionTrigger = suggestionTrigger;
   }
 
-  public static TabNineCompletion createAdjustedCompletion(
-      TabNineCompletion other, String oldPrefix, String cursorPrefix) {
+  public TabNineCompletion createAdjustedCompletion(String oldPrefix, String cursorPrefix) {
     return new TabNineCompletion(
         oldPrefix,
-        other.newPrefix,
-        other.oldSuffix,
-        other.newSuffix,
-        other.index,
+        this.newPrefix,
+        this.oldSuffix,
+        this.newSuffix,
+        this.index,
         cursorPrefix,
-        other.cursorSuffix,
-        other.origin,
-        other.completionKind,
+        this.cursorSuffix,
+        this.origin,
+        this.completionKind,
         true,
-        other.snippet_context,
-        other.suggestionTrigger);
+        this.snippet_context,
+        this.suggestionTrigger);
   }
 
   public CompletionOrigin getOrigin() {

--- a/src/main/java/com/tabnine/prediction/TabNineCompletion.java
+++ b/src/main/java/com/tabnine/prediction/TabNineCompletion.java
@@ -56,6 +56,23 @@ public class TabNineCompletion implements Completion {
     this.suggestionTrigger = suggestionTrigger;
   }
 
+  public static TabNineCompletion createAdjustedCompletion(
+      TabNineCompletion other, String oldPrefix, String cursorPrefix) {
+    return new TabNineCompletion(
+        oldPrefix,
+        other.newPrefix,
+        other.oldSuffix,
+        other.newSuffix,
+        other.index,
+        cursorPrefix,
+        other.cursorSuffix,
+        other.origin,
+        other.completionKind,
+        true,
+        other.snippet_context,
+        other.suggestionTrigger);
+  }
+
   public CompletionOrigin getOrigin() {
     return origin;
   }
@@ -78,6 +95,10 @@ public class TabNineCompletion implements Completion {
     }
 
     return fullSuffix = "";
+  }
+
+  public int getNetLength() {
+    return getSuffix().length();
   }
 
   @Override

--- a/src/test/java/com/tabnine/plugin/CompletionHintTests.java
+++ b/src/test/java/com/tabnine/plugin/CompletionHintTests.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.when;
 
 import com.tabnine.MockedBinaryCompletionTestCase;
 import com.tabnine.balloon.FirstSuggestionHintTooltip;
+import com.tabnine.capabilities.CapabilitiesService;
+import com.tabnine.capabilities.Capability;
 import com.tabnine.capabilities.SuggestionsMode;
 import com.tabnine.state.SuggestionHintState;
 import com.tabnine.state.UserState;
@@ -20,6 +22,9 @@ public class CompletionHintTests extends MockedBinaryCompletionTestCase {
 
   private static final SuggestionHintState suggestionHintStateMock =
       Mockito.mock(SuggestionHintState.class);
+
+  private static final CapabilitiesService capabilityServiceMock =
+      Mockito.mock(CapabilitiesService.class);
 
   @Before
   public void init() {
@@ -38,6 +43,9 @@ public class CompletionHintTests extends MockedBinaryCompletionTestCase {
   }
 
   private void mockIsEligibleForCompletionHint(boolean isEligible) {
+    when(capabilityServiceMock.isCapabilityEnabled(Capability.FIRST_SUGGESTION_HINT_ENABLED))
+        .thenReturn(true);
+    when(CapabilitiesService.getInstance()).thenReturn(capabilityServiceMock);
     when(suggestionHintStateMock.isEligibleForSuggestionHint()).thenReturn(isEligible);
     UserState userStateMock = Mockito.mock(UserState.class);
     when(userStateMock.getSuggestionHintState()).thenReturn(suggestionHintStateMock);

--- a/src/test/java/com/tabnine/unitTests/InlineCompletionCacheTests.kt
+++ b/src/test/java/com/tabnine/unitTests/InlineCompletionCacheTests.kt
@@ -1,0 +1,69 @@
+package com.tabnine.unitTests
+
+import com.tabnine.MockedBinaryCompletionTestCase
+import com.tabnine.general.CompletionKind
+import com.tabnine.general.CompletionOrigin
+import com.tabnine.general.SuggestionTrigger
+import com.tabnine.inline.InlineCompletionCache
+import com.tabnine.prediction.TabNineCompletion
+import org.junit.Test
+
+class InlineCompletionCacheTests : MockedBinaryCompletionTestCase() {
+
+    @Test
+    fun shouldRetrieveOnlyRelevantCompletions() {
+        InlineCompletionCache.instance.store(
+            myFixture.editor,
+            listOf(
+                createBasicTabnineCompletion(
+                    "c",
+                    "const",
+                ),
+                createBasicTabnineCompletion(
+                    "c",
+                    "cable",
+                ),
+            )
+        )
+        val result = InlineCompletionCache.instance.retrieveAdjustedCompletions(myFixture.editor, "o")
+        assertEquals(1, result.size)
+        assertEquals("co", result[0].oldPrefix)
+        assertEquals("co", result[0].cursorPrefix)
+    }
+
+    @Test
+    fun shouldClearCompletionsCache() {
+        InlineCompletionCache.instance.store(
+            myFixture.editor,
+            listOf(
+                createBasicTabnineCompletion(
+                    "t",
+                    "temp",
+                ),
+            )
+        )
+        assertEquals(1, InlineCompletionCache.instance.retrieveAdjustedCompletions(myFixture.editor, "e").size)
+        InlineCompletionCache.instance.clear(myFixture.editor)
+        assertEquals(0, InlineCompletionCache.instance.retrieveAdjustedCompletions(myFixture.editor, "e").size)
+    }
+
+    private fun createBasicTabnineCompletion(
+        oldPrefix: String,
+        newPrefix: String,
+    ): TabNineCompletion {
+        return TabNineCompletion(
+            oldPrefix,
+            newPrefix,
+            "",
+            "",
+            0,
+            oldPrefix,
+            "",
+            CompletionOrigin.UNKNOWN,
+            CompletionKind.Classic,
+            true,
+            null,
+            SuggestionTrigger.DocumentChanged
+        )
+    }
+}

--- a/src/test/java/com/tabnine/unitTests/InlineCompletionCacheTests.kt
+++ b/src/test/java/com/tabnine/unitTests/InlineCompletionCacheTests.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 class InlineCompletionCacheTests : MockedBinaryCompletionTestCase() {
 
     @Test
-    fun shouldRetrieveOnlyRelevantCompletions() {
+    fun givenAPrefixThenReturnOnlySuggestionsThatStartWithThisPrefix() {
         InlineCompletionCache.instance.store(
             myFixture.editor,
             listOf(
@@ -32,7 +32,26 @@ class InlineCompletionCacheTests : MockedBinaryCompletionTestCase() {
     }
 
     @Test
-    fun shouldClearCompletionsCache() {
+    fun givenExistingCompletionInCacheAndCallWithEmptyInputThenReturnAllOfThem() {
+        InlineCompletionCache.instance.store(
+            myFixture.editor,
+            listOf(
+                createBasicTabnineCompletion(
+                    "a",
+                    "abc",
+                ),
+                createBasicTabnineCompletion(
+                    "d",
+                    "def",
+                ),
+            )
+        )
+        val result = InlineCompletionCache.instance.retrieveAdjustedCompletions(myFixture.editor, "")
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun givenExistingCompletionInCacheAndCallClearCacheThenCacheShouldBeEmpty() {
         InlineCompletionCache.instance.store(
             myFixture.editor,
             listOf(
@@ -44,6 +63,20 @@ class InlineCompletionCacheTests : MockedBinaryCompletionTestCase() {
         )
         assertEquals(1, InlineCompletionCache.instance.retrieveAdjustedCompletions(myFixture.editor, "e").size)
         InlineCompletionCache.instance.clear(myFixture.editor)
+        assertEquals(0, InlineCompletionCache.instance.retrieveAdjustedCompletions(myFixture.editor, "e").size)
+    }
+
+    @Test
+    fun givenEmptyCompletionInCacheAndCallRetrieveWithInputThenShouldReturnEmptyList() {
+        InlineCompletionCache.instance.store(
+            myFixture.editor,
+            listOf(
+                createBasicTabnineCompletion(
+                    "",
+                    "",
+                ),
+            )
+        )
         assertEquals(0, InlineCompletionCache.instance.retrieveAdjustedCompletions(myFixture.editor, "e").size)
     }
 


### PR DESCRIPTION
Changes:
- As long as you type as the suggested completion preview, the suggestion won't be changed
- Once you type a different character than the suggested completion preview, you will get a new suggestion from the binary
- Send "SuggestionShown" event only for new and rendered completion
- Change the lousy design in `InlineCompletionHandler.java` that executes a different code for tests and different code for the actual application to be the same code
-  The previous change led to a failed test in `CompletionHintTests.java`, and apparently, I removed it by accident in a previous PR. I reverted the change. (it was an experimental feature)
- Add more debounce value capabilities

https://user-images.githubusercontent.com/10290661/206501227-a029ee5f-3028-4f35-a7bf-16f8e1e23a92.mp4

