### PR TITLE
DEV2-2022 use new api version 4.4.223

### DIFF
--- a/src/main/java/com/tabnine/binary/requests/autocomplete/AutocompleteResponse.java
+++ b/src/main/java/com/tabnine/binary/requests/autocomplete/AutocompleteResponse.java
@@ -1,13 +1,10 @@
 package com.tabnine.binary.requests.autocomplete;
 
 import com.tabnine.binary.BinaryResponse;
-import java.util.Map;
-import org.jetbrains.annotations.Nullable;
 
 public class AutocompleteResponse implements BinaryResponse {
   public String old_prefix;
   public ResultEntry[] results;
   public String[] user_message;
   public boolean is_locked;
-  @Nullable public Map<String, Object> snippet_context;
 }

--- a/src/main/java/com/tabnine/binary/requests/autocomplete/CompletionMetadata.kt
+++ b/src/main/java/com/tabnine/binary/requests/autocomplete/CompletionMetadata.kt
@@ -1,0 +1,17 @@
+package com.tabnine.binary.requests.autocomplete
+
+import com.tabnine.general.CompletionKind
+import com.tabnine.general.CompletionOrigin
+
+data class CompletionMetadata(
+    val origin: CompletionOrigin? = null,
+    val detail: String? = null,
+    val completion_kind: CompletionKind? = null,
+    val snippet_context: Map<String, Any>? = null,
+    val is_cached: Boolean? = null,
+    val deprecated: Boolean? = null,
+) {
+    fun getIsDeprecated(): Boolean {
+        return deprecated ?: false
+    }
+}

--- a/src/main/java/com/tabnine/binary/requests/autocomplete/ResultEntry.java
+++ b/src/main/java/com/tabnine/binary/requests/autocomplete/ResultEntry.java
@@ -1,23 +1,20 @@
 package com.tabnine.binary.requests.autocomplete;
 
 import com.tabnine.general.CompletionKind;
-import com.tabnine.general.CompletionOrigin;
 import com.tabnine.intellij.completions.Completion;
 
 public class ResultEntry implements Completion {
   public String new_prefix;
   public String old_suffix;
   public String new_suffix;
-
-  public CompletionOrigin origin;
-  public String detail;
-  public Boolean deprecated;
-  public CompletionKind completion_kind;
-  public Boolean is_cached;
-  // TODO other lsp types
+  public CompletionMetadata completion_metadata;
 
   @Override
   public boolean isSnippet() {
-    return this.completion_kind == CompletionKind.Snippet;
+    if (this.completion_metadata == null) {
+      return false;
+    }
+
+    return this.completion_metadata.getCompletion_kind() == CompletionKind.Snippet;
   }
 }

--- a/src/main/java/com/tabnine/binary/requests/notifications/shown/SuggestionShownRequest.kt
+++ b/src/main/java/com/tabnine/binary/requests/notifications/shown/SuggestionShownRequest.kt
@@ -3,10 +3,13 @@ package com.tabnine.binary.requests.notifications.shown
 import com.tabnine.binary.BinaryRequest
 import com.tabnine.binary.exceptions.TabNineInvalidResponseException
 import com.tabnine.binary.requests.EmptyResponse
-import com.tabnine.general.CompletionKind
-import com.tabnine.general.CompletionOrigin
+import com.tabnine.binary.requests.autocomplete.CompletionMetadata
 
-data class SuggestionShownRequest(var origin: CompletionOrigin?, var completion_kind: CompletionKind?, var net_length: Int, var filename: String) : BinaryRequest<EmptyResponse> {
+data class SuggestionShownRequest(
+    var net_length: Int,
+    var filename: String,
+    var metadata: CompletionMetadata
+) : BinaryRequest<EmptyResponse> {
     override fun response(): Class<EmptyResponse> {
         return EmptyResponse::class.java
     }

--- a/src/main/java/com/tabnine/general/StaticConfig.java
+++ b/src/main/java/com/tabnine/general/StaticConfig.java
@@ -26,7 +26,7 @@ public class StaticConfig {
   public static final String TABNINE_PLUGIN_ID_RAW = "com.tabnine.TabNine";
   public static final PluginId TABNINE_PLUGIN_ID = PluginId.getId(TABNINE_PLUGIN_ID_RAW);
   public static final int MAX_COMPLETIONS = 5;
-  public static final String BINARY_PROTOCOL_VERSION = "4.4.71";
+  public static final String BINARY_PROTOCOL_VERSION = "4.4.223";
   public static final int COMPLETION_TIME_THRESHOLD = 1000;
   public static final int NEWLINE_COMPLETION_TIME_THRESHOLD = 3000;
   public static final int ILLEGAL_RESPONSE_THRESHOLD = 5;

--- a/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
+++ b/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
@@ -235,6 +235,7 @@ public class InlineCompletionHandler {
       FirstSuggestionHintTooltip.handle(editor);
     }
 
+    if (completion.completionMetadata == null) return;
     Boolean isCached = completion.completionMetadata.is_cached();
     // binary is not supporting api version ^4.0.57
     if (isCached == null) return;

--- a/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
+++ b/src/main/java/com/tabnine/inline/InlineCompletionHandler.java
@@ -12,7 +12,6 @@ import com.intellij.util.ObjectUtils;
 import com.tabnine.balloon.FirstSuggestionHintTooltip;
 import com.tabnine.binary.BinaryRequestFacade;
 import com.tabnine.binary.requests.autocomplete.AutocompleteResponse;
-import com.tabnine.binary.requests.autocomplete.ResultEntry;
 import com.tabnine.binary.requests.notifications.shown.SnippetShownRequest;
 import com.tabnine.binary.requests.notifications.shown.SuggestionShownRequest;
 import com.tabnine.capabilities.CapabilitiesService;
@@ -275,11 +274,14 @@ public class InlineCompletionHandler {
       SuggestionTrigger suggestionTrigger) {
     return IntStream.range(0, completions.results.length)
         .mapToObj(
-            index -> {
-              ResultEntry resultEntry = completions.results[index];
-              return CompletionUtils.createTabnineCompletion(
-                  document, offset, completions.old_prefix, resultEntry, index, suggestionTrigger);
-            })
+            index ->
+                CompletionUtils.createTabnineCompletion(
+                    document,
+                    offset,
+                    completions.old_prefix,
+                    completions.results[index],
+                    index,
+                    suggestionTrigger))
         .filter(completion -> completion != null && !completion.getSuffix().isEmpty())
         .collect(Collectors.toList());
   }

--- a/src/main/java/com/tabnine/inline/render/DefaultTabnineInlay.kt
+++ b/src/main/java/com/tabnine/inline/render/DefaultTabnineInlay.kt
@@ -90,7 +90,7 @@ class DefaultTabnineInlay(parent: Disposable) : TabnineInlay {
         completion: TabNineCompletion,
         offset: Int
     ) {
-        val blockElementRenderer = BlockElementRenderer(editor, lines, completion.deprecated)
+        val blockElementRenderer = BlockElementRenderer(editor, lines, completion.completionMetadata.deprecated ?: false)
         val element = editor
             .inlayModel
             .addBlockElement(
@@ -152,7 +152,7 @@ class DefaultTabnineInlay(parent: Disposable) : TabnineInlay {
     ): Inlay<InlineElementRenderer>? {
         val element = editor
             .inlayModel
-            .addInlineElement(offset, true, InlineElementRenderer(editor, before, completion.deprecated))
+            .addInlineElement(offset, true, InlineElementRenderer(editor, before, completion.completionMetadata.deprecated ?: false))
 
         element?.let { Disposer.register(this, it) }
 

--- a/src/main/java/com/tabnine/inline/render/DefaultTabnineInlay.kt
+++ b/src/main/java/com/tabnine/inline/render/DefaultTabnineInlay.kt
@@ -90,7 +90,7 @@ class DefaultTabnineInlay(parent: Disposable) : TabnineInlay {
         completion: TabNineCompletion,
         offset: Int
     ) {
-        val blockElementRenderer = BlockElementRenderer(editor, lines, completion.completionMetadata.deprecated ?: false)
+        val blockElementRenderer = BlockElementRenderer(editor, lines, completion.completionMetadata?.deprecated ?: false)
         val element = editor
             .inlayModel
             .addBlockElement(
@@ -152,7 +152,7 @@ class DefaultTabnineInlay(parent: Disposable) : TabnineInlay {
     ): Inlay<InlineElementRenderer>? {
         val element = editor
             .inlayModel
-            .addInlineElement(offset, true, InlineElementRenderer(editor, before, completion.completionMetadata.deprecated ?: false))
+            .addInlineElement(offset, true, InlineElementRenderer(editor, before, completion.completionMetadata?.deprecated ?: false))
 
         element?.let { Disposer.register(this, it) }
 

--- a/src/main/java/com/tabnine/intellij/completions/CompletionUtils.java
+++ b/src/main/java/com/tabnine/intellij/completions/CompletionUtils.java
@@ -11,7 +11,6 @@ import com.intellij.openapi.util.TextRange;
 import com.tabnine.binary.requests.autocomplete.ResultEntry;
 import com.tabnine.general.SuggestionTrigger;
 import com.tabnine.prediction.TabNineCompletion;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -50,7 +49,6 @@ public class CompletionUtils {
       String oldPrefix,
       ResultEntry result,
       int index,
-      Map<String, Object> snippetContext,
       SuggestionTrigger suggestionTrigger) {
     String cursorPrefix = CompletionUtils.getCursorPrefix(document, offset);
     String cursorSuffix = CompletionUtils.getCursorSuffix(document, offset);
@@ -58,28 +56,16 @@ public class CompletionUtils {
       return null;
     }
 
-    TabNineCompletion completion =
-        new TabNineCompletion(
-            oldPrefix,
-            result.new_prefix,
-            result.old_suffix,
-            result.new_suffix,
-            index,
-            cursorPrefix,
-            cursorSuffix,
-            result.origin,
-            result.completion_kind,
-            result.is_cached,
-            snippetContext,
-            suggestionTrigger);
-
-    completion.detail = result.detail;
-
-    if (result.deprecated != null) {
-      completion.deprecated = result.deprecated;
-    }
-
-    return completion;
+    return new TabNineCompletion(
+        oldPrefix,
+        result.new_prefix,
+        result.old_suffix,
+        result.new_suffix,
+        index,
+        cursorPrefix,
+        cursorSuffix,
+        result.completion_metadata,
+        suggestionTrigger);
   }
 
   static int completionLimit(

--- a/src/main/java/com/tabnine/intellij/completions/TabNineCompletionContributor.java
+++ b/src/main/java/com/tabnine/intellij/completions/TabNineCompletionContributor.java
@@ -159,7 +159,9 @@ public class TabNineCompletionContributor extends CompletionContributor {
                       LookupElement element, LookupElementPresentation presentation) {
                     TabNineCompletion lookupElement = (TabNineCompletion) element.getObject();
                     String typeText = (locked ? LIMITATION_SYMBOL : "");
-                    if (Config.DISPLAY_ORIGIN) {
+                    if (Config.DISPLAY_ORIGIN
+                        && lookupElement.completionMetadata != null
+                        && lookupElement.completionMetadata.getOrigin() != null) {
                       typeText += lookupElement.completionMetadata.getOrigin().toString();
                     } else {
                       typeText += StaticConfig.BRAND_NAME;
@@ -167,7 +169,9 @@ public class TabNineCompletionContributor extends CompletionContributor {
 
                     presentation.setTypeText(typeText);
                     presentation.setItemTextBold(false);
-                    presentation.setStrikeout(lookupElement.completionMetadata.getIsDeprecated());
+                    presentation.setStrikeout(
+                        lookupElement.completionMetadata != null
+                            && lookupElement.completionMetadata.getIsDeprecated());
                     presentation.setItemText(lookupElement.newPrefix);
                     presentation.setIcon(ICON);
                   }

--- a/src/main/java/com/tabnine/intellij/completions/TabNineCompletionContributor.java
+++ b/src/main/java/com/tabnine/intellij/completions/TabNineCompletionContributor.java
@@ -145,18 +145,9 @@ public class TabNineCompletionContributor extends CompletionContributor {
             oldPrefix,
             result,
             index,
-            // since snippets doesn't work without inline completions and the intent is only
-            // relevant for snippets, this is always null.
-            null,
             null);
     if (completion == null) {
       return null;
-    }
-
-    completion.detail = result.detail;
-
-    if (result.deprecated != null) {
-      completion.deprecated = result.deprecated;
     }
 
     LookupElementBuilder lookupElementBuilder =
@@ -169,13 +160,14 @@ public class TabNineCompletionContributor extends CompletionContributor {
                     TabNineCompletion lookupElement = (TabNineCompletion) element.getObject();
                     String typeText = (locked ? LIMITATION_SYMBOL : "");
                     if (Config.DISPLAY_ORIGIN) {
-                      typeText += lookupElement.origin.toString();
+                      typeText += lookupElement.completionMetadata.getOrigin().toString();
                     } else {
                       typeText += StaticConfig.BRAND_NAME;
                     }
+
                     presentation.setTypeText(typeText);
                     presentation.setItemTextBold(false);
-                    presentation.setStrikeout(lookupElement.deprecated);
+                    presentation.setStrikeout(lookupElement.completionMetadata.getIsDeprecated());
                     presentation.setItemText(lookupElement.newPrefix);
                     presentation.setIcon(ICON);
                   }

--- a/src/main/java/com/tabnine/prediction/TabNineCompletion.java
+++ b/src/main/java/com/tabnine/prediction/TabNineCompletion.java
@@ -3,13 +3,14 @@ package com.tabnine.prediction;
 import com.intellij.codeInsight.lookup.impl.LookupCellRenderer;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.util.containers.FList;
+import com.tabnine.binary.requests.autocomplete.CompletionMetadata;
 import com.tabnine.general.CompletionKind;
 import com.tabnine.general.CompletionOrigin;
 import com.tabnine.general.SuggestionTrigger;
 import com.tabnine.intellij.completions.Completion;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import org.jetbrains.annotations.Nullable;
 
 public class TabNineCompletion implements Completion {
   public final String oldPrefix;
@@ -19,14 +20,8 @@ public class TabNineCompletion implements Completion {
   public final int index;
   public String cursorPrefix;
   public String cursorSuffix;
-  public CompletionOrigin origin;
-  public CompletionKind completionKind;
   public SuggestionTrigger suggestionTrigger;
-  public Boolean isCached;
-  public Map<String, Object> snippet_context;
-
-  public String detail = null;
-  public boolean deprecated = false;
+  public CompletionMetadata completionMetadata;
   private String fullSuffix = null;
 
   public TabNineCompletion(
@@ -37,10 +32,7 @@ public class TabNineCompletion implements Completion {
       int index,
       String cursorPrefix,
       String cursorSuffix,
-      CompletionOrigin origin,
-      CompletionKind completionKind,
-      Boolean isCached,
-      Map<String, Object> snippet_context,
+      CompletionMetadata completionMetadata,
       SuggestionTrigger suggestionTrigger) {
     this.oldPrefix = oldPrefix;
     this.newPrefix = newPrefix;
@@ -49,10 +41,7 @@ public class TabNineCompletion implements Completion {
     this.index = index;
     this.cursorPrefix = cursorPrefix;
     this.cursorSuffix = cursorSuffix;
-    this.origin = origin;
-    this.completionKind = completionKind;
-    this.isCached = isCached;
-    this.snippet_context = snippet_context;
+    this.completionMetadata = completionMetadata;
     this.suggestionTrigger = suggestionTrigger;
   }
 
@@ -65,15 +54,13 @@ public class TabNineCompletion implements Completion {
         this.index,
         cursorPrefix,
         this.cursorSuffix,
-        this.origin,
-        this.completionKind,
-        true,
-        this.snippet_context,
+        this.completionMetadata,
         this.suggestionTrigger);
   }
 
+  @Nullable
   public CompletionOrigin getOrigin() {
-    return origin;
+    return completionMetadata.getOrigin();
   }
 
   public String getSuffix() {
@@ -102,6 +89,10 @@ public class TabNineCompletion implements Completion {
 
   @Override
   public boolean isSnippet() {
-    return this.completionKind == CompletionKind.Snippet;
+    if (this.completionMetadata == null || this.completionMetadata.getCompletion_kind() == null) {
+      return false;
+    }
+
+    return this.completionMetadata.getCompletion_kind() == CompletionKind.Snippet;
   }
 }

--- a/src/main/java/com/tabnine/prediction/TabNineCompletion.java
+++ b/src/main/java/com/tabnine/prediction/TabNineCompletion.java
@@ -21,6 +21,7 @@ public class TabNineCompletion implements Completion {
   public String cursorPrefix;
   public String cursorSuffix;
   public SuggestionTrigger suggestionTrigger;
+  @Nullable // if new plugin with old binary
   public CompletionMetadata completionMetadata;
   private String fullSuffix = null;
 
@@ -32,7 +33,7 @@ public class TabNineCompletion implements Completion {
       int index,
       String cursorPrefix,
       String cursorSuffix,
-      CompletionMetadata completionMetadata,
+      @Nullable CompletionMetadata completionMetadata,
       SuggestionTrigger suggestionTrigger) {
     this.oldPrefix = oldPrefix;
     this.newPrefix = newPrefix;
@@ -60,7 +61,7 @@ public class TabNineCompletion implements Completion {
 
   @Nullable
   public CompletionOrigin getOrigin() {
-    return completionMetadata.getOrigin();
+    return completionMetadata != null ? completionMetadata.getOrigin() : null;
   }
 
   public String getSuffix() {

--- a/src/main/java/com/tabnine/selections/CompletionPreviewListener.java
+++ b/src/main/java/com/tabnine/selections/CompletionPreviewListener.java
@@ -38,11 +38,18 @@ public class CompletionPreviewListener {
     selection.linePrefixLength = completion.cursorPrefix.length();
     selection.lineNetPrefixLength = selection.linePrefixLength - completion.oldPrefix.length();
     selection.lineSuffixLength = completion.cursorSuffix.length();
-    selection.origin = completion.completionMetadata.getOrigin();
+    selection.origin =
+        completion.completionMetadata != null ? completion.completionMetadata.getOrigin() : null;
     selection.length = completion.newPrefix.length();
     selection.strength = SelectionUtil.getStrength(completion);
-    selection.completionKind = completion.completionMetadata.getCompletion_kind();
-    selection.snippetContext = completion.completionMetadata.getSnippet_context();
+    selection.completionKind =
+        completion.completionMetadata != null
+            ? completion.completionMetadata.getCompletion_kind()
+            : null;
+    selection.snippetContext =
+        completion.completionMetadata != null
+            ? completion.completionMetadata.getSnippet_context()
+            : null;
     selection.suggestionRenderingMode = renderingMode;
     selection.suggestionTrigger = completion.suggestionTrigger;
     extendSelectionRequest.accept(selection);

--- a/src/main/java/com/tabnine/selections/CompletionPreviewListener.java
+++ b/src/main/java/com/tabnine/selections/CompletionPreviewListener.java
@@ -38,11 +38,11 @@ public class CompletionPreviewListener {
     selection.linePrefixLength = completion.cursorPrefix.length();
     selection.lineNetPrefixLength = selection.linePrefixLength - completion.oldPrefix.length();
     selection.lineSuffixLength = completion.cursorSuffix.length();
-    selection.origin = completion.origin;
+    selection.origin = completion.completionMetadata.getOrigin();
     selection.length = completion.newPrefix.length();
     selection.strength = SelectionUtil.getStrength(completion);
-    selection.completionKind = completion.completionKind;
-    selection.snippetContext = completion.snippet_context;
+    selection.completionKind = completion.completionMetadata.getCompletion_kind();
+    selection.snippetContext = completion.completionMetadata.getSnippet_context();
     selection.suggestionRenderingMode = renderingMode;
     selection.suggestionTrigger = completion.suggestionTrigger;
     extendSelectionRequest.accept(selection);

--- a/src/main/java/com/tabnine/selections/SelectionUtil.java
+++ b/src/main/java/com/tabnine/selections/SelectionUtil.java
@@ -35,16 +35,16 @@ public class SelectionUtil {
                     new SelectionSuggestionRequest(
                         suggestion.newPrefix.length(),
                         getStrength(suggestion),
-                        suggestion.origin.name()))
+                        suggestion.completionMetadata.getOrigin().name()))
             .collect(toList());
   }
 
   public static String getStrength(TabNineCompletion item) {
-    if (item.origin == CompletionOrigin.LSP) {
+    if (item.completionMetadata.getOrigin() == CompletionOrigin.LSP) {
       return null;
     }
 
-    return item.detail;
+    return item.completionMetadata.getDetail();
   }
 
   @NotNull

--- a/src/main/java/com/tabnine/selections/TabNineLookupListener.java
+++ b/src/main/java/com/tabnine/selections/TabNineLookupListener.java
@@ -72,11 +72,11 @@ public class TabNineLookupListener implements LookupListener {
       selection.lineNetPrefixLength = selection.linePrefixLength - item.oldPrefix.length();
       selection.lineSuffixLength = item.cursorSuffix.length();
       selection.index = ((LookupImpl) event.getLookup()).getSelectedIndex();
-      selection.origin = item.origin;
+      selection.origin = item.completionMetadata.getOrigin();
       selection.length = item.newPrefix.length();
       selection.strength = SelectionUtil.getStrength(item);
-      selection.completionKind = item.completionKind;
-      selection.snippetContext = item.snippet_context;
+      selection.completionKind = item.completionMetadata.getCompletion_kind();
+      selection.snippetContext = item.completionMetadata.getSnippet_context();
       selection.suggestionRenderingMode = RenderingMode.AUTOCOMPLETE;
       SelectionUtil.addSuggestionsCount(selection, suggestions);
 

--- a/src/main/java/com/tabnine/selections/TabNineLookupListener.java
+++ b/src/main/java/com/tabnine/selections/TabNineLookupListener.java
@@ -72,11 +72,14 @@ public class TabNineLookupListener implements LookupListener {
       selection.lineNetPrefixLength = selection.linePrefixLength - item.oldPrefix.length();
       selection.lineSuffixLength = item.cursorSuffix.length();
       selection.index = ((LookupImpl) event.getLookup()).getSelectedIndex();
-      selection.origin = item.completionMetadata.getOrigin();
+      selection.origin =
+          item.completionMetadata != null ? item.completionMetadata.getOrigin() : null;
       selection.length = item.newPrefix.length();
       selection.strength = SelectionUtil.getStrength(item);
-      selection.completionKind = item.completionMetadata.getCompletion_kind();
-      selection.snippetContext = item.completionMetadata.getSnippet_context();
+      selection.completionKind =
+          item.completionMetadata != null ? item.completionMetadata.getCompletion_kind() : null;
+      selection.snippetContext =
+          item.completionMetadata != null ? item.completionMetadata.getSnippet_context() : null;
       selection.suggestionRenderingMode = RenderingMode.AUTOCOMPLETE;
       SelectionUtil.addSuggestionsCount(selection, suggestions);
 

--- a/src/test/java/com/tabnine/testUtils/TestData.java
+++ b/src/test/java/com/tabnine/testUtils/TestData.java
@@ -16,13 +16,13 @@ public class TestData {
   public static final String A_FILE_WITH_NO_EXTENSION = "file_with_no_extension";
   public static final String SOME_CONTENT = "hello<caret>\nhello";
   public static final String A_PREDICTION_RESULT =
-      "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"return result\",\"old_suffix\":\"\\\\n\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"11%\"},{\"new_prefix\":\"return result;\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 7%\"}],\"user_message\":[],\"docs\":[]}";
+      "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"return result\",\"old_suffix\":\"\\\\n\",\"new_suffix\":\"\",\"completion_metadata\":{\"origin\":\"LOCAL\",\"detail\":\"11%\"}},{\"new_prefix\":\"return result;\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"completion_metadata\":{\"origin\":\"LOCAL\",\"detail\":\" 7%\"}}],\"user_message\":[],\"docs\":[]}";
   public static final String SECOND_PREDICTION_RESULT =
-      "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"test\",\"old_suffix\":\"\\\\n\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"11%\"}],\"user_message\":[],\"docs\":[]}";
+      "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"test\",\"old_suffix\":\"\\\\n\",\"new_suffix\":\"\",\"completion_metadata\":{\"origin\":\"LOCAL\",\"detail\":\"11%\"}}],\"user_message\":[],\"docs\":[]}";
   public static final String THIRD_PREDICTION_RESULT =
-      "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"temp\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"21%\"},{\"new_prefix\":\"temporary\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 17%\"},{\"new_prefix\":\"temporary file\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 13%\"}],\"user_message\":[],\"docs\":[]}";
+      "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"temp\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"completion_metadata\":{\"origin\":\"LOCAL\",\"detail\":\"21%\"}},{\"new_prefix\":\"temporary\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"completion_metadata\":{\"origin\":\"LOCAL\",\"detail\":\" 17%\"}},{\"new_prefix\":\"temporary file\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"completion_metadata\":{\"origin\":\"LOCAL\",\"detail\":\" 13%\"}}],\"user_message\":[],\"docs\":[]}";
   public static final String MULTI_LINE_SNIPPET_PREDICTION_RESULT =
-      "{\"old_prefix\":\"\",\"results\":[{\"completion_kind\":\"Snippet\",\"new_prefix\":\"temp\\ntemp2\",\"old_suffix\":\"hello\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\"21%\"},{\"new_prefix\":\"temporary\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 17%\"},{\"new_prefix\":\"temporary file\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"origin\":\"LOCAL\",\"detail\":\" 13%\"}],\"user_message\":[],\"docs\":[]}";
+      "{\"old_prefix\":\"\",\"results\":[{\"new_prefix\":\"temp\\ntemp2\",\"old_suffix\":\"hello\",\"new_suffix\":\"\",\"completion_metadata\":{\"origin\":\"LOCAL\",\"detail\":\"21%\",\"completion_kind\":\"Snippet\"}},{\"new_prefix\":\"temporary\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"completion_metadata\":{\"origin\":\"LOCAL\",\"detail\":\" 17%\"}},{\"new_prefix\":\"temporary file\",\"old_suffix\":\"\",\"new_suffix\":\"\",\"completion_metadata\":{\"origin\":\"LOCAL\",\"detail\":\" 13%\"}}],\"user_message\":[],\"docs\":[]}";
 
   public static final int OVERFLOW = 1;
   public static final String INVALID_RESULT = "Nonsense";

--- a/src/test/java/com/tabnine/unitTests/InlineCompletionCacheTests.kt
+++ b/src/test/java/com/tabnine/unitTests/InlineCompletionCacheTests.kt
@@ -1,6 +1,7 @@
 package com.tabnine.unitTests
 
 import com.tabnine.MockedBinaryCompletionTestCase
+import com.tabnine.binary.requests.autocomplete.CompletionMetadata
 import com.tabnine.general.CompletionKind
 import com.tabnine.general.CompletionOrigin
 import com.tabnine.general.SuggestionTrigger
@@ -84,6 +85,14 @@ class InlineCompletionCacheTests : MockedBinaryCompletionTestCase() {
         oldPrefix: String,
         newPrefix: String,
     ): TabNineCompletion {
+        val someMetadata = CompletionMetadata(
+            CompletionOrigin.UNKNOWN,
+            "0.345",
+            CompletionKind.Classic,
+            null,
+            null,
+            false
+        )
         return TabNineCompletion(
             oldPrefix,
             newPrefix,
@@ -92,10 +101,7 @@ class InlineCompletionCacheTests : MockedBinaryCompletionTestCase() {
             0,
             oldPrefix,
             "",
-            CompletionOrigin.UNKNOWN,
-            CompletionKind.Classic,
-            true,
-            null,
+            someMetadata,
             SuggestionTrigger.DocumentChanged
         )
     }


### PR DESCRIPTION
In order to support suggestion-dropped events we first need to use the new API version 4.4.223.
This pr only handles the migration to this API version, I will add the new event in a separate pr.

### Main changes
1. Introduce `CompletionMetadata` class - its fields were flattened inside `ResultEntry` (and `snippet_context` in `AutocompleteResult`)
Now, `ResultEntry` has a `completion_metadata` field with all these un-flattened fields.
2. Change `SuggestionShown` event args - it now accepts this `CompletionMetadata` object instead of "kind" and "origin".
The rest of the changes are all direct consequences of these 2 changes. 