### PR TITLE
DEV2-4253 refine workspace folders resolution

### DIFF
--- a/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/WorkspaceFoldersHandler.kt
+++ b/Common/src/main/java/com/tabnineCommon/chat/commandHandlers/WorkspaceFoldersHandler.kt
@@ -11,7 +11,7 @@ class WorkspaceFoldersHandler(gson: Gson) : ChatMessageHandler<Unit, WorkspaceFo
     private val workspaceService = ServiceManager.getService(WorkspaceListenerService::class.java)
 
     override fun handle(payload: Unit?, project: Project): WorkspaceFoldersPayload? {
-        val rootPaths = workspaceService.getWorkspaceRootPaths() ?: return null
+        val rootPaths = workspaceService.getWorkspaceRootPaths(project) ?: return null
         return WorkspaceFoldersPayload(rootPaths)
     }
 

--- a/Common/src/main/java/com/tabnineCommon/lifecycle/WorkspaceListenerService.kt
+++ b/Common/src/main/java/com/tabnineCommon/lifecycle/WorkspaceListenerService.kt
@@ -39,7 +39,7 @@ class WorkspaceListenerService {
             .reduceOrNull { acc, cur -> acc.plus(cur) }
 
         if (rootPaths.isNullOrEmpty()) return
-        Logger.getInstance(javaClass).info("All Root paths collected: $rootPaths")
+        Logger.getInstance(javaClass).info("All root paths collected: $rootPaths")
 
         binaryRequestFacade.executeRequest(Workspace(rootPaths))
     }

--- a/Common/src/main/java/com/tabnineCommon/lifecycle/WorkspaceListenerService.kt
+++ b/Common/src/main/java/com/tabnineCommon/lifecycle/WorkspaceListenerService.kt
@@ -39,6 +39,7 @@ class WorkspaceListenerService {
             .reduceOrNull { acc, cur -> acc.plus(cur) }
 
         if (rootPaths.isNullOrEmpty()) return
+        Logger.getInstance(javaClass).info("All Root paths collected: $rootPaths")
 
         binaryRequestFacade.executeRequest(Workspace(rootPaths))
     }


### PR DESCRIPTION
- when updating the binary: iterate over all opened projects, and update all the root paths within them
- when answering the chat's `workspace_folders` request - only reply with the root paths in the chat's respective project

I ran 2 IJ windows, each one with 2 projects in their workspace, and made sure that each indexing indication reflected the correct status according to the project, and that the binary request contains the paths from both windows together