### PR TITLE
DEV2-3062 Do not run binary versions 4.5.0 through 4.5.13

### DIFF
--- a/Common/src/main/java/com/tabnineCommon/binary/fetch/BinaryVersionFetcher.java
+++ b/Common/src/main/java/com/tabnineCommon/binary/fetch/BinaryVersionFetcher.java
@@ -3,6 +3,7 @@ package com.tabnineCommon.binary.fetch;
 import static java.lang.String.format;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.util.text.SemVer;
 import com.tabnineCommon.binary.exceptions.NoValidBinaryToRunException;
 import java.util.List;
 import java.util.Optional;
@@ -55,7 +56,9 @@ public class BinaryVersionFetcher {
                   "Binary latest beta version %s was found locally, so it is being preferred.",
                   preferredBetaVersion.get().getVersion()));
 
-      return preferredBetaVersion.get().getVersionFullPath();
+      if (!isBadVersion(preferredBetaVersion.get())) {
+        return preferredBetaVersion.get().getVersionFullPath();
+      }
     }
 
     return binaryRemoteSource
@@ -84,5 +87,15 @@ public class BinaryVersionFetcher {
 
       return binaryDownloader.downloadBinary(preferred);
     };
+  }
+
+  static boolean isBadVersion(BinaryVersion binaryVersion) {
+    SemVer semver = SemVer.parseFromText(binaryVersion.getVersion());
+
+    if (semver == null) {
+      return false;
+    }
+
+    return semver.isGreaterOrEqualThan(4, 5, 0) && !semver.isGreaterOrEqualThan(4, 5, 13);
   }
 }

--- a/Common/src/main/java/com/tabnineCommon/binary/fetch/BootstrapperSupport.java
+++ b/Common/src/main/java/com/tabnineCommon/binary/fetch/BootstrapperSupport.java
@@ -20,9 +20,16 @@ public class BootstrapperSupport {
         locateLocalBootstrapSupportedVersion(localBinaryVersions);
     if (localBootstrapVersion.isPresent()) {
       PluginInstalled.Companion.setNewInstallation(false);
-      return localBootstrapVersion;
+
+      if (!BinaryVersionFetcher.isBadVersion(localBootstrapVersion.get())) {
+        return localBootstrapVersion;
+      }
     }
-    notifyPluginInstalled();
+
+    if (!localBootstrapVersion.isPresent()) {
+      notifyPluginInstalled();
+    }
+
     return downloadRemoteVersion(binaryRemoteSource, bundleDownloader);
   }
 


### PR DESCRIPTION
they have an isue updating in envs with custom certificates, so it is up to the plugin to download a newer version with a fix