### PR TITLE
DEV2-1956 fix serialization

### DIFF
--- a/src/main/java/com/tabnine/binary/BinaryProcessRequesterProvider.java
+++ b/src/main/java/com/tabnine/binary/BinaryProcessRequesterProvider.java
@@ -3,12 +3,13 @@ package com.tabnine.binary;
 import static com.tabnine.general.StaticConfig.*;
 import static com.tabnine.general.Utils.executeThread;
 
-import com.google.gson.GsonBuilder;
+import com.google.gson.*;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.ObjectUtils;
 import com.tabnine.binary.exceptions.BinaryRequestTimeoutException;
 import java.util.Collections;
 import java.util.concurrent.Future;
+import org.jetbrains.annotations.NotNull;
 
 public class BinaryProcessRequesterProvider {
   private final BinaryRun binaryRun;
@@ -105,7 +106,21 @@ public class BinaryProcessRequesterProvider {
 
     this.binaryProcessRequester =
         new BinaryProcessRequesterImpl(
-            new ParsedBinaryIO(new GsonBuilder().create(), binaryProcessGateway));
+            new ParsedBinaryIO(
+                new GsonBuilder()
+                    .registerTypeAdapter(Double.class, doubleOrIntSerializer())
+                    .create(),
+                binaryProcessGateway));
+  }
+
+  @NotNull
+  private static JsonSerializer<Double> doubleOrIntSerializer() {
+    return (src, type, jsonSerializationContext) -> {
+      if (src == src.longValue()) {
+        return new JsonPrimitive(src.longValue());
+      }
+      return new JsonPrimitive(src);
+    };
   }
 
   private synchronized void initProcess(BinaryProcessGateway binaryProcessGateway) {


### PR DESCRIPTION
### Problem
Once we're working with a generic `Map<String, Object>`, Gson decides that it serializes all numbers to floats, so 1 will turn into 1.0.
Then we return this 1.0 to the binary, and the binary expects `usize` - so it fails to deserialize the context.
Example context object as being sent from the plugin:
```json
{
  "snippet_id": "649abb3e-3c85-4662-93f6-354ce169e6a6",
  "user_intent": "NewLine",
  "intent_metadata": {
    "current_line_indentation": 12.0,
    "previous_line_indentation": 12.0,
    "triggered_after_character": ","
  },
  "is_cached": true,
  "generated_tokens": 20.0,
  "first_token_score": "0.961",
  "stop_reason": "stop_token",
  "response_time_ms": 983.0,
  "context_len": 346.0,
  "resolved_dependencies": false,
  "fetched_hinting": false
}
```
### Solution
Based on this [S.O thread](https://stackoverflow.com/questions/15507997/how-to-prevent-gson-from-expressing-integers-as-floats) (second answer) - I'm telling Gson to serialize doubles that end with ".0" to longs.
I made sure that Rust is ok with this by running this test:
```rust
#[test]
fn a() {
    let a = serde_json::from_str::<f32>("1").unwrap();
    assert_eq!(a, 1.0);
}
```
and it sure passes. So there's no issue with sending round floats as longs to Rust. 


 