### PR TITLE
DEV2-3471 fix read/write permissions of chat message handlers

### DIFF
--- a/Common/src/main/java/com/tabnineCommon/chat/ChatBrowser.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/ChatBrowser.kt
@@ -1,6 +1,5 @@
 package com.tabnineCommon.chat
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.ui.jcef.JBCefApp
@@ -97,12 +96,10 @@ class ChatBrowser(messagesRouter: ChatMessagesRouter, project: Project) {
         messagesRouter: ChatMessagesRouter
     ) {
         Logger.getInstance(javaClass).trace("Received message: $it")
+        val response = messagesRouter.handleRawMessage(it, project)
 
-        ApplicationManager.getApplication().invokeLater {
-            val response = messagesRouter.handleRawMessage(it, project)
-            Logger.getInstance(javaClass).trace("Sending response: $response")
-            browser.cefBrowser.executeJavaScript("window.postMessage($response, '*')", "", 0)
-        }
+        Logger.getInstance(javaClass).trace("Sending response: $response")
+        browser.cefBrowser.executeJavaScript("window.postMessage($response, '*')", "", 0)
     }
 
     private fun cefLoadHandler(

--- a/Common/src/main/java/com/tabnineCommon/chat/ChatMessagesRouter.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/ChatMessagesRouter.kt
@@ -3,6 +3,7 @@ package com.tabnineCommon.chat
 import InitHandler
 import InsertAtCursorHandler
 import com.google.gson.JsonElement
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.tabnineCommon.chat.commandHandlers.ChatMessageHandler
 import com.tabnineCommon.chat.commandHandlers.GetUserHandler
@@ -44,10 +45,12 @@ class ChatMessagesRouter {
         try {
             val commandHandler = commandHandlers[request.command] ?: return noHandlerError(request)
 
-            val responsePayload = commandHandler.handleRaw(request.data, project) ?: return ChatMessageResponse(request.id)
+            val responsePayload =
+                commandHandler.handleRaw(request.data, project) ?: return ChatMessageResponse(request.id)
 
             return ChatMessageResponse(request.id, responsePayload)
         } catch (e: Exception) {
+            Logger.getInstance(ChatMessagesRouter::class.java).error("Failed to handle request '${request.command}'", e)
             return ChatMessageResponse(request.id, error = e.message ?: e.toString())
         }
     }

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/DiagnosticsContext.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/DiagnosticsContext.kt
@@ -7,7 +7,10 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.util.Processor
+import com.tabnineCommon.chat.commandHandlers.utils.ActionPermissions
+import com.tabnineCommon.chat.commandHandlers.utils.AsyncAction
 import java.awt.Point
+import java.util.concurrent.CompletableFuture
 
 data class DiagnosticsContext(
     private val diagnosticsText: String? = null,
@@ -16,7 +19,13 @@ data class DiagnosticsContext(
     private val type: EnrichingContextType = EnrichingContextType.Diagnostics
 
     companion object {
-        fun create(editor: Editor, project: Project): DiagnosticsContext? {
+        fun createFuture(editor: Editor, project: Project): CompletableFuture<DiagnosticsContext?> {
+            return AsyncAction(ActionPermissions.WRITE).execute {
+                create(editor, project)
+            }
+        }
+
+        private fun create(editor: Editor, project: Project): DiagnosticsContext? {
             val visibleRange = getVisibleRange(editor) ?: return null
             val highlights = mutableListOf<String>()
 
@@ -46,7 +55,7 @@ data class DiagnosticsContext(
             return try {
                 TextRange(startOffset, endOffset)
             } catch (e: IllegalArgumentException) {
-                Logger.getInstance(javaClass).warn("failed to get visible range", e)
+                Logger.getInstance(DiagnosticsContext::class.java).warn("failed to get visible range", e)
                 null
             }
         }

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/EditorContext.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/EditorContext.kt
@@ -3,6 +3,9 @@ package com.tabnineCommon.chat.commandHandlers.context
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.TextRange
+import com.tabnineCommon.chat.commandHandlers.utils.ActionPermissions
+import com.tabnineCommon.chat.commandHandlers.utils.AsyncAction
+import java.util.concurrent.CompletableFuture
 
 data class SelectedCode(val code: String, val filePath: String)
 
@@ -24,7 +27,12 @@ data class EditorContext(
     }
 
     companion object {
-        fun create(editor: Editor): EditorContext {
+        fun createFuture(editor: Editor): CompletableFuture<EditorContext> {
+            return AsyncAction(ActionPermissions.READ).execute {
+                create(editor)
+            }
+        }
+        private fun create(editor: Editor): EditorContext {
             val fileCode = editor.document.text
             val selectedCode = editor.selectionModel.selectedText ?: ""
             val currentLineIndex = editor.caretModel.currentCaret.logicalPosition.line

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/GetBasicContextHandler.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/GetBasicContextHandler.kt
@@ -3,6 +3,7 @@ package com.tabnineCommon.chat.commandHandlers.context
 import com.google.gson.Gson
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.tabnineCommon.binary.requests.fileMetadata.FileMetadataRequest
@@ -23,7 +24,11 @@ data class BasicContext(
 class GetBasicContextHandler(gson: Gson) : ChatMessageHandler<Unit, BasicContext>(gson) {
     private val binaryRequestFacade = DependencyContainer.instanceOfBinaryRequestFacade()
 
-    override fun handle(payload: Unit?, project: Project): BasicContext? {
+    override fun handle(payload: Unit?, project: Project): BasicContext {
+        return ReadAction.compute<BasicContext, Throwable> { createBasicContext(project) }
+    }
+
+    private fun createBasicContext(project: Project): BasicContext {
         val editor = getEditorFromProject(project) ?: return noEditorResponse(project)
 
         val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document)

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/GetEnrichingContextHandler.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/GetEnrichingContextHandler.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.project.Project
 import com.tabnineCommon.chat.commandHandlers.ChatMessageHandler
 import com.tabnineCommon.chat.commandHandlers.context.workspace.WorkspaceCommand
 import com.tabnineCommon.chat.commandHandlers.context.workspace.WorkspaceContext
-import com.tabnineCommon.chat.commandHandlers.utils.submitReadAction
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
@@ -32,12 +31,15 @@ class GetEnrichingContextHandler(gson: Gson) :
         val editor = getEditorFromProject(project) ?: return EnrichingContextResponsePayload()
 
         val enrichingContextData = contextTypesSet.map {
-            submitReadAction {
-                when (it) {
-                    EnrichingContextType.Editor -> EditorContext.create(editor)
-                    EnrichingContextType.Workspace -> WorkspaceContext.create(editor, project, payload.workspaceCommands ?: emptyList())
-                    EnrichingContextType.Diagnostics -> DiagnosticsContext.create(editor, project)
-                }
+            when (it) {
+                EnrichingContextType.Editor -> EditorContext.createFuture(editor)
+                EnrichingContextType.Workspace -> WorkspaceContext.createFuture(
+                    editor,
+                    project,
+                    payload.workspaceCommands ?: emptyList()
+                )
+
+                EnrichingContextType.Diagnostics -> DiagnosticsContext.createFuture(editor, project)
             }
         }
 

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/workspace/FindSymbolsCommandExecutor.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/workspace/FindSymbolsCommandExecutor.kt
@@ -2,9 +2,10 @@ package com.tabnineCommon.chat.commandHandlers.context.workspace
 
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.tabnineCommon.chat.commandHandlers.utils.ActionPermissions
+import com.tabnineCommon.chat.commandHandlers.utils.AsyncAction
 import com.tabnineCommon.chat.commandHandlers.utils.StringCaseConverter
 import com.tabnineCommon.chat.commandHandlers.utils.SymbolsResolver
-import com.tabnineCommon.chat.commandHandlers.utils.submitReadAction
 import java.util.concurrent.CompletableFuture
 
 private const val MAX_RESULTS_PER_SYMBOL = 5
@@ -15,13 +16,13 @@ class FindSymbolsCommandExecutor : CommandsExecutor {
         val snakeCaseArg = StringCaseConverter.toSnakeCase(arg)
 
         val tasks = listOf(
-            submitReadAction {
+            AsyncAction(ActionPermissions.READ).execute {
                 SymbolsResolver.resolveSymbols(
                     project, editor.document, camelCaseArg,
                     MAX_RESULTS_PER_SYMBOL
                 )
             },
-            submitReadAction {
+            AsyncAction(ActionPermissions.READ).execute {
                 SymbolsResolver.resolveSymbols(
                     project, editor.document, snakeCaseArg,
                     MAX_RESULTS_PER_SYMBOL

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/workspace/WorkspaceContext.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/context/workspace/WorkspaceContext.kt
@@ -6,7 +6,8 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.tabnineCommon.chat.commandHandlers.context.EnrichingContextData
 import com.tabnineCommon.chat.commandHandlers.context.EnrichingContextType
-import com.tabnineCommon.chat.commandHandlers.utils.submitReadAction
+import com.tabnineCommon.chat.commandHandlers.utils.ActionPermissions
+import com.tabnineCommon.chat.commandHandlers.utils.AsyncAction
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -25,11 +26,17 @@ data class WorkspaceContext(
     private val type: EnrichingContextType = EnrichingContextType.Workspace
 
     companion object {
-        fun create(editor: Editor, project: Project, workspaceCommands: List<WorkspaceCommand>): WorkspaceContext {
+        fun createFuture(editor: Editor, project: Project, workspaceCommands: List<WorkspaceCommand>): CompletableFuture<WorkspaceContext> {
+            return AsyncAction(ActionPermissions.READ).execute {
+                create(editor, project, workspaceCommands)
+            }
+        }
+
+        private fun create(editor: Editor, project: Project, workspaceCommands: List<WorkspaceCommand>): WorkspaceContext {
             if (workspaceCommands.isEmpty()) return WorkspaceContext(emptyList())
 
             val tasks = workspaceCommands.map { workspaceCommand ->
-                submitReadAction {
+                AsyncAction(ActionPermissions.READ).execute {
                     CommandsExecutor.execute(workspaceCommand, editor, project)
                 }
             }

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/utils/Execution.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/utils/Execution.kt
@@ -4,10 +4,16 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.concurrency.AppExecutorUtil
 import java.util.concurrent.CompletableFuture
 
-fun <T> submitReadAction(action: () -> T): CompletableFuture<T> {
-    val future = CompletableFuture<T>()
-    AppExecutorUtil.getAppExecutorService().submit {
-        ApplicationManager.getApplication().runReadAction {
+enum class ActionPermissions {
+    READ,
+    WRITE
+}
+
+class AsyncAction(private val permissions: ActionPermissions) {
+    fun <T> execute(action: () -> T): CompletableFuture<T> {
+        val future = CompletableFuture<T>()
+
+        val completeAction: () -> Unit = {
             try {
                 val result = action()
                 future.complete(result)
@@ -15,6 +21,19 @@ fun <T> submitReadAction(action: () -> T): CompletableFuture<T> {
                 future.completeExceptionally(e)
             }
         }
+
+        when (permissions) {
+            ActionPermissions.READ -> AppExecutorUtil.getAppExecutorService().submit {
+                ApplicationManager.getApplication().runReadAction {
+                    completeAction()
+                }
+            }
+
+            ActionPermissions.WRITE -> ApplicationManager.getApplication().invokeLater {
+                completeAction()
+            }
+        }
+
+        return future
     }
-    return future
 }

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/utils/Execution.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/utils/Execution.kt
@@ -9,11 +9,21 @@ enum class ActionPermissions {
     WRITE
 }
 
+/**
+ * Runs the given action *not* now - the thread in which the action
+ * is executed depends on the permissions of the action.
+ *
+ * READ - runs on a thread provided by `AppExecutorUtil.getAppExecutorService().submit`,
+ * with read permissions - i.e. acquires a read lock.
+ * WRITE - runs on the AWT thread, with write permissions.
+ *
+ * The result of the action is then captured in a CompletableFuture, and returned.
+ */
 class AsyncAction(private val permissions: ActionPermissions) {
     fun <T> execute(action: () -> T): CompletableFuture<T> {
         val future = CompletableFuture<T>()
 
-        val completeAction: () -> Unit = {
+        val performAction: () -> Unit = {
             try {
                 val result = action()
                 future.complete(result)
@@ -25,12 +35,12 @@ class AsyncAction(private val permissions: ActionPermissions) {
         when (permissions) {
             ActionPermissions.READ -> AppExecutorUtil.getAppExecutorService().submit {
                 ApplicationManager.getApplication().runReadAction {
-                    completeAction()
+                    performAction()
                 }
             }
 
             ActionPermissions.WRITE -> ApplicationManager.getApplication().invokeLater {
-                completeAction()
+                performAction()
             }
         }
 

--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/utils/Execution.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/utils/Execution.kt
@@ -15,6 +15,7 @@ enum class ActionPermissions {
  *
  * READ - runs on a thread provided by `AppExecutorUtil.getAppExecutorService().submit`,
  * with read permissions - i.e. acquires a read lock.
+ *
  * WRITE - runs on the AWT thread, with write permissions.
  *
  * The result of the action is then captured in a CompletableFuture, and returned.


### PR DESCRIPTION
This PR changes the asynchronous thread dispatching and read/write permissions acquired by the chat handlers.
The motivation behind this change is - the permissions required to run each handler are different, and each handler should decide on its permissions.

### Before
- All handlers were running with write actions on the AWT thread (by `ChatBrowser::handleIncomingMessage`)
- `GetEnrichingContextHandler` was dispatching its specific context creators (editor/workspace/diagnostics) with read actions on a thread from JB's thread pool (`AppExecutorUtil.getAppExecutorService().submit`)
  The context creators can in turn spawn nested async tasks on the same thread pool, with read permissions as well.

### After
- The handlers are being executed on the same thread as the `ChatBrowser`, no async dispatching there.
- Each handler decides whether it needs to spawn async tasks and which permissions it needs.
- `GetBasicContextHandler`, which didn't handle any permissions in master, now runs with read lock (still sync)
- `GetEnrichingContextHandler` is not deciding on the asynchronicity and permissions of its context creators.
- The context creators are now running async-ly, each one decides whether it needs read/write permissions. (Diagnostics requires write permissions, the rest require read permissions).

To provide a convenient mechanism for running an async task with the correct permissions, I created the `AsyncAction` class, which accepts the required permission (`READ`/`WRITE`) - and executes the provided `action` accordingly (see details in the class' documentation).  