### PR TITLE
DEV2-2041: fix impact of multiple document change event on inline completions

### DIFF
--- a/src/main/java/com/tabnine/logging/TabnineLogDispatcher.kt
+++ b/src/main/java/com/tabnine/logging/TabnineLogDispatcher.kt
@@ -3,6 +3,7 @@ package com.tabnine.logging
 import com.google.gson.JsonObject
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.PermanentInstallationID
 import com.intellij.openapi.diagnostic.Logger
 import com.tabnine.config.Config
 import com.tabnine.general.Utils
@@ -22,6 +23,7 @@ class TabnineLogDispatcher(private val loggerDelegate: Logger) {
         body.addProperty("pluginVersion", Utils.cmdSanitize(Utils.getTabNinePluginVersion()))
         body.addProperty("os", System.getProperty("os.name"))
         body.addProperty("channel", Config.CHANNEL)
+        body.addProperty("userId", PermanentInstallationID.get())
         return body
     }
 


### PR DESCRIPTION
**Background:**
In some cases, IJ fires multiple events on a single document change. For example, after a line breakת it fires two events, where the first event is relevant for the completion but the other one is not ("\n" change event and then "empty" event with offset correction).
When we are about to render the completion, we check if it's relevant by checking that modificationStamp and offset haven't changed. 

**The problem:**
When such a scenario occurs (like that in the example), This is the order of events:
1. we get the first "\n" event 
2. we save the editor's modificationStamp and offset
3. we are invoking a non-AWT thread that should handle the completions fetching and rendering
4. we get the second "empty" event which modifies the editor's modificationStamp and offset - this event is blocked as we don't get completions for such a change
5. we are about to render the completions, but the modificationStamp and the offset are not equal to the new editor values, and therefore we are not rendering the completion.

When we are executing a non-AWT thread, so the order is inconsistent.

**The solution:**
Executing an AWT thread. this is the new order of events:
1. we get the first "\n" event
2. we are invoking an AWT thread that should handle the completions fetching and rendering, and then waiting
3. we get the second "empty" event which modifies the editor's modificationStamp and offset - this event is blocked as we don't get completions for such a change
4. the AWT thread starts running
5. we save the editor's modificationStamp and offset (now they are updated since the second event already fired)
6. we make sure that the editor values are equal
7. we are rendering the completion

before:

https://user-images.githubusercontent.com/10290661/209946430-74da6378-39bd-4d97-b41c-862c8154a175.mp4

after:

https://user-images.githubusercontent.com/10290661/209946405-20675fdf-784d-4dd6-a80c-8d92b19f6ba2.mp4


