### PR TITLE
DEV2-3931 fix alpha release job

### DIFF
--- a/Tabnine/src/main/resources/META-INF/plugin.xml
+++ b/Tabnine/src/main/resources/META-INF/plugin.xml
@@ -119,11 +119,11 @@
         <preloadingActivity implementation="com.tabnine.Initializer"/>
         <postStartupActivity implementation="com.tabnine.Initializer"/>
 
-        <statusBarWidgetFactory implementation="com.tabnine.statusBar.StatusBarProvider"/>
+        <statusBarWidgetFactory implementation="com.tabnine.statusBar.StatusBarProvider" id="com.tabnine.statusBar.StatusBarProvider"/>
         <completion.contributor language="any"
                                 implementationClass="com.tabnine.intellij.completions.TabNineCompletionContributor"
                                 order="first"/>
-        <statusBarWidgetFactory implementation="com.tabnine.statusBar.StatusBarPromotionProvider"/>
+        <statusBarWidgetFactory implementation="com.tabnine.statusBar.StatusBarPromotionProvider" id="com.tabnine.statusBar.StatusBarPromotionProvider"/>
         <fileType name="Tabnine project model file" implementationClass="com.tabnine.TabnineProjectModelFileType"
                   extensions="tabnine,.tabnine,tabnine.model,.tabnine.model,model,.model"/>
         <fileType name="Tabnine ignore file" implementationClass="com.tabnine.TabnineIgnoreFileType"

--- a/TabnineSelfHosted/src/main/resources/META-INF/plugin.xml
+++ b/TabnineSelfHosted/src/main/resources/META-INF/plugin.xml
@@ -112,7 +112,7 @@ Other Tabnine AI users, <b> including Tabnine Enterprise SaaS</b>, should use th
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="com.tabnineSelfHosted.Initializer"/>
         <applicationService serviceImplementation="com.tabnineSelfHosted.binary.lifecycle.UserInfoService"/>
-        <statusBarWidgetFactory implementation="com.tabnineSelfHosted.statusBar.StatusBarProvider"/>
+        <statusBarWidgetFactory implementation="com.tabnineSelfHosted.statusBar.StatusBarProvider" id="com.tabnineSelfHosted.statusBar.StatusBarProvider"/>
     </extensions>
     <actions>
         <action class="com.tabnineSelfHosted.LoginLogoutAction" id="com.tabnineSelfHosted.LoginLogoutAction" text="Login/Logout of Tabnine">

--- a/TabnineSelfHostedForMarketplace/src/main/resources/META-INF/plugin.xml
+++ b/TabnineSelfHostedForMarketplace/src/main/resources/META-INF/plugin.xml
@@ -108,7 +108,7 @@ Other Tabnine AI users, <b> including Tabnine Enterprise SaaS</b>, should use th
     <idea-version since-build="202.6397.94"/>
     <depends>com.intellij.modules.lang</depends>
     <extensions defaultExtensionNs="com.intellij">
-        <statusBarWidgetFactory implementation="com.tabnineSelfHosted.statusBar.StatusBarForMarketPlaceProvider"/>
+        <statusBarWidgetFactory implementation="com.tabnineSelfHosted.statusBar.StatusBarForMarketPlaceProvider" id="com.tabnineSelfHosted.statusBar.StatusBarForMarketPlaceProvider"/>
         <postStartupActivity implementation="com.tabnineSelfHosted.SelfHostedInitializer"/>
         <applicationService serviceImplementation="com.tabnineSelfHosted.userSettings.AppSettingsState"/>
         <applicationConfigurable parentId="tools" instance="com.tabnineSelfHosted.userSettings.AppSettingsConfigurable"


### PR DESCRIPTION
from the alpha release CI job [logs](https://github.com/codota/tabnine-intellij/actions/runs/6469012328/job/17562221422):
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':Tabnine:publishPlugin'.
> Failed to upload plugin: Upload failed: Extension Point in the &lt;com.intellij.statusBarWidgetFactory&gt; element must have 'id' attribute set with same value returned from the getId() method of the com.tabnine.statusBar.StatusBarProvider implementation.
  Extension Point in the &lt;com.intellij.statusBarWidgetFactory&gt; element must have 'id' attribute set with same value returned from the getId() method of the com.tabnine.statusBar.StatusBarPromotionProvider implementation.
> Task :Tabnine:publishPlugin FAILED
```