### PR TITLE
DEV2-1716 previous and next suggestion events

### DIFF
--- a/src/main/java/com/tabnine/general/DependencyContainer.java
+++ b/src/main/java/com/tabnine/general/DependencyContainer.java
@@ -5,6 +5,7 @@ import com.tabnine.binary.*;
 import com.tabnine.binary.fetch.*;
 import com.tabnine.capabilities.SuggestionsModeService;
 import com.tabnine.hover.HoverUpdater;
+import com.tabnine.inline.CompletionPreviewToggleEventSender;
 import com.tabnine.inline.InlineCompletionHandler;
 import com.tabnine.inline.TabnineInlineLookupListener;
 import com.tabnine.lifecycle.BinaryInstantiatedActions;
@@ -18,6 +19,10 @@ import com.tabnine.statusBar.StatusBarUpdater;
 import org.jetbrains.annotations.NotNull;
 
 public class DependencyContainer {
+  public static int binaryRequestsConsecutiveTimeoutsThreshold =
+      StaticConfig.CONSECUTIVE_TIMEOUTS_THRESHOLD;
+  public static int binaryRequestConsecutiveRestartsThreshold =
+      StaticConfig.CONSECUTIVE_RESTART_THRESHOLD;
   private static BinaryProcessRequesterProvider BINARY_PROCESS_REQUESTER_PROVIDER_INSTANCE = null;
   private static InlineCompletionHandler INLINE_COMPLETION_HANDLER_INSTANCE = null;
 
@@ -86,15 +91,24 @@ public class DependencyContainer {
     return new UninstallListener(instanceOfBinaryRequestFacade(), instanceOfUninstallReporter());
   }
 
+  public static CompletionPreviewToggleEventSender instanceOfCompletionPreviewToggleEventSender() {
+    return new CompletionPreviewToggleEventSender(instanceOfBinaryRequestFacade());
+  }
+
   public static void setTesting(
       BinaryRun binaryRunMock,
       BinaryProcessGatewayProvider binaryProcessGatewayProviderMock,
       BinaryProcessRequesterPoller poller,
-      SuggestionsModeService suggestionsModeServiceMock) {
+      SuggestionsModeService suggestionsModeServiceMock,
+      int binaryRequestsTimeoutsThreshold,
+      int binaryRequestRestartsThreshold) {
     DependencyContainer.binaryRunMock = binaryRunMock;
     DependencyContainer.binaryProcessGatewayProviderMock = binaryProcessGatewayProviderMock;
     DependencyContainer.poller = poller;
     DependencyContainer.suggestionsModeServiceMock = suggestionsModeServiceMock;
+    DependencyContainer.binaryRequestsConsecutiveTimeoutsThreshold =
+        binaryRequestsTimeoutsThreshold;
+    DependencyContainer.binaryRequestConsecutiveRestartsThreshold = binaryRequestRestartsThreshold;
   }
 
   public static SuggestionsModeService instanceOfSuggestionsModeService() {
@@ -111,7 +125,9 @@ public class DependencyContainer {
           BinaryProcessRequesterProvider.create(
               instanceOfBinaryRun(),
               instanceOfBinaryProcessGatewayProvider(),
-              instanceOfRequestPoller());
+              instanceOfRequestPoller(),
+              binaryRequestsConsecutiveTimeoutsThreshold,
+              binaryRequestConsecutiveRestartsThreshold);
     }
 
     return BINARY_PROCESS_REQUESTER_PROVIDER_INSTANCE;

--- a/src/main/java/com/tabnine/inline/CompletionPreview.java
+++ b/src/main/java/com/tabnine/inline/CompletionPreview.java
@@ -34,6 +34,8 @@ public class CompletionPreview implements Disposable {
 
   private final CompletionPreviewListener previewListener =
       DependencyContainer.instanceOfCompletionPreviewListener();
+  private final CompletionPreviewToggleEventSender completionPreviewToggleEventSender =
+      DependencyContainer.instanceOfCompletionPreviewToggleEventSender();
 
   public final Editor editor;
   private TabnineInlay tabnineInlay;
@@ -91,6 +93,7 @@ public class CompletionPreview implements Disposable {
     tabnineInlay = TabnineInlay.create(this);
 
     createPreview();
+    completionPreviewToggleEventSender.sendToggleEvent(order, currentIndex);
   }
 
   private TabNineCompletion createPreview() {

--- a/src/main/java/com/tabnine/inline/CompletionPreviewToggleEventSender.kt
+++ b/src/main/java/com/tabnine/inline/CompletionPreviewToggleEventSender.kt
@@ -1,0 +1,19 @@
+package com.tabnine.inline
+
+import com.intellij.openapi.application.ApplicationManager
+import com.tabnine.binary.BinaryRequestFacade
+import com.tabnine.binary.requests.analytics.EventRequest
+
+class CompletionPreviewToggleEventSender(private val binaryRequestFacade: BinaryRequestFacade) {
+    fun sendToggleEvent(order: CompletionOrder, index: Int) {
+        ApplicationManager.getApplication().invokeLater {
+            val eventOrder = if (order == CompletionOrder.NEXT) {
+                "next"
+            } else {
+                "previous"
+            }
+            val eventName = "toggle-$eventOrder-suggestion"
+            binaryRequestFacade.executeRequest(EventRequest(eventName, mapOf("suggestion_index" to index.toString())))
+        }
+    }
+}

--- a/src/test/java/com/tabnine/MockedBinaryCompletionTestCase.java
+++ b/src/test/java/com/tabnine/MockedBinaryCompletionTestCase.java
@@ -34,6 +34,8 @@ import org.mockito.Mockito;
 
 public abstract class MockedBinaryCompletionTestCase
     extends LightPlatformCodeInsightFixture4TestCase implements Disposable {
+  private static int TESTS_TIMEOUTS_THRESHOLD = 5;
+  private static int TESTS_RESTARTS_THRESHOLD = 5;
   protected static BinaryProcessGateway binaryProcessGatewayMock =
       Mockito.mock(BinaryProcessGateway.class);
   protected static BinaryRun binaryRunMock = Mockito.mock(BinaryRun.class);
@@ -48,7 +50,9 @@ public abstract class MockedBinaryCompletionTestCase
         binaryRunMock,
         binaryProcessGatewayProviderMock,
         new BinaryProcessRequesterPollerCappedImpl(0, 0, 0),
-        suggestionsModeServiceMock);
+        suggestionsModeServiceMock,
+        TESTS_TIMEOUTS_THRESHOLD,
+        TESTS_RESTARTS_THRESHOLD);
   }
 
   @Before

--- a/src/test/java/com/tabnine/testUtils/BadResultsUtils.java
+++ b/src/test/java/com/tabnine/testUtils/BadResultsUtils.java
@@ -1,9 +1,9 @@
 package com.tabnine.testUtils;
 
-import static com.tabnine.general.StaticConfig.CONSECUTIVE_RESTART_THRESHOLD;
 import static com.tabnine.general.StaticConfig.ILLEGAL_RESPONSE_THRESHOLD;
 import static com.tabnine.testUtils.TestData.*;
 
+import com.tabnine.general.DependencyContainer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
@@ -14,7 +14,7 @@ public class BadResultsUtils {
     Stream<String> results =
         Stream.concat(enoughBadResultsToCauseARestart(), Stream.of(A_PREDICTION_RESULT));
 
-    for (int i = 0; i < CONSECUTIVE_RESTART_THRESHOLD; i++) {
+    for (int i = 0; i < DependencyContainer.binaryRequestConsecutiveRestartsThreshold; i++) {
       results = Stream.concat(results, enoughBadResultsToCauseARestart());
     }
 
@@ -25,7 +25,7 @@ public class BadResultsUtils {
   public static Stream<String> enoughBadResultsToCauseADeath() {
     Stream<String> results = enoughBadResultsToCauseARestart();
 
-    for (int i = 0; i < CONSECUTIVE_RESTART_THRESHOLD; i++) {
+    for (int i = 0; i < DependencyContainer.binaryRequestConsecutiveRestartsThreshold; i++) {
       results = Stream.concat(results, enoughBadResultsToCauseARestart());
     }
 


### PR DESCRIPTION
This PR also includes a fix to the tests from #424 - since this PR increased the TOs threshold to 80, it caused the tests to take longer and even fail sometimes.
I fixed it by passing the TOs and restarts thresoleds as data members to `BinaryProcessRequesterProvider`, and change the values for tests in `DependencyContainer.setTesting`