### PR TITLE
DEV2-2560: Fix publish with wrong name

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -40,6 +40,7 @@ intellij {
     version = '2019.3'
     type = 'IC'
     updateSinceUntilBuild = false
+    pluginName = 'TabNine'
 }
 
 def channelName = project.hasProperty('channel') ? project.channel : 'alpha'

--- a/Tabnine/build.gradle
+++ b/Tabnine/build.gradle
@@ -64,6 +64,7 @@ intellij {
     version = '2019.3'
     type = 'IC'
     updateSinceUntilBuild = false
+    pluginName = 'TabNine'
 }
 
 def PRODUCTION_CHANNEL = null

--- a/TabnineSelfHosted/build.gradle
+++ b/TabnineSelfHosted/build.gradle
@@ -42,6 +42,7 @@ intellij {
     version = '2019.3'
     type = 'IC'
     updateSinceUntilBuild = false
+    pluginName = 'TabNine'
 }
 
 publishPlugin {

--- a/TabnineSelfHostedForMarketplace/build.gradle
+++ b/TabnineSelfHostedForMarketplace/build.gradle
@@ -40,6 +40,7 @@ intellij {
     version = '2019.3'
     type = 'IC'
     updateSinceUntilBuild = false
+    pluginName = 'TabNine'
 }
 
 tasks.create("currentVersion") {


### PR DESCRIPTION
now it will always produce the same plugin name even if the project name is different
