### PR TITLE
DEV2-2661 fix missing status bar

### DIFF
--- a/Tabnine/src/main/java/com/tabnine/statusBar/StatusBarPromotionProvider.java
+++ b/Tabnine/src/main/java/com/tabnine/statusBar/StatusBarPromotionProvider.java
@@ -2,28 +2,53 @@ package com.tabnine.statusBar;
 
 import static com.tabnineCommon.general.DependencyContainer.instanceOfBinaryRequestFacade;
 
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.openapi.wm.StatusBarWidgetFactory;
 import com.intellij.openapi.wm.StatusBarWidgetProvider;
 import com.tabnine.lifecycle.BinaryInstantiatedActions;
 import com.tabnineCommon.binary.BinaryRequestFacade;
+import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class StatusBarPromotionProvider implements StatusBarWidgetProvider {
+public class StatusBarPromotionProvider implements StatusBarWidgetFactory {
   private final BinaryRequestFacade binaryRequestFacade = instanceOfBinaryRequestFacade();
   private final BinaryInstantiatedActions actionVisitor =
       new BinaryInstantiatedActions(instanceOfBinaryRequestFacade());
 
-  @Nullable
   @Override
-  public com.intellij.openapi.wm.StatusBarWidget getWidget(@NotNull Project project) {
+  public @NotNull String getId() {
+    return getClass().getName();
+  }
+
+  @Override
+  public @Nls @NotNull String getDisplayName() {
+    return "Tabnine (promotion)";
+  }
+
+  @Override
+  public boolean isAvailable(@NotNull Project project) {
+    return true;
+  }
+
+  @Override
+  public @NotNull StatusBarWidget createWidget(@NotNull Project project) {
+    Logger.getInstance(getClass()).info("creating (promotion) status bar widget");
     return new StatusBarPromotionWidget(project, binaryRequestFacade, actionVisitor);
   }
 
-  @NotNull
   @Override
-  public String getAnchor() {
-    return StatusBar.Anchors.after(TabnineStatusBarWidget.class.getName());
+  public void disposeWidget(@NotNull StatusBarWidget widget) {
+    Logger.getInstance(getClass()).info("disposing (promotion) status bar widget");
+    Disposer.dispose(widget);
+  }
+
+  @Override
+  public boolean canBeEnabledOn(@NotNull StatusBar statusBar) {
+    return true;
   }
 }

--- a/Tabnine/src/main/java/com/tabnine/statusBar/StatusBarPromotionProvider.java
+++ b/Tabnine/src/main/java/com/tabnine/statusBar/StatusBarPromotionProvider.java
@@ -8,12 +8,10 @@ import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.openapi.wm.StatusBarWidget;
 import com.intellij.openapi.wm.StatusBarWidgetFactory;
-import com.intellij.openapi.wm.StatusBarWidgetProvider;
 import com.tabnine.lifecycle.BinaryInstantiatedActions;
 import com.tabnineCommon.binary.BinaryRequestFacade;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class StatusBarPromotionProvider implements StatusBarWidgetFactory {
   private final BinaryRequestFacade binaryRequestFacade = instanceOfBinaryRequestFacade();

--- a/Tabnine/src/main/java/com/tabnine/statusBar/StatusBarProvider.java
+++ b/Tabnine/src/main/java/com/tabnine/statusBar/StatusBarProvider.java
@@ -1,22 +1,44 @@
 package com.tabnine.statusBar;
 
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.openapi.wm.StatusBarWidget;
-import com.intellij.openapi.wm.StatusBarWidgetProvider;
+import com.intellij.openapi.wm.StatusBarWidgetFactory;
+import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-public class StatusBarProvider implements StatusBarWidgetProvider {
-  @Nullable
+public class StatusBarProvider implements StatusBarWidgetFactory {
   @Override
-  public StatusBarWidget getWidget(@NotNull Project project) {
+  public @NotNull String getId() {
+    return getClass().getName();
+  }
+
+  @Override
+  public @Nls @NotNull String getDisplayName() {
+    return "Tabnine";
+  }
+
+  @Override
+  public boolean isAvailable(@NotNull Project project) {
+    return true;
+  }
+
+  @Override
+  public @NotNull StatusBarWidget createWidget(@NotNull Project project) {
+    Logger.getInstance(getClass()).info("creating status bar widget");
     return new TabnineStatusBarWidget(project);
   }
 
-  @NotNull
   @Override
-  public String getAnchor() {
-    return StatusBar.Anchors.before(StatusBar.StandardWidgets.POSITION_PANEL);
+  public void disposeWidget(@NotNull StatusBarWidget widget) {
+    Logger.getInstance(getClass()).info("disposing status bar widget");
+    Disposer.dispose(widget);
+  }
+
+  @Override
+  public boolean canBeEnabledOn(@NotNull StatusBar statusBar) {
+    return true;
   }
 }

--- a/Tabnine/src/main/java/com/tabnine/statusBar/TabnineStatusBarWidget.java
+++ b/Tabnine/src/main/java/com/tabnine/statusBar/TabnineStatusBarWidget.java
@@ -4,6 +4,7 @@ import static com.tabnineCommon.general.StaticConfig.*;
 
 import com.intellij.ide.DataManager;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
 import com.intellij.openapi.ui.popup.ListPopup;
@@ -142,7 +143,7 @@ public class TabnineStatusBarWidget extends EditorBasedWidget
 
   private void update() {
     if (myStatusBar == null) {
-      //      Logger.getInstance(getClass()).warn("Failed to update the status bar");
+      Logger.getInstance(getClass()).warn("Failed to update the status bar");
       return;
     }
     myStatusBar.updateWidget(ID());

--- a/Tabnine/src/main/resources/META-INF/plugin.xml
+++ b/Tabnine/src/main/resources/META-INF/plugin.xml
@@ -112,11 +112,11 @@
         <preloadingActivity implementation="com.tabnine.Initializer"/>
         <postStartupActivity implementation="com.tabnine.Initializer"/>
 
-        <statusBarWidgetProvider implementation="com.tabnine.statusBar.StatusBarProvider"/>
+        <statusBarWidgetFactory implementation="com.tabnine.statusBar.StatusBarProvider"/>
         <completion.contributor language="any"
                                 implementationClass="com.tabnine.intellij.completions.TabNineCompletionContributor"
                                 order="first"/>
-        <statusBarWidgetProvider implementation="com.tabnine.statusBar.StatusBarPromotionProvider"/>
+        <statusBarWidgetFactory implementation="com.tabnine.statusBar.StatusBarPromotionProvider"/>
         <fileType name="Tabnine project model file" implementationClass="com.tabnine.TabnineProjectModelFileType"
                   extensions="tabnine,.tabnine,tabnine.model,.tabnine.model,model,.model"/>
         <fileType name="Tabnine ignore file" implementationClass="com.tabnine.TabnineIgnoreFileType"

--- a/TabnineSelfHosted/src/main/java/com/tabnineSelfHosted/statusBar/StatusBarProvider.kt
+++ b/TabnineSelfHosted/src/main/java/com/tabnineSelfHosted/statusBar/StatusBarProvider.kt
@@ -1,16 +1,36 @@
 package com.tabnineSelfHosted.statusBar
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.StatusBarWidget
-import com.intellij.openapi.wm.StatusBarWidgetProvider
+import com.intellij.openapi.wm.StatusBarWidgetFactory
 
-class StatusBarProvider : StatusBarWidgetProvider {
-    override fun getWidget(project: Project): StatusBarWidget {
+class StatusBarProvider : StatusBarWidgetFactory {
+    override fun getId(): String {
+        return javaClass.name
+    }
+
+    override fun getDisplayName(): String {
+        return "Tabnine"
+    }
+
+    override fun isAvailable(project: Project): Boolean {
+        return true
+    }
+
+    override fun createWidget(project: Project): StatusBarWidget {
+        Logger.getInstance(javaClass).info("creating (self hosted) status bar widget")
         return TabnineSelfHostedStatusBarWidget(project)
     }
 
-    override fun getAnchor(): String {
-        return StatusBar.Anchors.before(StatusBar.StandardWidgets.POSITION_PANEL)
+    override fun disposeWidget(widget: StatusBarWidget) {
+        Logger.getInstance(javaClass).info("disposing (self hosted) status bar widget")
+        Disposer.dispose(widget)
+    }
+
+    override fun canBeEnabledOn(statusBar: StatusBar): Boolean {
+        return true
     }
 }

--- a/TabnineSelfHosted/src/main/java/com/tabnineSelfHosted/statusBar/TabnineSelfHostedStatusBarWidget.kt
+++ b/TabnineSelfHosted/src/main/java/com/tabnineSelfHosted/statusBar/TabnineSelfHostedStatusBarWidget.kt
@@ -3,6 +3,7 @@ package com.tabnineSelfHosted.statusBar
 import com.intellij.ide.DataManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.ui.popup.ListPopup
@@ -142,7 +143,7 @@ class TabnineSelfHostedStatusBarWidget(project: Project) :
 
     private fun update() {
         if (myStatusBar == null) {
-//            Logger.getInstance(javaClass).warn("Failed to update the status bar")
+            Logger.getInstance(javaClass).warn("Failed to update the status bar")
             return
         }
         myStatusBar.updateWidget(ID())

--- a/TabnineSelfHosted/src/main/resources/META-INF/plugin.xml
+++ b/TabnineSelfHosted/src/main/resources/META-INF/plugin.xml
@@ -111,7 +111,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="com.tabnineSelfHosted.Initializer"/>
         <applicationService serviceImplementation="com.tabnineSelfHosted.binary.lifecycle.UserInfoService"/>
-        <statusBarWidgetProvider implementation="com.tabnineSelfHosted.statusBar.StatusBarProvider"/>
+        <statusBarWidgetFactory implementation="com.tabnineSelfHosted.statusBar.StatusBarProvider"/>
     </extensions>
     <actions>
         <action class="com.tabnineSelfHosted.LoginLogoutAction" id="com.tabnineSelfHosted.LoginLogoutAction" text="Login/Logout of Tabnine">

--- a/TabnineSelfHostedForMarketplace/src/main/java/com/tabnineSelfHosted/statusBar/StatusBarForMarketPlaceProvider.kt
+++ b/TabnineSelfHostedForMarketplace/src/main/java/com/tabnineSelfHosted/statusBar/StatusBarForMarketPlaceProvider.kt
@@ -1,16 +1,36 @@
 package com.tabnineSelfHosted.statusBar
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.StatusBarWidget
-import com.intellij.openapi.wm.StatusBarWidgetProvider
+import com.intellij.openapi.wm.StatusBarWidgetFactory
 
-class StatusBarForMarketPlaceProvider : StatusBarWidgetProvider {
-    override fun getWidget(project: Project): StatusBarWidget {
+class StatusBarForMarketPlaceProvider : StatusBarWidgetFactory {
+    override fun getId(): String {
+        return javaClass.name
+    }
+
+    override fun getDisplayName(): String {
+        return "Tabnine"
+    }
+
+    override fun isAvailable(project: Project): Boolean {
+        return true
+    }
+
+    override fun createWidget(project: Project): StatusBarWidget {
+        Logger.getInstance(javaClass).info("creating (marketplace) status bar widget")
         return TabnineSelfHostedForMarketPlaceStatusBarWidget(project)
     }
 
-    override fun getAnchor(): String {
-        return StatusBar.Anchors.before(StatusBar.StandardWidgets.POSITION_PANEL)
+    override fun disposeWidget(widget: StatusBarWidget) {
+        Logger.getInstance(javaClass).info("disposing (marketplace) status bar widget")
+        Disposer.dispose(widget)
+    }
+
+    override fun canBeEnabledOn(statusBar: StatusBar): Boolean {
+        return true
     }
 }

--- a/TabnineSelfHostedForMarketplace/src/main/java/com/tabnineSelfHosted/statusBar/TabnineSelfHostedForMarketPlaceStatusBarWidget.kt
+++ b/TabnineSelfHostedForMarketplace/src/main/java/com/tabnineSelfHosted/statusBar/TabnineSelfHostedForMarketPlaceStatusBarWidget.kt
@@ -54,7 +54,7 @@ class TabnineSelfHostedForMarketPlaceStatusBarWidget(project: Project) : EditorB
 
     private fun update() {
         if (myStatusBar == null) {
-//            Logger.getInstance(javaClass).warn("Failed to update the status bar")
+            Logger.getInstance(javaClass).warn("Failed to update the status bar")
             return
         }
         myStatusBar.updateWidget(ID())

--- a/TabnineSelfHostedForMarketplace/src/main/resources/META-INF/plugin.xml
+++ b/TabnineSelfHostedForMarketplace/src/main/resources/META-INF/plugin.xml
@@ -108,7 +108,7 @@
     <idea-version since-build="202.6397.94"/>
     <depends>com.intellij.modules.lang</depends>
     <extensions defaultExtensionNs="com.intellij">
-        <statusBarWidgetProvider implementation="com.tabnineSelfHosted.statusBar.StatusBarForMarketPlaceProvider"/>
+        <statusBarWidgetFactory implementation="com.tabnineSelfHosted.statusBar.StatusBarForMarketPlaceProvider"/>
         <postStartupActivity implementation="com.tabnineSelfHosted.SelfHostedInitializer"/>
         <applicationService serviceImplementation="com.tabnineSelfHosted.userSettings.AppSettingsState"/>
         <applicationConfigurable parentId="tools" instance="com.tabnineSelfHosted.userSettings.AppSettingsConfigurable"


### PR DESCRIPTION
following this [suggested workaround](https://youtrack.jetbrains.com/issue/IDEA-319569/Status-bar-provided-by-StatusBarProvider-disappears-sometimes-when-the-new-UI-is-enabled-Tabnine#focus=Comments-27-7545061.0-0) by the JB team
It appears to be the case that after you hide the status bar manually, you can't make it re-appear - and it looks like its a bug on JB's side, I've already informed them and waiting for their response [on this issue](https://youtrack.jetbrains.com/issue/IDEA-319569/Status-bar-provided-by-StatusBarProvider-disappears-sometimes-when-the-new-UI-is-enabled-Tabnine#focus=Comments-27-7861481.0-0).
Other than that, looks like it works OK.

I have tested the 3 plugins (production, self hosted, and marketplace) - both with the `runIde` job (i.e on IJ 2020.2), and by building and installing locally (i.e. on 2023.1) - everything seem to work smoothly