### PR TITLE
DEV2-2518 fix publish jobs

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get Version
         id: get_build_version
         run: |
-          CURRENT_VERSION=$(./gradlew -q currentVersion)
+          CURRENT_VERSION=$(./gradlew -q currentVersion | tail -n1)
           TIMESTAMP=$(date '+%Y%m%d%H%M%S')
           echo "::set-output name=build_version::$CURRENT_VERSION-alpha.$TIMESTAMP"
       - name: Publish 

--- a/.github/workflows/production-new-version.yml
+++ b/.github/workflows/production-new-version.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set version
         run: |
           set -e
-          OLD_VERSION="$(./gradlew -q currentVersion)"
+          OLD_VERSION="$(./gradlew -q currentVersion | tail -n1)"
           NEW_VERSION="${{ github.event.inputs.version }}"
           if [ -z "$NEW_VERSION" ]; then
             NEW_VERSION=$(echo $OLD_VERSION | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g' )
@@ -52,7 +52,7 @@ jobs:
       - name: Get Version
         id: get_build_version
         run: |
-          VERSION="$(./gradlew -q currentVersion)"
+          VERSION="$(./gradlew -q currentVersion | tail -n1)"
           echo "new version is $VERSION"
           echo "::set-output name=build_version::$VERSION"
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Get Version
         id: get_build_version
         run: |
-          echo "::set-output name=build_version::$(./gradlew -q currentVersion)"
+          echo "::set-output name=build_version::$(./gradlew -q currentVersion | tail -n1)"
 
       - name: Create Tag
         run: |

--- a/ci/increment-patch-version.sh
+++ b/ci/increment-patch-version.sh
@@ -4,7 +4,7 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-CURRENT_VERSION=$(./gradlew -q currentVersion)
+CURRENT_VERSION=$(./gradlew -q currentVersion | tail -n1)
 
 increment_version ()
 {


### PR DESCRIPTION
### Issue
the output of `./gradlew -q currentVersion` is like so (idk when it was changed):
```
➜  ./gradlew -q currentVersion
channelName: alpha
0.8.13
```
you can see here that the job thinks that `${{ steps.get_build_version.outputs.build_version }}` == `channelName: alpha`:
![image](https://user-images.githubusercontent.com/67855609/227188234-3a445332-42de-446a-be44-106924198b4f.png)

### Fix
add `| tail -n1` to the end of `./gradlew -q currentVersion`
this takes the last line of the output.
Its also idempotent, i.e. if there's only one line, it'll take this line.
You can see that if I run `tail -n1` twice it still outputs the correct version:
```
➜  CURRENT_VERSION=$(./gradlew -q currentVersion | tail -n1)
➜  echo $CURRENT_VERSION | tail -n1
0.8.13
```