### PR TITLE
DEV2-3336 add intent to conversation state

### DIFF
--- a/Common/src/main/java/com/tabnineCommon/chat/ChatMessagesRouter.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/ChatMessagesRouter.kt
@@ -2,7 +2,6 @@ package com.tabnineCommon.chat
 
 import InitHandler
 import InsertAtCursorHandler
-import com.google.gson.GsonBuilder
 import com.google.gson.JsonElement
 import com.intellij.openapi.project.Project
 import com.tabnineCommon.chat.commandHandlers.ChatMessageHandler
@@ -15,12 +14,13 @@ import com.tabnineCommon.chat.commandHandlers.chatState.GetChatStateHandler
 import com.tabnineCommon.chat.commandHandlers.chatState.UpdateChatConversationHandler
 import com.tabnineCommon.chat.commandHandlers.context.GetBasicContextHandler
 import com.tabnineCommon.chat.commandHandlers.context.GetEnrichingContextHandler
+import com.tabnineCommon.general.DependencyContainer
 
 data class ChatMessageRequest(val id: String, val command: String, val data: JsonElement? = null)
 data class ChatMessageResponse(val id: String, val payload: Any? = null, val error: String? = null)
 
 class ChatMessagesRouter {
-    private val gson = GsonBuilder().create()
+    private val gson = DependencyContainer.instanceOfGson()
     private val commandHandlers = mapOf<String, ChatMessageHandler<*, *>>(
         "init" to InitHandler(gson),
         "get_user" to GetUserHandler(gson),

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/chatState/ChatState.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/chatState/ChatState.kt
@@ -5,7 +5,15 @@ import com.intellij.ide.util.PropertiesComponent
 
 private const val CHAT_CONVERSATIONS_KEY = "com.tabnine.chat.conversations.v2"
 
-data class ChatMessageProps(val id: String, val text: Any, val isBot: Boolean, val timestamp: String, val selected: Int?)
+data class ChatMessageProps(
+    val id: String,
+    val text: Any,
+    val isBot: Boolean,
+    val timestamp: String,
+    val selected: Int?,
+    val intent: Any?
+)
+
 data class ChatConversation(val id: String, val messages: List<ChatMessageProps>)
 
 data class ChatStateData(val conversations: MutableMap<String, ChatConversation>)
@@ -21,7 +29,8 @@ class ChatState(private val gson: Gson) {
     }
 
     fun get(): ChatStateData {
-        return PropertiesComponent.getInstance().getValue(CHAT_CONVERSATIONS_KEY)?.let { gson.fromJson(it, ChatStateData::class.java) } ?: ChatStateData(mutableMapOf())
+        return PropertiesComponent.getInstance().getValue(CHAT_CONVERSATIONS_KEY)
+            ?.let { gson.fromJson(it, ChatStateData::class.java) } ?: ChatStateData(mutableMapOf())
     }
 
     fun clear() {

--- a/Tabnine/src/test/java/com/tabnine/unitTests/GsonSerDeTests.kt
+++ b/Tabnine/src/test/java/com/tabnine/unitTests/GsonSerDeTests.kt
@@ -1,0 +1,112 @@
+package com.tabnine.unitTests
+
+import com.google.gson.JsonSyntaxException
+import com.tabnineCommon.general.DependencyContainer
+import org.junit.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+
+data class Simple(val test: String, val number: Int)
+data class WithOptional(val test: String, val number: Int, val optional: String? = null)
+data class WithDouble(val double: Double)
+
+@ExtendWith(MockitoExtension::class)
+class GsonDeserializeTests {
+    private val ourSingletonGson = DependencyContainer.instanceOfGson()
+
+    @Test
+    fun shouldDeserializeCorrectlyWhenJsonIsValid() {
+        val json = "{\"test\":\"test\",\"number\":1}"
+        val testGson = ourSingletonGson.fromJson(json, Simple::class.java)
+        assert(testGson.test == "test" && testGson.number == 1)
+    }
+
+    @Test
+    fun shouldDeserializeDoubleCorrectly() {
+        val json = "{\"double\":1.1}"
+        val testGson = ourSingletonGson.fromJson(json, WithDouble::class.java)
+        assert(testGson.double == 1.1)
+
+        val json2 = "{\"double\":\"3\"}"
+        val testGson2 = ourSingletonGson.fromJson(json2, WithDouble::class.java)
+        assert(testGson2.double == 3.0)
+    }
+
+    @Test
+    fun shouldDeserializeCorrectlyWhenJsonHasOptionalField() {
+        val testGson = ourSingletonGson.fromJson("{\"test\":\"test\",\"number\":1}", WithOptional::class.java)
+        assert(testGson.test == "test" && testGson.number == 1 && testGson.optional == null)
+        val testGson2 = ourSingletonGson.fromJson(
+            "{\"test\":\"test\",\"number\":1,\"optional\":\"test\"}",
+            WithOptional::class.java
+        )
+        assert(testGson2.test == "test" && testGson2.number == 1 && testGson2.optional == "test")
+    }
+
+    @Test
+    fun shouldDeSerializeWithDefaultValuesWhenJsonMissingRequireFields() {
+        val json = "{\"number\":1}"
+        val testGson = ourSingletonGson.fromJson(json, Simple::class.java)
+        assert(testGson.test == null && testGson.number == 1)
+
+        val json2 = "{\"test\":\"test\"}"
+        val testGson2 = ourSingletonGson.fromJson(json2, Simple::class.java)
+        assert(testGson2.test == "test" && testGson2.number == 0)
+    }
+
+    @Test
+    @Throws(JsonSyntaxException::class)
+    fun shouldThrowExceptionWhenJsonHasInvalidValues() {
+        val json = "{\"test\":\"test\",\"number\":\"kaki\"}"
+        assertThrows<JsonSyntaxException> {
+            ourSingletonGson.fromJson(json, Simple::class.java)
+        }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun shouldThrowExceptionWhenJsonIsInvalid() {
+        val json = "{\"test:\"test\"}"
+        assertThrows<JsonSyntaxException> {
+            ourSingletonGson.fromJson(json, Simple::class.java)
+        }
+    }
+}
+
+@ExtendWith(MockitoExtension::class)
+class GsonSerializeTests {
+    private val ourSingletonGson = DependencyContainer.instanceOfGson()
+
+    @Test
+    fun shouldSerializeCorrectly() {
+        val value = Simple("test", 1)
+        val json = ourSingletonGson.toJson(value)
+        assert(json == "{\"test\":\"test\",\"number\":1}")
+    }
+
+    @Test
+    fun shouldSerializeWholeDoubleAsInt() {
+        val value = WithDouble(1.1)
+        val json = ourSingletonGson.toJson(value)
+        assert(json == "{\"double\":1.1}")
+
+        val value2 = WithDouble(3.0)
+        val json2 = ourSingletonGson.toJson(value2)
+
+        // note: this is important, we're handling this case specifically by registering
+        // a custom type adapter that serializes whole doubles without the `.0` suffix.
+        assert(json2 == "{\"double\":3}")
+    }
+
+    @Test
+    fun shouldSkipSerializingOptionalFieldsWhenNotProvided() {
+        val value = WithOptional("test", 1)
+        val json = ourSingletonGson.toJson(value)
+        assert(json == "{\"test\":\"test\",\"number\":1}")
+
+        val value2 = WithOptional("test", 1, "testOptional")
+        val json2 = ourSingletonGson.toJson(value2)
+        assert(json2 == "{\"test\":\"test\",\"number\":1,\"optional\":\"testOptional\"}")
+    }
+}


### PR DESCRIPTION
since the latest fixes to the intent detection mechanism, the UI relies on the `intent` field of the conversation state to render the chat history (combines the intent to the user's question to create the entire title of the chat item)
for example, here it joins "/explain-code" to "with text" for the title: 
![image](https://github.com/codota/tabnine-intellij/assets/67855609/a799bd60-a564-44ad-a544-b081555682c8)

since kotlin&java are strict with serialization, we need to add this field explicitly in order for it to be persisted