### PR TITLE
DEV2-3485 shorten plugin name to pass compatibility check with latest EAP 

### DIFF
--- a/Common/src/main/resources/META-INF/common-plugin.xml
+++ b/Common/src/main/resources/META-INF/common-plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <idea-plugin require-restart="true" url="https://tabnine.com">
-    <name>Tabnine AI Code Completion- JS Java Python TS Rust Go PHP &amp; More</name>
+    <name>Tabnine: AI Code Completion &amp; Chat in Java JS/TS Python &amp; More</name>
     <vendor email="support@tabnine.com" url="https://tabnine.com">Tabnine</vendor>
     <description><![CDATA[
 <p>

--- a/Tabnine/src/main/resources/META-INF/plugin.xml
+++ b/Tabnine/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <idea-plugin require-restart="true" url="https://tabnine.com">
-    <name>Tabnine: AI Code Completion &amp; Chat in Java JS/TS Python PHP &amp; More</name>
+    <name>Tabnine: AI Code Completion &amp; Chat in Java JS/TS Python &amp; More</name>
     <id>com.tabnine.TabNine</id>
     <vendor email="support@tabnine.com" url="https://tabnine.com">Tabnine</vendor>
 


### PR DESCRIPTION
they require a max of 64 chars in the latest EAP, and ours is 66 🤦🏻 - so I removed "php" from the name
the job is passing on this branch: https://github.com/codota/tabnine-intellij/actions/runs/5916121678/job/16043040814