### PR TITLE
DEV2-1536 increase restarts threshold

### DIFF
--- a/src/main/java/com/tabnine/general/StaticConfig.java
+++ b/src/main/java/com/tabnine/general/StaticConfig.java
@@ -28,7 +28,7 @@ public class StaticConfig {
   public static final int COMPLETION_TIME_THRESHOLD = 1000;
   public static final int NEWLINE_COMPLETION_TIME_THRESHOLD = 3000;
   public static final int ILLEGAL_RESPONSE_THRESHOLD = 5;
-  public static final int CONSECUTIVE_RESTART_THRESHOLD = 5;
+  public static final int CONSECUTIVE_RESTART_THRESHOLD = 20;
   public static final int ADVERTISEMENT_MAX_LENGTH = 100;
   public static final int MAX_OFFSET = 100000; // 100 KB
   public static final int SLEEP_TIME_BETWEEN_FAILURES = 1000;


### PR DESCRIPTION
The theory is:
-> Multiple IDEs are running, current version = `x.x.x`
-> IDE 1 downloads a new version (= `x.x.y`) and schedules a restart to all the binaries
-> bootstrapper 2 receives the scheduled restarts and its bootstrapper kills the process -- current `.active` file is `x.x.x`
-> IDE 2 detects that the binary is dead, and spawns a new process from the `.active` file - which is still `x.x.x`
-> bootstrapper 2 detects that `x.x.y` is the desired version which is > from current (`x.x.x`) - marks the `.active` to be `x.x.y` and kills the process
-> IDE 2 detects a dead binary for the second time, and re-runs from the `.active` - which is now the updated `x.x.y`.

This means that IDE 2 restarts **twice** per version update

The restarts threshold was 5 ==> if there were 5 requests while these 2 restarts were taking place, without a successful request between them - the exception is thrown.