### PR TITLE
DEV2-3931 fix chat first loading

### DIFF
--- a/Common/src/main/java/com/tabnineCommon/chat/ChatFrame.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/ChatFrame.kt
@@ -27,7 +27,7 @@ import javax.swing.JPanel
 import javax.swing.SwingConstants.CENTER
 import javax.swing.event.HyperlinkEvent
 
-class ChatFrame(private val project: Project, private val messagesRouter: ChatMessagesRouter, private val binaryRequestFacade: BinaryRequestFacade) :
+class ChatFrame(private val project: Project, private val binaryRequestFacade: BinaryRequestFacade) :
     JPanel(true), Disposable {
     private var capabilitiesFetched = false
 
@@ -97,7 +97,7 @@ class ChatFrame(private val project: Project, private val messagesRouter: ChatMe
 
     private fun displayChat() {
         val browser = try {
-            ChatBrowser(messagesRouter, project)
+            ChatBrowser.getInstance(project)
         } catch (e: Exception) {
             Logger.getInstance(javaClass).warn("Failed to create browser", e)
             displayBrowserNotAvailable()

--- a/Common/src/main/java/com/tabnineCommon/chat/ChatMessagesRouter.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/ChatMessagesRouter.kt
@@ -22,7 +22,7 @@ import com.tabnineCommon.general.DependencyContainer
 data class ChatMessageRequest(val id: String, val command: String, val data: JsonElement? = null)
 data class ChatMessageResponse(val id: String, val payload: Any? = null, val error: String? = null)
 
-class ChatMessagesRouter {
+object ChatMessagesRouter {
     private val gson = DependencyContainer.instanceOfGson()
     private val commandHandlers = mapOf<String, ChatMessageHandler<*, *>>(
         "init" to InitHandler(gson),

--- a/Common/src/main/java/com/tabnineCommon/chat/TabnineChatWebViewFactory.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/TabnineChatWebViewFactory.kt
@@ -8,12 +8,10 @@ import com.intellij.openapi.wm.ToolWindowFactory
 import com.tabnineCommon.general.DependencyContainer.instanceOfBinaryRequestFacade
 
 class TabnineChatWebViewFactory : ToolWindowFactory, Disposable {
-
-    private var messagesRouter = ChatMessagesRouter()
     private val binaryRequestFacade = instanceOfBinaryRequestFacade()
 
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        val chatFrame = ChatFrame(project, messagesRouter, binaryRequestFacade)
+        val chatFrame = ChatFrame(project, binaryRequestFacade)
         Disposer.register(toolWindow.disposable, chatFrame)
         toolWindow.component.add(chatFrame)
     }

--- a/Common/src/main/java/com/tabnineCommon/chat/actions/common/ChatActionCommunicator.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/actions/common/ChatActionCommunicator.kt
@@ -17,25 +17,24 @@ object ChatActionCommunicator {
 
         if (browser.isChatAppAlive()) {
             ourToolWindow.activate {
-                submitMessageToChat(browser, project, value)
+                submitMessageToChat(browser, value)
             }
         } else {
             browser.registerChatAppStartupListener(actionId, project) {
-                submitMessageToChat(browser, project, value)
+                submitMessageToChat(browser, value)
             }
             ourToolWindow.activate(null)
         }
     }
 
-    private fun submitMessageToChat(browser: ChatBrowser, project: Project, result: String) {
-        sendMessage(project, TabnineActionRequest("submit-message", AskChatPayload(result)), browser)
+    private fun submitMessageToChat(browser: ChatBrowser, result: String) {
+        sendMessage(browser, TabnineActionRequest("submit-message", AskChatPayload(result)))
     }
 
-    private fun sendMessage(project: Project, message: TabnineActionRequest, browser: ChatBrowser? = null) {
-        val chatBrowser = browser ?: ChatBrowser.getInstance(project)
+    private fun sendMessage(browser: ChatBrowser, message: TabnineActionRequest) {
         val messageJson = DependencyContainer.instanceOfGson().toJson(message)
 
         Logger.getInstance(javaClass).info("Sending message: $messageJson")
-        chatBrowser.jbCefBrowser.cefBrowser.executeJavaScript("window.postMessage($messageJson, '*')", "", 0)
+        browser.jbCefBrowser.cefBrowser.executeJavaScript("window.postMessage($messageJson, '*')", "", 0)
     }
 }

--- a/Common/src/main/java/com/tabnineCommon/chat/actions/common/ChatActionCommunicator.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/actions/common/ChatActionCommunicator.kt
@@ -8,47 +8,34 @@ import com.tabnineCommon.chat.Consts
 import com.tabnineCommon.chat.actions.AskChatPayload
 import com.tabnineCommon.chat.actions.TabnineActionRequest
 import com.tabnineCommon.general.DependencyContainer
-import org.jetbrains.concurrency.runAsync
 
 object ChatActionCommunicator {
     fun sendMessageToChat(project: Project, actionId: String, value: String) {
-        val browser = getBrowser(project) ?: return
+        val browser = ChatBrowser.getInstance(project)
         val ourToolWindow = ToolWindowManager.getInstance(project)
             .getToolWindow(Consts.CHAT_TOOL_WINDOW_ID) ?: return
 
-        if (browser.isLoaded()) {
+        if (browser.isChatAppAlive()) {
             ourToolWindow.activate {
-                submitMessageToChat(project, value)
+                submitMessageToChat(browser, project, value)
             }
         } else {
-            browser.registerBrowserLoadedListener(actionId) {
-                runAsync {
-                    Thread.sleep(1000)
-                    submitMessageToChat(project, value)
-                }
+            browser.registerChatAppStartupListener(actionId, project) {
+                submitMessageToChat(browser, project, value)
             }
             ourToolWindow.activate(null)
         }
     }
 
-    private fun submitMessageToChat(project: Project, result: String) {
-        sendMessage(project, TabnineActionRequest("submit-message", AskChatPayload(result)))
+    private fun submitMessageToChat(browser: ChatBrowser, project: Project, result: String) {
+        sendMessage(project, TabnineActionRequest("submit-message", AskChatPayload(result)), browser)
     }
 
-    private fun sendMessage(project: Project, message: TabnineActionRequest) {
-        val browser = getBrowser(project) ?: return
+    private fun sendMessage(project: Project, message: TabnineActionRequest, browser: ChatBrowser? = null) {
+        val chatBrowser = browser ?: ChatBrowser.getInstance(project)
         val messageJson = DependencyContainer.instanceOfGson().toJson(message)
 
         Logger.getInstance(javaClass).info("Sending message: $messageJson")
-        browser.jbCefBrowser.cefBrowser.executeJavaScript("window.postMessage($messageJson, '*')", "", 0)
-    }
-
-    private fun getBrowser(project: Project): ChatBrowser? {
-        val browser = ChatBrowser.getInstance(project)
-        if (browser == null) {
-            Logger.getInstance(javaClass).warn("Browser not found on project ${project.name}")
-            return null
-        }
-        return browser
+        chatBrowser.jbCefBrowser.cefBrowser.executeJavaScript("window.postMessage($messageJson, '*')", "", 0)
     }
 }


### PR DESCRIPTION
### Problem
An action can't invoke the chat tool window before the user manually opens it in the current session.

It happens because `ChatBrowser.getInstance` would return `null` until the user opens the tool window, thus creating a browser instance.

### Solution
I solved it by making the browser creation available from anywhere, not just from the user's manual hook.
This solution required the following:
1. Making the `ChatMessagesRouter` singleton and not pass it in the creation phase.
2. Changing `ChatBrowser.getInstance` to create an instance if it doesn't exist on the project's user data, and making the constructor private to prevent double-creation per project.
3. Changing the "browser loaded" listeners to "chat app startup" listeners
   This was necessary because the previous implementation simply didn't work: The browser is considered "loaded" before the app itself is running, just when the static files are loaded onto the browser instance.
   I solved it by hooking the mechanism to the first message received from the app instead of the low-level-ish browser loading API, which means that the react app is completely running.
   And since we're sending requests from the app as soon as it's alive, it's a pretty good approximation. 