### PR TITLE
DEV2-1536 binary TOs - measure time instead of counter

### DIFF
--- a/src/main/java/com/tabnine/binary/BinaryProcessRequesterProvider.java
+++ b/src/main/java/com/tabnine/binary/BinaryProcessRequesterProvider.java
@@ -18,24 +18,24 @@ public class BinaryProcessRequesterProvider {
   private final BinaryProcessGatewayProvider binaryProcessGatewayProvider;
 
   private int consecutiveRestarts = 0;
-  private int consecutiveTimeouts = 0;
+  private Long firstTimeoutTimestamp = null;
   private BinaryProcessRequesterPoller poller;
   private BinaryProcessRequester binaryProcessRequester;
   private Future<?> binaryInit;
   private AtomicInteger requestsCounter = new AtomicInteger(0);
-  private final int timeoutsThreshold;
+  private final int timeoutsThresholdMillis;
   private final int restartsThreshold;
 
   private BinaryProcessRequesterProvider(
       BinaryRun binaryRun,
       BinaryProcessGatewayProvider binaryProcessGatewayProvider,
       BinaryProcessRequesterPoller poller,
-      int timeoutsThreshold,
+      int timeoutsThresholdMillis,
       int restartsThreshold) {
     this.binaryRun = binaryRun;
     this.binaryProcessGatewayProvider = binaryProcessGatewayProvider;
     this.poller = poller;
-    this.timeoutsThreshold = timeoutsThreshold;
+    this.timeoutsThresholdMillis = timeoutsThresholdMillis;
     this.restartsThreshold = restartsThreshold;
   }
 
@@ -73,7 +73,7 @@ public class BinaryProcessRequesterProvider {
             "Called successfulRequest with request #%d", requestsCounter.incrementAndGet());
     Logger.getInstance(BinaryProcessRequesterProvider.class)
         .debug(String.format("<<ALPHA LOG>> %s", msg));
-    consecutiveTimeouts = 0;
+    firstTimeoutTimestamp = null;
     consecutiveRestarts = 0;
   }
 
@@ -82,7 +82,7 @@ public class BinaryProcessRequesterProvider {
     Logger.getInstance(BinaryProcessRequesterProvider.class)
         .debug(String.format("<<ALPHA LOG>> %s", msg));
 
-    consecutiveTimeouts = 0;
+    firstTimeoutTimestamp = null;
     Logger.getInstance(getClass()).warn("Tabnine is in invalid state, it is being restarted.", e);
 
     if (++consecutiveRestarts > restartsThreshold) {
@@ -105,7 +105,12 @@ public class BinaryProcessRequesterProvider {
 
     Logger.getInstance(getClass()).info("TabNine's response timed out.");
 
-    if (++consecutiveTimeouts >= timeoutsThreshold) {
+    long now = System.currentTimeMillis();
+    if (firstTimeoutTimestamp == null) {
+      firstTimeoutTimestamp = now;
+    }
+
+    if (now - firstTimeoutTimestamp >= timeoutsThresholdMillis) {
       Logger.getInstance(getClass())
           .warn(
               "Requests to TabNine's binary are consistently taking too long. Restarting the binary.");

--- a/src/main/java/com/tabnine/general/DependencyContainer.java
+++ b/src/main/java/com/tabnine/general/DependencyContainer.java
@@ -18,8 +18,8 @@ import com.tabnine.statusBar.StatusBarUpdater;
 import org.jetbrains.annotations.NotNull;
 
 public class DependencyContainer {
-  public static int binaryRequestsConsecutiveTimeoutsThreshold =
-      StaticConfig.CONSECUTIVE_TIMEOUTS_THRESHOLD;
+  public static int binaryRequestsTimeoutsThresholdMillis =
+      StaticConfig.BINARY_TIMEOUTS_THRESHOLD_MILLIS;
   public static int binaryRequestConsecutiveRestartsThreshold =
       StaticConfig.CONSECUTIVE_RESTART_THRESHOLD;
   private static BinaryProcessRequesterProvider BINARY_PROCESS_REQUESTER_PROVIDER_INSTANCE = null;
@@ -103,8 +103,7 @@ public class DependencyContainer {
     DependencyContainer.poller = poller;
     DependencyContainer.suggestionsModeServiceMock = suggestionsModeServiceMock;
     DependencyContainer.completionsEventSender = completionsEventSenderMock;
-    DependencyContainer.binaryRequestsConsecutiveTimeoutsThreshold =
-        binaryRequestsTimeoutsThreshold;
+    DependencyContainer.binaryRequestsTimeoutsThresholdMillis = binaryRequestsTimeoutsThreshold;
     DependencyContainer.binaryRequestConsecutiveRestartsThreshold = binaryRequestRestartsThreshold;
   }
 
@@ -123,7 +122,7 @@ public class DependencyContainer {
               instanceOfBinaryRun(),
               instanceOfBinaryProcessGatewayProvider(),
               instanceOfRequestPoller(),
-              binaryRequestsConsecutiveTimeoutsThreshold,
+              binaryRequestsTimeoutsThresholdMillis,
               binaryRequestConsecutiveRestartsThreshold);
     }
 

--- a/src/main/java/com/tabnine/general/StaticConfig.java
+++ b/src/main/java/com/tabnine/general/StaticConfig.java
@@ -35,7 +35,7 @@ public class StaticConfig {
   public static final int BINARY_MINIMUM_REASONABLE_SIZE = 1000 * 1000; // roughly 1MB
   public static final String SET_STATE_RESPONSE_RESULT_STRING = "Done";
   public static final String UNINSTALLING_FLAG = "--uninstalling";
-  public static final int CONSECUTIVE_TIMEOUTS_THRESHOLD = 80;
+  public static final int BINARY_TIMEOUTS_THRESHOLD_MILLIS = 60_000;
   public static final String BRAND_NAME = "tabnine";
   public static final String TARGET_NAME = getDistributionName();
   public static final String EXECUTABLE_NAME = getExeName();

--- a/src/test/java/com/tabnine/MockedBinaryCompletionTestCase.java
+++ b/src/test/java/com/tabnine/MockedBinaryCompletionTestCase.java
@@ -35,7 +35,7 @@ import org.mockito.Mockito;
 
 public abstract class MockedBinaryCompletionTestCase
     extends LightPlatformCodeInsightFixture4TestCase implements Disposable {
-  private static int TESTS_TIMEOUTS_THRESHOLD = 5;
+  private static int TESTS_TIMEOUTS_THRESHOLD_MILLIS = 500;
   private static int TESTS_RESTARTS_THRESHOLD = 5;
   protected static BinaryProcessGateway binaryProcessGatewayMock =
       Mockito.mock(BinaryProcessGateway.class);
@@ -55,7 +55,7 @@ public abstract class MockedBinaryCompletionTestCase
         new BinaryProcessRequesterPollerCappedImpl(0, 0, 0),
         suggestionsModeServiceMock,
         completionEventSenderMock,
-        TESTS_TIMEOUTS_THRESHOLD,
+        TESTS_TIMEOUTS_THRESHOLD_MILLIS,
         TESTS_RESTARTS_THRESHOLD);
   }
 

--- a/src/test/java/com/tabnine/integration/PredictionTimeoutIntegrationTests.java
+++ b/src/test/java/com/tabnine/integration/PredictionTimeoutIntegrationTests.java
@@ -1,6 +1,8 @@
 package com.tabnine.integration;
 
 import static com.tabnine.general.StaticConfig.COMPLETION_TIME_THRESHOLD;
+import static com.tabnine.testUtils.MockAnswersUtilsKt.returnAfter;
+import static com.tabnine.testUtils.MockAnswersUtilsKt.returnAfterTimeout;
 import static com.tabnine.testUtils.TabnineMatchers.lookupBuilder;
 import static com.tabnine.testUtils.TabnineMatchers.lookupElement;
 import static com.tabnine.testUtils.TestData.*;
@@ -14,7 +16,6 @@ import com.tabnine.binary.*;
 import com.tabnine.binary.exceptions.TabNineDeadException;
 import com.tabnine.general.DependencyContainer;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
@@ -23,13 +24,7 @@ public class PredictionTimeoutIntegrationTests extends MockedBinaryCompletionTes
   @Test
   public void givenAFileWhenCompletionFiredAndResponseTakeMoreThanThresholdThenResponseIsNulled()
       throws Exception {
-    when(binaryProcessGatewayMock.readRawResponse())
-        .thenAnswer(
-            invocation -> {
-              Thread.sleep(COMPLETION_TIME_THRESHOLD + OVERFLOW);
-
-              return A_PREDICTION_RESULT;
-            });
+    when(binaryProcessGatewayMock.readRawResponse()).then(returnAfterTimeout(A_PREDICTION_RESULT));
 
     LookupElement[] actual = myFixture.completeBasic();
 
@@ -38,19 +33,11 @@ public class PredictionTimeoutIntegrationTests extends MockedBinaryCompletionTes
 
   @Test
   public void
-      givenAFileWhenCompletionFiredAndResponseTakeMoreThanThresholdThenResponseIsNulledAndThePrecidingResponseGoThrough()
+      givenAFileWhenCompletionFiredAndResponseTakeMoreThanThresholdThenResponseIsNulledAndThePrecedingResponseGoThrough()
           throws Exception {
-    AtomicBoolean first = new AtomicBoolean(true);
     when(binaryProcessGatewayMock.readRawResponse())
-        .thenAnswer(
-            invocation -> {
-              if (first.get()) {
-                first.set(false);
-                Thread.sleep(COMPLETION_TIME_THRESHOLD + OVERFLOW);
-              }
-
-              return A_PREDICTION_RESULT;
-            });
+        .then(returnAfterTimeout(A_PREDICTION_RESULT))
+        .thenReturn(A_PREDICTION_RESULT);
 
     LookupElement[] actual = myFixture.completeBasic();
 
@@ -68,19 +55,9 @@ public class PredictionTimeoutIntegrationTests extends MockedBinaryCompletionTes
   public void
       givenPreviousTimedOutCompletionWhenCompletionThenPreviousResultIsIgnoredAndCurrentIsReturned()
           throws Exception {
-    AtomicInteger index = new AtomicInteger();
     when(binaryProcessGatewayMock.readRawResponse())
-        .then(
-            (invocation) -> {
-              if (index.getAndIncrement() == 0) {
-                Thread.sleep(COMPLETION_TIME_THRESHOLD + EPSILON);
-
-                return A_PREDICTION_RESULT;
-              }
-
-              Thread.sleep(EPSILON);
-              return SECOND_PREDICTION_RESULT;
-            });
+        .then(returnAfterTimeout(A_PREDICTION_RESULT))
+        .then(returnAfter(SECOND_PREDICTION_RESULT, EPSILON));
 
     assertThat(myFixture.completeBasic(), nullValue());
     assertThat(myFixture.completeBasic(), array(lookupBuilder("hello"), lookupElement("test")));
@@ -90,25 +67,14 @@ public class PredictionTimeoutIntegrationTests extends MockedBinaryCompletionTes
   public void
       givenConsecutiveTimeOutsCompletionWhenCompletionThenPreviousResultIsIgnoredAndCurrentIsReturned()
           throws Exception {
-    AtomicInteger index = new AtomicInteger();
     when(binaryProcessGatewayMock.readRawResponse())
-        .then(
-            (invocation) -> {
-              if (index.getAndIncrement()
-                  < DependencyContainer.binaryRequestsConsecutiveTimeoutsThreshold) {
-                Thread.sleep(COMPLETION_TIME_THRESHOLD + EPSILON);
+        .then(returnAfterTimeout(A_PREDICTION_RESULT))
+        .then(returnAfterTimeout(A_PREDICTION_RESULT))
+        .then(returnAfter(SECOND_PREDICTION_RESULT, EPSILON));
 
-                return A_PREDICTION_RESULT;
-              }
-
-              Thread.sleep(EPSILON);
-              return SECOND_PREDICTION_RESULT;
-            });
-
-    for (int i = 0; i < DependencyContainer.binaryRequestsConsecutiveTimeoutsThreshold; i++) {
-      assertThat(myFixture.completeBasic(), nullValue());
-    }
-
+    assertThat(myFixture.completeBasic(), nullValue());
+    Thread.sleep(DependencyContainer.binaryRequestsTimeoutsThresholdMillis + EPSILON);
+    assertThat(myFixture.completeBasic(), nullValue());
     verify(binaryProcessGatewayProviderMock).generateBinaryProcessGateway();
     assertThat(myFixture.completeBasic(), array(lookupBuilder("hello"), lookupElement("test")));
   }
@@ -116,36 +82,15 @@ public class PredictionTimeoutIntegrationTests extends MockedBinaryCompletionTes
   @Test
   public void givenCompletionTimeOutsButNotConsecutiveWhenCompletionThenRestartIsNotHappening()
       throws Exception {
-    AtomicInteger index = new AtomicInteger();
     when(binaryProcessGatewayMock.readRawResponse())
-        .then(
-            (invocation) -> {
-              int currentIndex = index.getAndIncrement();
+        .then(returnAfterTimeout(A_PREDICTION_RESULT))
+        .thenReturn(A_PREDICTION_RESULT)
+        .then(returnAfterTimeout(A_PREDICTION_RESULT))
+        .thenReturn(SECOND_PREDICTION_RESULT);
 
-              if (currentIndex == INDEX_OF_SOME_VALID_RESULT_BETWEEN_TIMEOUTS) {
-                return A_PREDICTION_RESULT;
-              }
-
-              if (currentIndex
-                  < DependencyContainer.binaryRequestsConsecutiveTimeoutsThreshold + OVERFLOW) {
-                Thread.sleep(COMPLETION_TIME_THRESHOLD + EPSILON);
-
-                return A_PREDICTION_RESULT;
-              }
-
-              Thread.sleep(EPSILON);
-              return SECOND_PREDICTION_RESULT;
-            });
-
-    for (int i = 0;
-        i < DependencyContainer.binaryRequestsConsecutiveTimeoutsThreshold + OVERFLOW;
-        i++) {
-      if (i != INDEX_OF_SOME_VALID_RESULT_BETWEEN_TIMEOUTS) {
-        assertThat(myFixture.completeBasic(), nullValue());
-      } else {
-        myFixture.completeBasic();
-      }
-    }
+    assertThat(myFixture.completeBasic(), nullValue());
+    assertThat(myFixture.completeBasic(), notNullValue());
+    assertThat(myFixture.completeBasic(), nullValue());
 
     assertThat(myFixture.completeBasic(), array(lookupBuilder("hello"), lookupElement("test")));
     verify(binaryProcessGatewayProviderMock, never()).generateBinaryProcessGateway();

--- a/src/test/java/com/tabnine/testUtils/MockAnswersUtils.kt
+++ b/src/test/java/com/tabnine/testUtils/MockAnswersUtils.kt
@@ -1,0 +1,15 @@
+package com.tabnine.testUtils
+
+import com.tabnine.general.StaticConfig
+import org.mockito.stubbing.Answer
+
+fun returnAfterTimeout(result: String): Answer<Any> {
+    return returnAfter(result, StaticConfig.COMPLETION_TIME_THRESHOLD + TestData.EPSILON)
+}
+
+fun returnAfter(result: String, millis: Int): Answer<Any> {
+    return Answer<Any> {
+        Thread.sleep(millis.toLong())
+        result
+    }
+}

--- a/src/test/java/com/tabnine/testUtils/TestData.java
+++ b/src/test/java/com/tabnine/testUtils/TestData.java
@@ -51,7 +51,6 @@ public class TestData {
           + "\"}\n";
   public static final String SET_STATE_RESPONSE = "{\"result\":\"Done\"}";
   public static final String NULL_RESULT = "null";
-  public static final int INDEX_OF_SOME_VALID_RESULT_BETWEEN_TIMEOUTS = 2;
   public static final String A_COMMAND = "testing";
 
   public static byte[] binaryContentSized(int size) {


### PR DESCRIPTION
### Problem
We were declaring the binary as "bad" based on x consecutive requests that timed out.
This approach proved to be incorrect, as since we defined this x, we added some serious polling requests - thus we began to reach this timeout threshold too quickly.

### Solution
In #424, I increased this threshold from 20 to 80, just to remediate with a quick and easy solution.

This pr is the more serious solution - measure time between successful requests instead of TOs counter.
The logic goes like so:
1. on successful request - restart timeouts tracking
2. on timeout:
    1. if it's the first after a successful request - set the time to now.
    2. if now - `firstTimeoutMillis` > threshold -> restart
Current threshold is 1 minute (60k ms). 