### PR TITLE
DEV2-4218 don't log "failed to get editor" as error

### DIFF
--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/ChatMessageHandler.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/ChatMessageHandler.kt
@@ -22,7 +22,7 @@ abstract class ChatMessageHandler<RequestPayload, ResponsePayload>(protected val
                 val fileEditor = FileEditorManager.getInstance(project).selectedEditor as? TextEditor
                 return@execute fileEditor?.editor
             } catch (e: Exception) {
-                Logger.getInstance(javaClass).error("Failed to get editor from project: ", e)
+                Logger.getInstance(javaClass).warn("Failed to get editor from project: ", e)
                 null
             }
         }.get()


### PR DESCRIPTION
error logs are being presented to the user in this stressful message window
![image](https://github.com/codota/tabnine-intellij/assets/67855609/031c5204-547f-469a-814e-f706f220d9c8)

but it isn't really a non-recoverable error, so no need to stress the user so much.
especially when it happens when you close a project.