### PR TITLE
DEV2-2856 re-fetch suggestions when results are empty

### DIFF
--- a/Common/src/main/java/com/tabnineCommon/inline/CompletionTracker.kt
+++ b/Common/src/main/java/com/tabnineCommon/inline/CompletionTracker.kt
@@ -10,7 +10,7 @@ object CompletionTracker {
     private val DEBOUNCE_INTERVAL_MS = getDebounceInterval()
 
     @JvmStatic
-    fun calcDebounceTime(editor: Editor, completionAdjustment: CompletionAdjustment): Long {
+    fun calcDebounceTimeMs(editor: Editor, completionAdjustment: CompletionAdjustment): Long {
         if (completionAdjustment.suggestionTrigger == SuggestionTrigger.LookAhead) {
             return 0
         }


### PR DESCRIPTION
using the existing debounce mechanism which fetches before debouncing and then re-fetches after, just applying the same logic with debounce time = 800ms when results are empty. 

you can see in the attached video that I did not type as suggested multiple times, and received completions each time.


https://github.com/codota/tabnine-intellij/assets/67855609/a539f6cb-1a06-4839-98b0-1b7244361cf0


