### PR TITLE
DEV2-3340 include text in workspace context

### DIFF
--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/BasicContextCache.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/BasicContextCache.kt
@@ -1,0 +1,11 @@
+package com.tabnineCommon.chat.commandHandlers.context
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.Key
+
+object BasicContextCache {
+    private val fileMetadataKey = Key.create<BasicContext>("com.tabnine.FileMetadataCacheEntry")
+    fun save(editor: Editor, entry: BasicContext) = editor.putUserData(fileMetadataKey, entry)
+
+    fun get(editor: Editor) = editor.getUserData(fileMetadataKey)
+}

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/workspace/FindSymbolsCommandExecutor.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/workspace/FindSymbolsCommandExecutor.kt
@@ -1,12 +1,22 @@
 package com.tabnineCommon.chat.commandHandlers.context.workspace
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.tabnineCommon.chat.commandHandlers.context.BasicContextCache
 import com.tabnineCommon.chat.commandHandlers.utils.SymbolsResolver
 
 class FindSymbolsCommandExecutor : CommandsExecutor {
     override fun execute(arg: String, editor: Editor, project: Project): List<String> {
+        val basicContext = BasicContextCache.get(editor)
+        if (basicContext == null || basicContext.language.isNullOrBlank()) {
+            Logger.getInstance(javaClass).warn("Could not obtain basic context, skipping findSymbols command execution")
+            return emptyList()
+        }
+
         return SymbolsResolver.resolveSymbols(project, editor.document, arg, 5)
-            .map { "${it.name} - ${it.relativePath}" }
+            .filter { !it.text.isNullOrBlank() }
+            .take(2)
+            .map { "file: ${it.relativePath}\n```${basicContext.language}\n${it.text}\n```" }
     }
 }

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/workspace/WorkspaceContext.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/workspace/WorkspaceContext.kt
@@ -41,7 +41,9 @@ data class WorkspaceContext(
 
                 tasks.mapNotNull { it.get() }.forEach { executionResult ->
                     when (executionResult.command) {
-                        Command.FindSymbols -> symbols.addAll(executionResult.result)
+                        // we reverse the list to get the most relevant symbols at the bottom - closer
+                        // to the end of the prompt eventually.
+                        Command.FindSymbols -> symbols.addAll(executionResult.result.distinct().reversed())
                     }
                 }
 

--- a/Tabnine/src/test/java/com/tabnine/unitTests/GsonSerDeTests.kt
+++ b/Tabnine/src/test/java/com/tabnine/unitTests/GsonSerDeTests.kt
@@ -23,6 +23,13 @@ class GsonDeserializeTests {
     }
 
     @Test
+    fun shouldIgnoreExtraFields() {
+        val json = "{\"test\":\"test\",\"number\":1,\"extra\":\"extra\"}"
+        val testGson = ourSingletonGson.fromJson(json, Simple::class.java)
+        assert(testGson.test == "test" && testGson.number == 1)
+    }
+
+    @Test
     fun shouldDeserializeDoubleCorrectly() {
         val json = "{\"double\":1.1}"
         val testGson = ourSingletonGson.fromJson(json, WithDouble::class.java)


### PR DESCRIPTION
1. fetch at most 2 symbols per "findSymbols" command
2. instead of only `"name - file path"`, add the entire symbol code, like the retrieval does
3. cache the `BasicContext` to later be used by the "get_enriching_context" handler
4. try to obtain the language field from the binary's metadata response, and use the IDE one as fallback (for both basic and enriching context handlers)