### PR TITLE
DEV2-1967: Use CNAME for tabnine-logs

### DIFF
--- a/channels/alpha/com/tabnine/config/Config.java
+++ b/channels/alpha/com/tabnine/config/Config.java
@@ -3,5 +3,5 @@ package com.tabnine.config;
 public class Config {
   public static final String CHANNEL = "alpha";
   public static final Boolean DISPLAY_ORIGIN = true;
-  public static final String LOGGER_HOST = "https://tabnine-logs-gateway.herokuapp.com";
+  public static final String LOGGER_HOST = "https://ij-logs-gateway.tabnine.com";
 }

--- a/channels/alpha/com/tabnine/config/Config.java
+++ b/channels/alpha/com/tabnine/config/Config.java
@@ -3,5 +3,5 @@ package com.tabnine.config;
 public class Config {
   public static final String CHANNEL = "alpha";
   public static final Boolean DISPLAY_ORIGIN = true;
-  public static final String LOGGER_HOST = "https://ij-logs-gateway.tabnine.com";
+  public static final String LOGGER_HOST = "https://ide-logs-gateway.tabnine.com";
 }

--- a/channels/beta/com/tabnine/config/Config.java
+++ b/channels/beta/com/tabnine/config/Config.java
@@ -3,5 +3,5 @@ package com.tabnine.config;
 public class Config {
   public static final String CHANNEL = "beta";
   public static final Boolean DISPLAY_ORIGIN = false;
-  public static final String LOGGER_HOST = "https://ij-logs-gateway.tabnine.com";
+  public static final String LOGGER_HOST = "https://ide-logs-gateway.tabnine.com";
 }

--- a/channels/beta/com/tabnine/config/Config.java
+++ b/channels/beta/com/tabnine/config/Config.java
@@ -3,5 +3,5 @@ package com.tabnine.config;
 public class Config {
   public static final String CHANNEL = "beta";
   public static final Boolean DISPLAY_ORIGIN = false;
-  public static final String LOGGER_HOST = "https://tabnine-logs-gateway.herokuapp.com";
+  public static final String LOGGER_HOST = "https://ij-logs-gateway.tabnine.com";
 }

--- a/channels/production/com/tabnine/config/Config.java
+++ b/channels/production/com/tabnine/config/Config.java
@@ -3,5 +3,5 @@ package com.tabnine.config;
 public class Config {
   public static final String CHANNEL = "production";
   public static final Boolean DISPLAY_ORIGIN = false;
-  public static final String LOGGER_HOST = "https://tabnine-logs-gateway.herokuapp.com";
+  public static final String LOGGER_HOST = "https://ij-logs-gateway.tabnine.com";
 }

--- a/channels/production/com/tabnine/config/Config.java
+++ b/channels/production/com/tabnine/config/Config.java
@@ -3,5 +3,5 @@ package com.tabnine.config;
 public class Config {
   public static final String CHANNEL = "production";
   public static final Boolean DISPLAY_ORIGIN = false;
-  public static final String LOGGER_HOST = "https://ij-logs-gateway.tabnine.com";
+  public static final String LOGGER_HOST = "https://ide-logs-gateway.tabnine.com";
 }


### PR DESCRIPTION
This is needed so we can move this service to GCP
