### PR TITLE
DEV2-2535: Fix missing need for step

### DIFF
--- a/.github/workflows/production-new-version.yml
+++ b/.github/workflows/production-new-version.yml
@@ -133,6 +133,9 @@ jobs:
   publish-self-hosted:
     name: Publish self hosted
     runs-on: ubuntu-latest
+    needs:
+      - set-version
+
     steps:
       - name: ⇣ Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Need first to set the version, then to publish. Missed that.