### PR TITLE
DEV2-3340 run both naming conventions in parallel

### DIFF
--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/workspace/FindSymbolsCommandExecutor.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/workspace/FindSymbolsCommandExecutor.kt
@@ -14,17 +14,20 @@ class FindSymbolsCommandExecutor : CommandsExecutor {
         val camelCaseArg = StringCaseConverter.toCamelCase(arg)
         val snakeCaseArg = StringCaseConverter.toSnakeCase(arg)
 
-        val tasks = listOf(submitReadAction {
-            SymbolsResolver.resolveSymbols(
-                project, editor.document, camelCaseArg,
-                MAX_RESULTS_PER_SYMBOL
-            )
-        }, submitReadAction {
-            SymbolsResolver.resolveSymbols(
-                project, editor.document, snakeCaseArg,
-                MAX_RESULTS_PER_SYMBOL
-            )
-        })
+        val tasks = listOf(
+            submitReadAction {
+                SymbolsResolver.resolveSymbols(
+                    project, editor.document, camelCaseArg,
+                    MAX_RESULTS_PER_SYMBOL
+                )
+            },
+            submitReadAction {
+                SymbolsResolver.resolveSymbols(
+                    project, editor.document, snakeCaseArg,
+                    MAX_RESULTS_PER_SYMBOL
+                )
+            }
+        )
 
         CompletableFuture.allOf(*tasks.toTypedArray()).get()
 

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/workspace/FindSymbolsCommandExecutor.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/workspace/FindSymbolsCommandExecutor.kt
@@ -4,8 +4,8 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.tabnineCommon.chat.commandHandlers.utils.StringCaseConverter
 import com.tabnineCommon.chat.commandHandlers.utils.SymbolsResolver
-import java.util.stream.Stream
-import kotlin.streams.toList
+import com.tabnineCommon.chat.commandHandlers.utils.submitReadAction
+import java.util.concurrent.CompletableFuture
 
 private const val MAX_RESULTS_PER_SYMBOL = 5
 
@@ -13,16 +13,22 @@ class FindSymbolsCommandExecutor : CommandsExecutor {
     override fun execute(arg: String, editor: Editor, project: Project): List<String> {
         val camelCaseArg = StringCaseConverter.toCamelCase(arg)
         val snakeCaseArg = StringCaseConverter.toSnakeCase(arg)
-        val camelCaseSymbols = SymbolsResolver.resolveSymbols(
-            project, editor.document, camelCaseArg,
-            MAX_RESULTS_PER_SYMBOL
-        )
-        val snakeCaseSymbols = SymbolsResolver.resolveSymbols(
-            project, editor.document, snakeCaseArg,
-            MAX_RESULTS_PER_SYMBOL
-        )
 
-        return Stream.concat(camelCaseSymbols.stream(), snakeCaseSymbols.stream())
+        val tasks = listOf(submitReadAction {
+            SymbolsResolver.resolveSymbols(
+                project, editor.document, camelCaseArg,
+                MAX_RESULTS_PER_SYMBOL
+            )
+        }, submitReadAction {
+            SymbolsResolver.resolveSymbols(
+                project, editor.document, snakeCaseArg,
+                MAX_RESULTS_PER_SYMBOL
+            )
+        })
+
+        CompletableFuture.allOf(*tasks.toTypedArray()).get()
+
+        return tasks.map { it.get() }.flatten()
             .map { "${it.name} - ${it.relativePath}" }
             .toList()
     }

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/utils/Execution.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/utils/Execution.kt
@@ -1,7 +1,6 @@
 package com.tabnineCommon.chat.commandHandlers.utils
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ReadAction
 import com.intellij.util.concurrency.AppExecutorUtil
 import java.util.concurrent.CompletableFuture
 
@@ -10,7 +9,7 @@ fun <T> submitReadAction(action: () -> T): CompletableFuture<T> {
     AppExecutorUtil.getAppExecutorService().submit {
         ApplicationManager.getApplication().runReadAction {
             try {
-                val result = ReadAction.compute<T, Throwable>(action)
+                val result = action()
                 future.complete(result)
             } catch (e: Throwable) {
                 future.completeExceptionally(e)


### PR DESCRIPTION
following up on [this comment](https://github.com/codota/tabnine-intellij/pull/611#discussion_r1289133119) from #611,
i think its ok to use `submitReadAction` in both locations, just like nested `Promise.all` are ok:
The code in `submitReadAction` is:
```kotlin
fun <T> submitReadAction(action: () -> T): CompletableFuture<T> {
    val future = CompletableFuture<T>()
    AppExecutorUtil.getAppExecutorService().submit {
        ApplicationManager.getApplication().runReadAction {
            try {
                val result = action()
                future.complete(result)
            } catch (e: Throwable) {
                future.completeExceptionally(e)
            }
        }
    }
    return future
}
```

- `AppExecutorUtil.getAppExecutorService().submit` -> this creates a task to be executed by the executor service, which is practically a thread pool
- `ApplicationManager.getApplication().runReadAction` -> according to their documentation:
> Runs the specified read action. Can be called from any thread. The action is executed immediately if no write action is currently running, or blocked until the currently running write action completes.
So it seems that this read action is not creating another thread, but rather behaves like Rust's `RwLock`.

Overall, it looks like the `submitReadAction` API is requiring a single thread from the threadpool, and a single read-write lock. So I think its ok to use it in nested futures.  