### PR TITLE
DEV2-1921 fix checkout step

### DIFF
--- a/.github/workflows/production-new-version.yml
+++ b/.github/workflows/production-new-version.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_BUILDER_TOKEN }}
-          fetch-depth: 0
 
       - uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
from the [checkout action's readme](https://github.com/actions/checkout):

> Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Set fetch-depth: 0 to fetch all history for all branches and tags.