### PR TITLE
DEV2-2972 add open devtools action

### DIFF
--- a/Common/src/main/java/com/tabnineCommon/chat/ChatBrowser.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/ChatBrowser.kt
@@ -80,7 +80,6 @@ class ChatBrowser(messagesRouter: ChatMessagesRouter, private val project: Proje
         if (devServerUrl != null) {
             Logger.getInstance(javaClass).debug("Running Tabnine Chat on dev server $devServerUrl")
             browser.loadURL(devServerUrl)
-            browser.openDevtools()
             return
         }
 

--- a/Common/src/main/java/com/tabnineCommon/chat/actions/TabnineActionsGroup.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/actions/TabnineActionsGroup.kt
@@ -5,6 +5,7 @@ import com.tabnineCommon.chat.ChatBrowser
 import com.tabnineCommon.chat.actions.toolWindowActions.ChatHistoryAction
 import com.tabnineCommon.chat.actions.toolWindowActions.ClearConversationAction
 import com.tabnineCommon.chat.actions.toolWindowActions.NewConversationAction
+import com.tabnineCommon.chat.actions.toolWindowActions.OpenDevToolsAction
 import com.tabnineCommon.chat.actions.toolWindowActions.SubmitFeedbackAction
 
 class TabnineActionsGroup private constructor() : DefaultActionGroup("Tabnine Chat", false) {
@@ -16,6 +17,7 @@ class TabnineActionsGroup private constructor() : DefaultActionGroup("Tabnine Ch
             group.add(ChatHistoryAction(browser))
             group.add(SubmitFeedbackAction(browser))
             group.add(ReloadAction(browser))
+            group.add(OpenDevToolsAction(browser))
 
             return group
         }

--- a/Common/src/main/java/com/tabnineCommon/chat/actions/toolWindowActions/OpenDevToolsAction.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/actions/toolWindowActions/OpenDevToolsAction.kt
@@ -1,0 +1,13 @@
+package com.tabnineCommon.chat.actions.toolWindowActions
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.tabnineCommon.chat.ChatBrowser
+import com.tabnineCommon.chat.actions.TabnineChatAction
+
+class OpenDevToolsAction(browser: ChatBrowser) :
+    TabnineChatAction(browser, "Open Devtools", "Open devtools", AllIcons.Toolwindows.ToolWindowDebugger) {
+    override fun actionPerformed(e: AnActionEvent) {
+        browser.jbCefBrowser.openDevtools()
+    }
+}


### PR DESCRIPTION
Since we need it to debug user complaints, and its already enabled by default in vscode, there's no harm in allowing this in jb as well.

https://github.com/codota/tabnine-intellij/assets/67855609/3e0d64a3-5b7d-4d01-8b7a-1fd783bc7052

