### PR TITLE
DEV2-2537 upgrade to language level 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.stream.Collectors
 
 plugins {
@@ -12,12 +13,12 @@ plugins {
 group 'com.tabnine'
 version project.hasProperty('externalVersion') ? project.externalVersion : '1.0.0'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 9
+targetCompatibility = 9
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+tasks.withType(KotlinCompile).configureEach {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "9"
     }
 }
 

--- a/src/main/java/com/tabnine/general/StaticConfig.java
+++ b/src/main/java/com/tabnine/general/StaticConfig.java
@@ -131,10 +131,8 @@ public class StaticConfig {
 
   @NotNull
   public static Optional<String> getTabNineBundleVersionUrl() {
-    if (System.getProperty(REMOTE_VERSION_URL_PROPERTY) != null) {
-      return Optional.of(System.getProperty(REMOTE_VERSION_URL_PROPERTY));
-    }
-    return StaticConfig.getBundleServerUrl().map(s -> s + "/version");
+    return Optional.ofNullable(System.getProperty(REMOTE_VERSION_URL_PROPERTY))
+        .or(() -> StaticConfig.getBundleServerUrl().map(s -> s + "/version"));
   }
 
   @NotNull


### PR DESCRIPTION
re-opening #494, since i found a small mistake in my changes and the diff got messed up anyway.

tests:
I installed locally on ij 2019 from a locally-built plugin, status bar and completions seem to work as expected.