### PR TITLE
DEV2-2535: Use IntelliJ Proxy settings

### DIFF
--- a/src/main/java/com/tabnine/binary/BinaryProcessGateway.kt
+++ b/src/main/java/com/tabnine/binary/BinaryProcessGateway.kt
@@ -1,9 +1,15 @@
 package com.tabnine.binary
 
+import com.intellij.util.net.HttpConfigurable
+import com.intellij.util.proxy.CommonProxy
 import com.tabnine.binary.exceptions.TabNineDeadException
+import com.tabnine.general.StaticConfig
+import com.tabnine.userSettings.AppSettingsState.Companion.instance
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
+import java.net.Proxy
+import java.net.URL
 import java.nio.charset.StandardCharsets
 
 open class BinaryProcessGateway {
@@ -12,10 +18,38 @@ open class BinaryProcessGateway {
 
     @Throws(IOException::class)
     open fun init(command: List<String?>?) {
-        val createdProcess = ProcessBuilder(command).start()
+        val pb = ProcessBuilder(command)
+        if (instance.useIJProxySettings) {
+            setProxyEnvironmentVariables(pb)
+        }
+        val createdProcess = pb.start()
 
         process = createdProcess
         reader = BufferedReader(InputStreamReader(createdProcess.inputStream, StandardCharsets.UTF_8))
+    }
+
+    private fun setProxyEnvironmentVariables(pb: ProcessBuilder) {
+        val env = pb.environment()
+        val serverUrl = StaticConfig.getBundleServerUrl()
+        if (serverUrl.isPresent) {
+            val serverUrlString = serverUrl.get()
+            val tabnineServerProxy = CommonProxy.getInstance().select(URL(serverUrlString)).firstOrNull()
+            if (tabnineServerProxy?.type() == Proxy.Type.DIRECT) {
+                env["NO_PROXY"] = serverUrlString
+                env["no_proxy"] = serverUrlString
+            }
+        }
+        if (!HttpConfigurable.getInstance().USE_HTTP_PROXY) {
+            return
+        }
+        val proxyString = "${HttpConfigurable.getInstance().PROXY_HOST}:${HttpConfigurable.getInstance().PROXY_PORT}"
+
+        if (proxyString.isNotBlank()) {
+            env["HTTPS_PROXY"] = proxyString
+            env["https_proxy"] = proxyString
+            env["HTTP_PROXY"] = proxyString
+            env["http_proxy"] = proxyString
+        }
     }
 
     @Throws(IOException::class, TabNineDeadException::class)

--- a/src/main/java/com/tabnine/userSettings/AppSettingsComponent.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsComponent.kt
@@ -31,6 +31,7 @@ class AppSettingsComponent {
         JBCheckBox("Enable auto-importing packages when selecting Tabnine suggestions", true)
     private val binariesFolderOverrideComponent = JXTextField(StaticConfig.getDefaultBaseDirectory().toString())
     private val cloud2UrlComponent = JBTextField()
+    private val useIJProxySettingsCheckBox = JBCheckBox("Use proxy settings for Tabnine (requires restart)", true)
 
     val preferredFocusedComponent: JComponent
         get() = colorChooser
@@ -76,6 +77,11 @@ class AppSettingsComponent {
         set(value) {
             cloud2UrlComponent.text = value
         }
+    var useIJProxySettings: Boolean
+        get() = useIJProxySettingsCheckBox.isSelected
+        set(value) {
+            useIJProxySettingsCheckBox.isSelected = value
+        }
 
     init {
         if (!suggestionsModeService.getSuggestionMode().isInlineEnabled) {
@@ -105,6 +111,7 @@ class AppSettingsComponent {
             .addLabeledComponent(colorChooserLabel, colorChooser, 1, true)
             .addComponent(useDefaultColorCheckbox, 1)
             .addComponent(autoImportCheckbox, 1)
+            .addComponent(useIJProxySettingsCheckBox, 1)
             .addLabeledComponent(
                 "Binaries Location absolute path (requires restart): ",
                 binariesFolderOverrideComponent,

--- a/src/main/java/com/tabnine/userSettings/AppSettingsConfigurable.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsConfigurable.kt
@@ -37,7 +37,8 @@ class AppSettingsConfigurable : Configurable {
                     it.debounceTime != settings.debounceTime.toString() ||
                     it.autoImportEnabled != settings.autoImportEnabled ||
                     it.binariesFolderOverride != settings.binariesFolderOverride ||
-                    it.cloud2Url != settings.cloud2Url
+                    it.cloud2Url != settings.cloud2Url ||
+                    it.useIJProxySettings != settings.useIJProxySettings
             }
         }
         return false
@@ -54,6 +55,7 @@ class AppSettingsConfigurable : Configurable {
             settings.autoImportEnabled = settingsComponent!!.autoImportEnabled
             settings.binariesFolderOverride = settingsComponent!!.binariesFolderOverride
             settings.cloud2Url = settingsComponent!!.cloud2Url
+            settings.useIJProxySettings = settingsComponent!!.useIJProxySettings
         }
     }
 
@@ -68,6 +70,7 @@ class AppSettingsConfigurable : Configurable {
             it.autoImportEnabled = settings.autoImportEnabled
             it.binariesFolderOverride = settings.binariesFolderOverride
             it.cloud2Url = settings.cloud2Url
+            it.useIJProxySettings = settings.useIJProxySettings
         }
     }
 

--- a/src/main/java/com/tabnine/userSettings/AppSettingsState.kt
+++ b/src/main/java/com/tabnine/userSettings/AppSettingsState.kt
@@ -27,6 +27,7 @@ class AppSettingsState : PersistentStateComponent<AppSettingsState?> {
     var autoImportEnabled: Boolean = true
     var binariesFolderOverride: String = ""
     var cloud2Url: String = ""
+    var useIJProxySettings: Boolean = true
 
     private var colorState = settingsDefaultColor
 


### PR DESCRIPTION
By default, we are getting the proxy settings from IntelliJ and inheriting them to the binary.
This won't happen if the checkbox is disabled.
Was able to see the binary requests via `mitmproxy` when the setting was on.

Process env var in windows:
![image](https://user-images.githubusercontent.com/4030466/229481998-4a5b0dba-1336-477e-a705-2ea6a4521939.png)

windows proxy:
![image](https://user-images.githubusercontent.com/4030466/229483518-b09fe735-4833-4e2b-a946-1c797f8441b0.png)
