### PR TITLE
Dev2 1536 add logs and increase threshold

### DIFF
--- a/src/main/java/com/tabnine/binary/BinaryProcessRequesterProvider.java
+++ b/src/main/java/com/tabnine/binary/BinaryProcessRequesterProvider.java
@@ -11,6 +11,7 @@ import com.tabnine.binary.exceptions.NoValidBinaryToRunException;
 import com.tabnine.binary.exceptions.TabNineDeadException;
 import java.io.IOException;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class BinaryProcessRequesterProvider {
   private final BinaryRun binaryRun;
@@ -21,6 +22,7 @@ public class BinaryProcessRequesterProvider {
   private BinaryProcessRequesterPoller poller;
   private BinaryProcessRequester binaryProcessRequester;
   private Future<?> binaryInit;
+  private AtomicInteger requestsCounter = new AtomicInteger(0);
 
   private BinaryProcessRequesterProvider(
       BinaryRun binaryRun,
@@ -35,6 +37,8 @@ public class BinaryProcessRequesterProvider {
       BinaryRun binaryRun,
       BinaryProcessGatewayProvider binaryProcessGatewayProvider,
       BinaryProcessRequesterPoller poller) {
+    Logger.getInstance(BinaryProcessRequesterProvider.class)
+        .debug(String.format("<<ALPHA LOG>> %s", "Creating binary process requester provider"));
     BinaryProcessRequesterProvider binaryProcessRequesterProvider =
         new BinaryProcessRequesterProvider(binaryRun, binaryProcessGatewayProvider, poller);
 
@@ -55,11 +59,20 @@ public class BinaryProcessRequesterProvider {
   }
 
   public void onSuccessfulRequest() {
+    String msg =
+        String.format(
+            "Called successfulRequest with request #%d", requestsCounter.incrementAndGet());
+    Logger.getInstance(BinaryProcessRequesterProvider.class)
+        .debug(String.format("<<ALPHA LOG>> %s", msg));
     consecutiveTimeouts = 0;
     consecutiveRestarts = 0;
   }
 
   public void onDead(Throwable e) {
+    String msg = String.format("Called onDead with request #%d", requestsCounter.incrementAndGet());
+    Logger.getInstance(BinaryProcessRequesterProvider.class)
+        .debug(String.format("<<ALPHA LOG>> %s", msg));
+
     consecutiveTimeouts = 0;
     Logger.getInstance(getClass()).warn("Tabnine is in invalid state, it is being restarted.", e);
 
@@ -76,6 +89,11 @@ public class BinaryProcessRequesterProvider {
   }
 
   public void onTimeout() {
+    String msg =
+        String.format("Called onTimeout with request #%d", requestsCounter.incrementAndGet());
+    Logger.getInstance(BinaryProcessRequesterProvider.class)
+        .debug(String.format("<<ALPHA LOG>> %s", msg));
+
     Logger.getInstance(getClass()).info("TabNine's response timed out.");
 
     if (++consecutiveTimeouts >= CONSECUTIVE_TIMEOUTS_THRESHOLD) {

--- a/src/main/java/com/tabnine/general/StaticConfig.java
+++ b/src/main/java/com/tabnine/general/StaticConfig.java
@@ -32,7 +32,7 @@ public class StaticConfig {
   public static final int BINARY_MINIMUM_REASONABLE_SIZE = 1000 * 1000; // roughly 1MB
   public static final String SET_STATE_RESPONSE_RESULT_STRING = "Done";
   public static final String UNINSTALLING_FLAG = "--uninstalling";
-  public static final int CONSECUTIVE_TIMEOUTS_THRESHOLD = 20;
+  public static final int CONSECUTIVE_TIMEOUTS_THRESHOLD = 60;
   public static final String BRAND_NAME = "tabnine";
   public static final String TARGET_NAME = getDistributionName();
   public static final String EXECUTABLE_NAME = getExeName();

--- a/src/main/java/com/tabnine/general/StaticConfig.java
+++ b/src/main/java/com/tabnine/general/StaticConfig.java
@@ -32,7 +32,7 @@ public class StaticConfig {
   public static final int BINARY_MINIMUM_REASONABLE_SIZE = 1000 * 1000; // roughly 1MB
   public static final String SET_STATE_RESPONSE_RESULT_STRING = "Done";
   public static final String UNINSTALLING_FLAG = "--uninstalling";
-  public static final int CONSECUTIVE_TIMEOUTS_THRESHOLD = 60;
+  public static final int CONSECUTIVE_TIMEOUTS_THRESHOLD = 80;
   public static final String BRAND_NAME = "tabnine";
   public static final String TARGET_NAME = getDistributionName();
   public static final String EXECUTABLE_NAME = getExeName();


### PR DESCRIPTION
I increased the TO from 20 to 80, because this 20 threshold was set a long time ago - long before we started polling the binary every 10 seconds.
I decided on 80 because with the logs I added, without doing anything in the IDE it took ~3min to reach 58 requests:
```
2022-12-08 16:44:50,235 [   6742]  DEBUG - BinaryProcessRequesterProvider - <<ALPHA LOG>> Called successfulRequest with request #1 
...
2022-12-08 16:47:30,269 [ 166776]  DEBUG - BinaryProcessRequesterProvider - <<ALPHA LOG>> Called successfulRequest with request #58 
```
and when I started typing fast immediately after restarting the IDE, I got to 80 in < 30 seconds:
```
2022-12-08 17:09:02,870 [   6688]  DEBUG - BinaryProcessRequesterProvider - <<ALPHA LOG>> Called successfulRequest with request #1 
...
2022-12-08 17:09:31,874 [  35692]  DEBUG - BinaryProcessRequesterProvider - <<ALPHA LOG>> Called successfulRequest with request #80 
```

So I'm guessing the 80 threshold is ok for avg. users - lmk wdyt