### PR TITLE
DEV2-1779: trigger autocomplete on indentation

### DIFF
--- a/src/main/java/com/tabnine/inline/CompletionUtils.kt
+++ b/src/main/java/com/tabnine/inline/CompletionUtils.kt
@@ -1,24 +1,21 @@
 package com.tabnine.inline
 
 import com.intellij.openapi.editor.Document
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.TextRange
-import com.tabnine.inline.render.getTabSize
 import java.util.regex.Pattern
 
 object CompletionUtils {
     private val END_OF_LINE_VALID_PATTERN = Pattern.compile("^\\s*[)}\\]\"'`]*\\s*[:{;,]?\\s*$")
 
     @JvmStatic
-    fun isValidDocumentChange(editor: Editor, document: Document, newOffset: Int, previousOffset: Int): Boolean {
+    fun isValidDocumentChange(document: Document, newOffset: Int, previousOffset: Int): Boolean {
         if (newOffset < 0 || previousOffset > newOffset) return false
 
         val addedText = document.getText(TextRange(previousOffset, newOffset))
         return (
             isValidMidlinePosition(document, newOffset) &&
                 isValidNonEmptyChange(addedText.length, addedText) &&
-                isSingleCharNonWhitespaceChange(addedText) &&
-                isNotIndentationChange(addedText, editor)
+                isSingleCharNonWhitespaceChange(addedText)
             )
     }
 
@@ -39,10 +36,5 @@ object CompletionUtils {
     @JvmStatic
     fun isSingleCharNonWhitespaceChange(newText: String): Boolean {
         return newText.trim().length <= 1
-    }
-
-    @JvmStatic
-    fun isNotIndentationChange(newText: String, editor: Editor): Boolean {
-        return newText != getTabSize(editor)?.let { " ".repeat(it) }
     }
 }

--- a/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
+++ b/src/main/java/com/tabnine/inline/TabnineDocumentListener.java
@@ -64,7 +64,7 @@ public class TabnineDocumentListener implements BulkAwareDocumentListener {
       return true;
     }
 
-    return !CompletionUtils.isValidDocumentChange(editor, document, offset, event.getOffset());
+    return !CompletionUtils.isValidDocumentChange(document, offset, event.getOffset());
   }
 
   @Nullable


### PR DESCRIPTION
this will solve the multiple events that are dispatched when typing enter after opening bracket `{`

https://user-images.githubusercontent.com/10290661/207634165-af7b9b30-3673-4d96-8c8b-ce4b0665b838.mp4

https://user-images.githubusercontent.com/10290661/207635602-25f64915-24d5-4b0d-8799-db9970995b36.mp4


