### PR TITLE
DEV2-2435 add health check

### DIFF
--- a/src/main/java/com/tabnine/Initializer.java
+++ b/src/main/java/com/tabnine/Initializer.java
@@ -5,6 +5,7 @@ import static com.tabnine.general.DependencyContainer.*;
 import com.intellij.ide.plugins.PluginInstaller;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.PreloadingActivity;
+import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
@@ -14,6 +15,7 @@ import com.tabnine.config.Config;
 import com.tabnine.general.StaticConfig;
 import com.tabnine.lifecycle.BinaryNotificationsLifecycle;
 import com.tabnine.lifecycle.BinaryPromotionStatusBarLifecycle;
+import com.tabnine.lifecycle.BinaryStateService;
 import com.tabnine.lifecycle.TabnineUpdater;
 import com.tabnine.logging.LogInitializerKt;
 import com.tabnine.notifications.ConnectionLostNotificationHandler;
@@ -51,6 +53,9 @@ public class Initializer extends PreloadingActivity implements StartupActivity {
                   + ", plugin id = "
                   + StaticConfig.TABNINE_PLUGIN_ID_RAW);
 
+      connectionLostNotificationHandler.startConnectionLostListener();
+      ServiceManager.getService(BinaryStateService.class).startUpdateLoop();
+
       if (!Config.IS_ON_PREM) {
         LogInitializerKt.init();
         binaryNotificationsLifecycle = instanceOfBinaryNotifications();
@@ -60,7 +65,6 @@ public class Initializer extends PreloadingActivity implements StartupActivity {
         CapabilitiesService.getInstance().init();
         TabnineUpdater.pollUpdates();
         PluginInstaller.addStateListener(instanceOfUninstallListener());
-        connectionLostNotificationHandler.startConnectionLostListener();
       }
     }
   }

--- a/src/main/java/com/tabnine/general/SubscriptionType.kt
+++ b/src/main/java/com/tabnine/general/SubscriptionType.kt
@@ -30,7 +30,7 @@ enum class SubscriptionType {
                 return StaticConfig.ICON_AND_NAME_ENTERPRISE
             }
 
-            return StaticConfig.ICON_AND_NAME_CONNECTION_LOST_ENTERPRISE;
+            return StaticConfig.ICON_AND_NAME_CONNECTION_LOST_ENTERPRISE
         }
     };
 

--- a/src/main/java/com/tabnine/lifecycle/BinaryStateService.java
+++ b/src/main/java/com/tabnine/lifecycle/BinaryStateService.java
@@ -9,18 +9,25 @@ import com.tabnine.binary.requests.config.StateResponse;
 import com.tabnine.general.DependencyContainer;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BinaryStateService {
-
   private static final ScheduledExecutorService scheduler =
       AppExecutorUtil.getAppScheduledExecutorService();
   private final BinaryRequestFacade binaryRequestFacade =
       DependencyContainer.instanceOfBinaryRequestFacade();
   private final MessageBus messageBus;
   private StateResponse lastStateResponse;
+  private final AtomicBoolean updateLoopStarted = new AtomicBoolean(false);
 
   public BinaryStateService() {
     this.messageBus = ApplicationManager.getApplication().getMessageBus();
+  }
+
+  public void startUpdateLoop() {
+    if (updateLoopStarted.getAndSet(true)) {
+      return;
+    }
     scheduler.scheduleWithFixedDelay(this::updateState, 0, 2, TimeUnit.SECONDS);
   }
 

--- a/src/main/java/com/tabnine/notifications/ConnectionLostNotificationHandler.kt
+++ b/src/main/java/com/tabnine/notifications/ConnectionLostNotificationHandler.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.tabnine.binary.requests.config.CloudConnectionHealthStatus
 import com.tabnine.binary.requests.config.StateResponse
+import com.tabnine.config.Config
 import com.tabnine.general.StaticConfig
 import com.tabnine.general.Utils.getHoursDiff
 import com.tabnine.lifecycle.BinaryStateChangeNotifier
@@ -19,6 +20,11 @@ private const val NOTIFICATION_CONTENT =
     "<b>Tabnine lost internet connection.</b>" +
         "<br/>" +
         "If your internet is connected and you're seeing this message, contact Tabnine support."
+
+private const val ON_PREM_NOTIFICATION_CONTENT =
+    "<b>Tabnine server connectivity issue.</b>" +
+        "<br/>" +
+        "Please check your network setup and access to your configured Tabnine Enterprise Host"
 
 class ConnectionLostNotificationHandler {
     private var lastNotificationTime: Date? = null
@@ -43,13 +49,19 @@ class ConnectionLostNotificationHandler {
     private fun showNotification() {
         val notification = Notification(StaticConfig.TABNINE_NOTIFICATION_GROUP.displayId, StaticConfig.CONNECTION_LOST_NOTIFICATION_ICON, NotificationType.INFORMATION)
         notification
-            .setContent(NOTIFICATION_CONTENT)
+            .setContent(getNotificaitonContent())
             .addAction(object : AnAction("Dismiss") {
                 override fun actionPerformed(e: AnActionEvent) {
                     notification.expire()
                 }
             })
         Notifications.Bus.notify(notification)
+    }
+
+    private fun getNotificaitonContent() = if (Config.IS_ON_PREM) {
+        ON_PREM_NOTIFICATION_CONTENT
+    } else {
+        NOTIFICATION_CONTENT
     }
 
     private fun shouldShowNotification(stateResponse: StateResponse): Boolean {

--- a/src/main/java/com/tabnine/statusBar/TabnineEnterpriseStatusBarWidget.java
+++ b/src/main/java/com/tabnine/statusBar/TabnineEnterpriseStatusBarWidget.java
@@ -62,7 +62,16 @@ public class TabnineEnterpriseStatusBarWidget extends EditorBasedWidget
   @Nullable
   public String getTooltipText() {
     String enterpriseHostDisplayString =
-        getTabnineEnterpriseHost().map(host -> "(host='" + host + "')").orElse("(host is not set)");
+        getTabnineEnterpriseHost()
+            .map(
+                host -> {
+                  String prefix =
+                      this.cloudConnectionHealthStatus == CloudConnectionHealthStatus.Failed
+                          ? "(connection failed to host '"
+                          : "(host='";
+                  return prefix + host + "')";
+                })
+            .orElse("(host is not set)");
     return "Open Tabnine Settings " + enterpriseHostDisplayString;
   }
 


### PR DESCRIPTION
previously, the update loop was initialized in the constructor of `BinaryStateServiec`.
the issue is that in onprem, we never called this service, so the constructor was never called.

i changed it so that the loop init is explicit and will be called within the `Initialize` extension point.