### PR TITLE
DEV2-2042: refetch suggestions after debounce

### DIFF
--- a/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
+++ b/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
@@ -121,21 +121,28 @@ public class InlineCompletionHandler {
                 return;
               }
 
-              lastDebounceRenderTask =
-                  executeThread(
-                      () -> {
-                        List<TabNineCompletion> afterDebounceCompletions =
-                            retrieveInlineCompletion(editor, offset, tabSize, completionAdjustment);
-                        rerenderCompletion(
-                            editor,
-                            afterDebounceCompletions,
-                            offset,
-                            modificationStamp,
-                            completionAdjustment);
-                      },
-                      debounceTime,
-                      TimeUnit.MILLISECONDS);
+              refetchCompletionsAfterDebounce(
+                  editor, tabSize, offset, modificationStamp, completionAdjustment, debounceTime);
             });
+  }
+
+  private void refetchCompletionsAfterDebounce(
+      @NotNull Editor editor,
+      Integer tabSize,
+      int offset,
+      long modificationStamp,
+      @NotNull CompletionAdjustment completionAdjustment,
+      long debounceTime) {
+    lastDebounceRenderTask =
+        executeThread(
+            () -> {
+              List<TabNineCompletion> completions =
+                  retrieveInlineCompletion(editor, offset, tabSize, completionAdjustment);
+              rerenderCompletion(
+                  editor, completions, offset, modificationStamp, completionAdjustment);
+            },
+            debounceTime,
+            TimeUnit.MILLISECONDS);
   }
 
   private void rerenderCompletion(

--- a/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
+++ b/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
@@ -54,7 +54,7 @@ public class InlineCompletionHandler {
   public void retrieveAndShowCompletion(
       @NotNull Editor editor,
       int offset,
-      @NotNull String userInput,
+      String userInput,
       @NotNull CompletionAdjustment completionAdjustment) {
     Integer tabSize = GraphicsUtilsKt.getTabSize(editor);
 
@@ -65,22 +65,28 @@ public class InlineCompletionHandler {
     List<TabNineCompletion> cachedCompletions =
         InlineCompletionCache.getInstance().retrieveAdjustedCompletions(editor, userInput);
     if (!cachedCompletions.isEmpty()) {
-      renderCachedCompletions(editor, offset, tabSize, cachedCompletions, completionAdjustment);
+      handleCachedCompletions(editor, offset, tabSize, cachedCompletions, completionAdjustment);
       return;
     }
 
     ApplicationManager.getApplication()
         .invokeLater(
-            () ->
-                renderNewCompletions(
-                    editor,
-                    tabSize,
-                    getCurrentEditorOffset(editor, userInput),
-                    editor.getDocument().getModificationStamp(),
-                    completionAdjustment));
+            () -> {
+              int updatedOffset =
+                  editor.getCaretModel().getOffset()
+                      + (ApplicationManager.getApplication().isUnitTestMode()
+                          ? userInput.length()
+                          : 0);
+              handleNewCompletions(
+                  editor,
+                  tabSize,
+                  updatedOffset,
+                  editor.getDocument().getModificationStamp(),
+                  completionAdjustment);
+            });
   }
 
-  private void renderCachedCompletions(
+  private void handleCachedCompletions(
       @NotNull Editor editor,
       int offset,
       Integer tabSize,
@@ -92,12 +98,7 @@ public class InlineCompletionHandler {
             () -> retrieveInlineCompletion(editor, offset, tabSize, completionAdjustment));
   }
 
-  private int getCurrentEditorOffset(@NotNull Editor editor, @NotNull String userInput) {
-    return editor.getCaretModel().getOffset()
-        + (ApplicationManager.getApplication().isUnitTestMode() ? userInput.length() : 0);
-  }
-
-  private void renderNewCompletions(
+  private void handleNewCompletions(
       @NotNull Editor editor,
       Integer tabSize,
       int offset,


### PR DESCRIPTION
If debounce is enabled, re-fetch completions after debounce time has passed to get better completions.
In the video, we can see that after the debounce time we get new completions that we didn't get before.

https://user-images.githubusercontent.com/10290661/209967128-80496c60-74b3-408f-af28-1f9fdd97a705.mp4

