### PR TITLE
DEV2-2518 add manual trigger inline completion action

### DIFF
--- a/src/main/java/com/tabnine/general/CompletionsEventSender.kt
+++ b/src/main/java/com/tabnine/general/CompletionsEventSender.kt
@@ -10,6 +10,7 @@ import com.tabnine.binary.BinaryResponse
 import com.tabnine.binary.requests.analytics.EventRequest
 import com.tabnine.binary.requests.notifications.shown.SuggestionDroppedReason
 import com.tabnine.binary.requests.notifications.shown.SuggestionDroppedRequest
+import com.tabnine.capabilities.RenderingMode
 import com.tabnine.inline.CompletionOrder
 import com.tabnine.prediction.CompletionFacade.getFilename
 import com.tabnine.prediction.TabNineCompletion
@@ -27,8 +28,8 @@ class CompletionsEventSender(private val binaryRequestFacade: BinaryRequestFacad
         sendEventAsync(event)
     }
 
-    fun sendManualSuggestionTrigger() {
-        val event = EventRequest("manual-suggestion-trigger", mapOf())
+    fun sendManualSuggestionTrigger(renderingMode: RenderingMode) {
+        val event = EventRequest("manual-suggestion-trigger", mapOf("suggestion_rendering_mode" to renderingMode.name))
         sendEventAsync(event)
     }
 

--- a/src/main/java/com/tabnine/inline/ManualTriggerTabnineInlineCompletionAction.kt
+++ b/src/main/java/com/tabnine/inline/ManualTriggerTabnineInlineCompletionAction.kt
@@ -1,0 +1,26 @@
+package com.tabnine.inline
+
+import com.intellij.codeInsight.CodeInsightActionHandler
+import com.intellij.codeInsight.actions.BaseCodeInsightAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.tabnine.general.DependencyContainer
+
+class ManualTriggerTabnineInlineCompletionAction : BaseCodeInsightAction(false), DumbAware, InlineCompletionAction {
+    private val handler = DependencyContainer.singletonOfInlineCompletionHandler()
+
+    override fun getHandler(): CodeInsightActionHandler {
+        return CodeInsightActionHandler { _: Project?, editor: Editor, _: PsiFile? ->
+            val lastShownCompletion = CompletionPreview.getCurrentCompletion(editor)
+
+            handler.retrieveAndShowCompletion(
+                editor, editor.caretModel.offset, lastShownCompletion, "",
+                DefaultCompletionAdjustment()
+            )
+        }
+    }
+
+    override fun isValidForLookup(): Boolean = true
+}

--- a/src/main/java/com/tabnine/inline/ManualTriggerTabnineInlineCompletionAction.kt
+++ b/src/main/java/com/tabnine/inline/ManualTriggerTabnineInlineCompletionAction.kt
@@ -6,13 +6,20 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
+import com.tabnine.capabilities.RenderingMode
 import com.tabnine.general.DependencyContainer
 
 class ManualTriggerTabnineInlineCompletionAction : BaseCodeInsightAction(false), DumbAware, InlineCompletionAction {
+    companion object {
+        const val ACTION_ID = "ManualTriggerTabnineInlineCompletionAction"
+    }
+
     private val handler = DependencyContainer.singletonOfInlineCompletionHandler()
+    private val completionsEventSender = DependencyContainer.instanceOfCompletionsEventSender()
 
     override fun getHandler(): CodeInsightActionHandler {
         return CodeInsightActionHandler { _: Project?, editor: Editor, _: PsiFile? ->
+            completionsEventSender.sendManualSuggestionTrigger(RenderingMode.INLINE)
             val lastShownCompletion = CompletionPreview.getCurrentCompletion(editor)
 
             handler.retrieveAndShowCompletion(

--- a/src/main/java/com/tabnine/intellij/completions/TabNineCompletionContributor.java
+++ b/src/main/java/com/tabnine/intellij/completions/TabNineCompletionContributor.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.messages.MessageBus;
 import com.tabnine.binary.requests.autocomplete.AutocompleteResponse;
 import com.tabnine.binary.requests.autocomplete.ResultEntry;
+import com.tabnine.capabilities.RenderingMode;
 import com.tabnine.capabilities.SuggestionsMode;
 import com.tabnine.capabilities.SuggestionsModeService;
 import com.tabnine.config.Config;
@@ -52,7 +53,7 @@ public class TabNineCompletionContributor extends CompletionContributor {
     }
 
     if (!parameters.isAutoPopup()) {
-      completionsEventSender.sendManualSuggestionTrigger();
+      completionsEventSender.sendManualSuggestionTrigger(RenderingMode.AUTOCOMPLETE);
     }
 
     if (suggestionsModeService.getSuggestionMode().isInlineEnabled()) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -141,5 +141,8 @@
         <action class="com.tabnine.inline.AcceptTabnineInlineCompletionAction" id="AcceptTabnineInlineCompletionAction" text="Accept Inline Completion">
             <keyboard-shortcut first-keystroke="TAB" keymap="$default"/>
         </action>
+        <action class="com.tabnine.inline.ManualTriggerTabnineInlineCompletionAction" id="ManualTriggerTabnineInlineCompletionAction" text="Trigger Inline Completion">
+            <keyboard-shortcut first-keystroke="Ctrl+\" keymap="$default"/>
+        </action>
     </actions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -141,8 +141,8 @@
         <action class="com.tabnine.inline.AcceptTabnineInlineCompletionAction" id="AcceptTabnineInlineCompletionAction" text="Accept Inline Completion">
             <keyboard-shortcut first-keystroke="TAB" keymap="$default"/>
         </action>
+        <!--no default shortcut for this action, users should configure manually-->
         <action class="com.tabnine.inline.ManualTriggerTabnineInlineCompletionAction" id="ManualTriggerTabnineInlineCompletionAction" text="Trigger Inline Completion">
-            <keyboard-shortcut first-keystroke="Ctrl+\" keymap="$default"/>
         </action>
     </actions>
 </idea-plugin>

--- a/src/test/java/com/tabnine/integration/PredictionBehaviourIntegrationTests.java
+++ b/src/test/java/com/tabnine/integration/PredictionBehaviourIntegrationTests.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.*;
 
 import com.intellij.codeInsight.completion.CompletionType;
 import com.tabnine.MockedBinaryCompletionTestCase;
+import com.tabnine.capabilities.RenderingMode;
 import org.junit.Test;
 
 public class PredictionBehaviourIntegrationTests extends MockedBinaryCompletionTestCase {
@@ -39,13 +40,15 @@ public class PredictionBehaviourIntegrationTests extends MockedBinaryCompletionT
   public void whenManuallyTriggeringCompletionThenEventIsFired() {
     myFixture.completeBasic();
 
-    verify(completionEventSenderMock, times(1)).sendManualSuggestionTrigger();
+    verify(completionEventSenderMock, times(1))
+        .sendManualSuggestionTrigger(RenderingMode.AUTOCOMPLETE);
   }
 
   @Test
   public void whenAutoTriggeringCompletionThenEventIsNotFired() {
     myFixture.complete(CompletionType.BASIC, 0);
 
-    verify(completionEventSenderMock, never()).sendManualSuggestionTrigger();
+    verify(completionEventSenderMock, never())
+        .sendManualSuggestionTrigger(RenderingMode.AUTOCOMPLETE);
   }
 }

--- a/src/test/java/com/tabnine/plugin/InlineCompletionTests.java
+++ b/src/test/java/com/tabnine/plugin/InlineCompletionTests.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.ide.CopyPasteManager;
 import com.tabnine.MockedBinaryCompletionTestCase;
 import com.tabnine.binary.requests.notifications.shown.SuggestionDroppedReason;
+import com.tabnine.capabilities.RenderingMode;
 import com.tabnine.capabilities.SuggestionsMode;
 import com.tabnine.inline.*;
 import com.tabnine.prediction.TabNineCompletion;
@@ -110,6 +111,18 @@ public class InlineCompletionTests extends MockedBinaryCompletionTestCase {
     myFixture.performEditorAction(ShowPreviousTabnineInlineCompletionAction.ACTION_ID);
 
     assertEquals("Incorrect inline completion", "mp", getTabnineCompletionContent(myFixture));
+  }
+
+  @Test
+  public void showSuggestionWhenExecutingManualTriggerInlineAction() throws Exception {
+    mockCompletionResponseWithPrefix("t");
+
+    type("\nt");
+
+    myFixture.performEditorAction(ManualTriggerTabnineInlineCompletionAction.ACTION_ID);
+
+    verify(completionEventSenderMock, times(1)).sendManualSuggestionTrigger(RenderingMode.INLINE);
+    assertEquals("Incorrect inline completion", "emp", getTabnineCompletionContent(myFixture));
   }
 
   @Test


### PR DESCRIPTION
users should define the shortcut for this action manually - no default shortcut is provided.
![image](https://user-images.githubusercontent.com/67855609/227156942-1061c32c-8038-45e8-bf31-d656c155ca69.png)
